### PR TITLE
fix: update lsio template registry url to valid endpoint

### DIFF
--- a/backend/src/services/TemplateService.ts
+++ b/backend/src/services/TemplateService.ts
@@ -50,7 +50,7 @@ export class TemplateService {
         try {
             const settings = DatabaseService.getInstance().getGlobalSettings();
             // Default to a reliable LSIO Portainer v2 template registry if not set
-            const registryUrl = settings.template_registry_url || 'https://raw.githubusercontent.com/technorabilia/portainer-templates/main/lsio/templates/templates-2.0.json';
+            const registryUrl = settings.template_registry_url || 'https://raw.githubusercontent.com/technorabilia/portainer-templates/main/lsio/templates/templates.json';
 
             const response = await axios.get<TemplatesResponse>(registryUrl);
             // Filter out templates without images as we are generating compose files from image, ports, etc.


### PR DESCRIPTION
Hotfix to correct the default LSIO template registry URL. PR #4 was merged with a 404 endpoint (`templates-2.0.json`). This fixes the fallback URL to `templates.json`.