### PR TITLE
fix: App Store build failure (duplicate ScrollArea tag)

### DIFF
--- a/frontend/src/components/AppStoreView.tsx
+++ b/frontend/src/components/AppStoreView.tsx
@@ -312,7 +312,6 @@ export function AppStoreView({ onDeploySuccess }: AppStoreViewProps) {
                                 </div>
                             </SheetHeader>
 
-                            <ScrollArea className="flex-1 pr-4">
                             <ScrollArea className="flex-1 pr-4 -mx-4 px-4">
                                 <div className="space-y-6 pb-8">
                                     <div className="space-y-2">


### PR DESCRIPTION
### What does this PR do?
Fixes a duplicate `<ScrollArea>` tag in `AppStoreView.tsx` that was causing the `build-and-test` CI check to fail on the `develop` branch.
