### PR TITLE
fix: Skip remote nodes in MonitorService

### DIFF
--- a/backend/src/services/MonitorService.ts
+++ b/backend/src/services/MonitorService.ts
@@ -121,6 +121,8 @@ export class MonitorService {
                 const nodes = DatabaseService.getInstance().getNodes();
                 for (const node of nodes) {
                     if (!node.id) continue;
+                    // Remote nodes run their own MonitorService locally — skip direct Docker access
+                    if (node.type === 'remote') continue;
                     try {
                         const docker = DockerController.getInstance(node.id);
                         const containers = await docker.getAllContainers();
@@ -206,6 +208,8 @@ export class MonitorService {
 
         for (const node of nodes) {
             if (!node.id) continue;
+            // Remote nodes are self-monitoring — skip direct Docker access
+            if (node.type === 'remote') continue;
             try {
                 const docker = DockerController.getInstance(node.id);
                 const containers = await docker.getRunningContainers();


### PR DESCRIPTION
## Problem

After the Distributed API pivot (PR #28), `MonitorService` continued iterating all nodes — including remote ones — and calling `DockerController.getInstance(nodeId)`, which throws because remote nodes no longer have direct Docker TCP access. This caused the backend to log fatal errors on every 30-second monitor tick, crashing the background watchdog and breaking the frontend.

## Fix

Added `if (node.type === 'remote') continue;` in both loops inside `MonitorService`:
- `evaluateGlobalSettings` — global crash detection
- `evaluateStackAlerts` — per-stack alert rule evaluation

## Why this is architecturally correct

In the Distributed API model, each remote Sencho instance runs its own `MonitorService` locally against its own Docker socket. The main dashboard instance only needs to monitor its own local containers. Remote node health is the responsibility of the remote Sencho.