### PR TITLE
fix: Memory Leak & Reload Loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- **Fixed:** Memory leak in `GlobalObservabilityView` SSE mode — log array now capped at 10,000 entries (`.slice(-10000)`) to prevent unbounded accumulation across long sessions.
+- **Fixed:** Infinite re-fetch loop in `NodeContext` — `refreshNodes` useCallback no longer depends on `activeNode` state; replaced with a `useRef` to read current node inside the callback without being a reactive dependency.
 - **Removed:** SSH/SFTP file adapters and remote Docker TCP connections (net negative ~500 lines of code).
 - **Added:** Distributed API proxying using http-proxy-middleware for HTTP and WebSockets.
 - **Added:** Long-lived JWT generation for Sencho-to-Sencho API authentication (`POST /api/auth/generate-node-token`).

--- a/frontend/src/components/GlobalObservabilityView.tsx
+++ b/frontend/src/components/GlobalObservabilityView.tsx
@@ -93,9 +93,8 @@ export function GlobalObservabilityView() {
                     const batch = bufferRef.current.splice(0);
                     setLogs(prev => {
                         const merged = [...prev, ...batch];
-                        // Infinite scroll: no slice limit in dev mode
                         merged.sort((a, b) => a.timestampMs - b.timestampMs);
-                        return merged;
+                        return merged.slice(-10000);
                     });
                 }
             }, 500);

--- a/frontend/src/context/NodeContext.tsx
+++ b/frontend/src/context/NodeContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+import React, { createContext, useContext, useState, useEffect, useCallback, useRef } from 'react';
 import { apiFetch } from '@/lib/api';
 
 export interface Node {
@@ -27,6 +27,9 @@ export function NodeProvider({ children }: { children: React.ReactNode }) {
   const [nodes, setNodes] = useState<Node[]>([]);
   const [activeNode, setActiveNodeState] = useState<Node | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  // Ref lets refreshNodes read current activeNode without being a dep (breaks infinite loop)
+  const activeNodeRef = useRef<Node | null>(null);
+  activeNodeRef.current = activeNode;
 
   const refreshNodes = useCallback(async () => {
     try {
@@ -35,7 +38,8 @@ export function NodeProvider({ children }: { children: React.ReactNode }) {
         const data = await res.json();
         setNodes(data);
 
-        if (!activeNode) {
+        const currentActive = activeNodeRef.current;
+        if (!currentActive) {
           const defaultNode = data.find((n: Node) => n.is_default);
           if (defaultNode) {
             setActiveNodeState(defaultNode);
@@ -43,7 +47,7 @@ export function NodeProvider({ children }: { children: React.ReactNode }) {
             setActiveNodeState(data[0]);
           }
         } else {
-          const updatedActive = data.find((n: Node) => n.id === activeNode.id);
+          const updatedActive = data.find((n: Node) => n.id === currentActive.id);
           if (updatedActive) {
             setActiveNodeState(updatedActive);
           } else {
@@ -63,7 +67,7 @@ export function NodeProvider({ children }: { children: React.ReactNode }) {
     } finally {
       setIsLoading(false);
     }
-  }, [activeNode]);
+  }, []); // stable — reads activeNode via ref, not closure capture
 
   const setActiveNode = useCallback((node: Node) => {
     setActiveNodeState(node);


### PR DESCRIPTION
## Summary

- **Memory leak fix:** `GlobalObservabilityView` SSE mode no longer accumulates logs without bound. The merged array is now capped at 10,000 entries (`.slice(-10000)`) before being committed to state, preventing multi-GB heap growth during long dev-mode sessions.
- **Infinite reload fix:** `NodeContext.refreshNodes` useCallback previously listed `activeNode` as a dependency, but also called `setActiveNodeState()` — causing a `useEffect → setState → useCallback recreation → useEffect` infinite loop. Fixed by reading `activeNode` via a `useRef` (assigned during render) so the callback is stable with an empty dependency array.

## Root Causes

| Bug | Location | Cause |
|-----|----------|-------|
| 3–7 GB browser memory leak | `GlobalObservabilityView.tsx:96` | Explicit comment "no slice limit in dev mode" — logs grew unbounded |
| Infinite page reload on remote | `NodeContext.tsx` | `refreshNodes` dep on `activeNode` it also mutates — re-render cycle |

## Test plan

- [ ] Open Global Logs in Developer Mode (SSE) and leave it running — memory should stabilise around 10k entries
- [ ] Add a remote node and switch to it — node selector should set once, not trigger repeated `/nodes` fetches
- [ ] Verify local node workflow is unaffected (stack list, deploy, logs)