### PR TITLE
fix: remote proxy strips /api prefix — remote Sencho returns SPA HTML instead of JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- **Fixed:** Remote node proxy stripping the `/api` path prefix — `remoteNodeProxy` is mounted at `app.use('/api/', ...)` so Express strips that prefix from `req.url` before `http-proxy-middleware` sees it; added `pathRewrite: (path) => '/api' + path` to restore the full path when forwarding to the remote Sencho instance (e.g. `/stats` → `/api/stats`). This was the root cause of all remote API calls returning the remote's SPA HTML instead of JSON.
 - **Fixed:** Dashboard cards (Active Containers, Host CPU, Host RAM, Docker Network) showing stale local-node data after switching to a remote node — `HomeDashboard` polling effects now depend on `activeNode?.id` and clear state immediately on node change.
 - **Fixed:** `refreshStacks` crashing with `SyntaxError` or `TypeError` when the remote proxy returns a non-JSON response (e.g., connection refused to unreachable remote node) — now checks `res.ok` before calling `res.json()` and iterates a typed `fileList` instead of the raw parsed value.
 - **Fixed:** Restored Local/Remote type selector and fixed state resets in the Add Node modal — form now resets to defaults every time the dialog opens, and the title reflects the chosen type dynamically.

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -331,6 +331,10 @@ const remoteNodeProxy = createProxyMiddleware<Request, Response>({
     const node = NodeRegistry.getInstance().getNode(req.nodeId);
     return node?.api_url?.replace(/\/$/, '');
   },
+  // When mounted at app.use('/api/', ...), Express strips the '/api/' prefix from
+  // req.url before the middleware sees it. Re-add it so the remote Sencho instance
+  // receives the full path (e.g. '/stats' becomes '/api/stats').
+  pathRewrite: (path) => '/api' + path,
   on: {
     proxyReq: (proxyReq, req) => {
       const node = NodeRegistry.getInstance().getNode(req.nodeId);


### PR DESCRIPTION
## Root cause

`remoteNodeProxy` is registered via `app.use('/api/', ...)`. Express **strips the mount-path prefix from `req.url`** inside that handler, so `http-proxy-middleware` sees `/stats` instead of `/api/stats`.

The proxy therefore forwarded:
- `GET /api/stats` → `http://192.168.x.x:3001/stats` ← no matching route on remote
- `GET /api/stacks` → `http://192.168.x.x:3001/stacks` ← no matching route on remote

The remote Sencho found no route, fell through to its SPA catch-all (`app.use` serving `index.html`), and returned `200 text/html`. That's why `res.json()` threw `SyntaxError: Unexpected token '<'` on every remote API call.

The connection test passed because `testRemoteConnection` calls the remote directly via `axios.get(baseUrl + '/api/auth/check')` — it uses the full URL and never goes through the proxy.

## Fix

Added `pathRewrite: (path) => '/api' + path` to `remoteNodeProxy`. This restores the `/api` prefix before the request is forwarded, so `/stats` becomes `/api/stats`, `/stacks` becomes `/api/stacks`, etc.

## Test plan

- [ ] Switch to a remote (DEV) node — stacks list populates with the remote node's stacks
- [ ] Dashboard cards (Active Containers, CPU, RAM, Disk) update to show remote node metrics
- [ ] Switching back to Local shows local data again
- [ ] Connection test in Settings → Nodes still passes