### PR TITLE
feat(resources): managed/unmanaged resource separation across Resources Hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Resources Hub — Managed/Unmanaged Separation:** All Docker resources (images, volumes, networks) are now classified as `managed` (belonging to a Sencho stack), `external` (belonging to another Compose project), or `unused`/`system`. Classification is exposed via a new `GET /api/system/resources` endpoint that makes 4 parallel Docker API calls once and returns all three resource types in a single round trip.
+- **Docker Disk Footprint widget:** Replaces the Reclaimable Space donut chart with an interactive horizontal stacked bar showing Sencho Managed vs External Projects vs Reclaimable bytes. Clicking a segment filters the Images and Volumes tabs simultaneously.
+- **Scoped prune operations:** Quick Clean buttons now target Sencho-managed resources only by default ("Sencho only" label). An "All Docker" option is hidden in a `⋮` dropdown per prune target, with a distinct destructive confirmation dialog. The `POST /api/system/prune/system` endpoint accepts an optional `scope: 'managed' | 'all'` body parameter; a new `pruneManagedOnly()` method on `DockerController` filters by `com.docker.compose.project` label before removing resources.
+- **Managed/External filter toggles:** Each resource tab (Images, Volumes, Networks) has a segmented pill control to show All / Managed / External resources with live counts.
+- **Classification badges:** Each resource row displays a green "stack-name" badge for managed resources, an orange "External" badge for external, and a muted "System" badge for Docker-native networks (`bridge`, `host`, `none`). System networks have their delete button disabled.
+- **Active Containers split stat:** `GET /api/stats` now returns `managed` and `unmanaged` container counts in addition to `active`/`exited`/`total`. The Home Dashboard "Active Containers" card subtitle shows "N managed · N external".
+- **Renamed "Ghost Containers" → "Unmanaged Containers":** Tab label, dialog titles, toast messages, and empty-state copy updated throughout `ResourcesView`.
+
 ### Security
 - **Fixed:** `POST /api/system/console-token` was missing `authMiddleware` — any unauthenticated client could generate console session tokens. Fixed by adding `authMiddleware` to the route.
 - **Fixed:** Remote node `api_url` was accepted without validation — an attacker could set it to `http://localhost:6379` to SSRF into internal services. Now validates: must be a well-formed `http://` or `https://` URL, and the hostname may not be `localhost`, `127.x.x.x`, `[::1]`, or `0.0.0.0`.

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1112,15 +1112,26 @@ app.post('/api/convert', async (req: Request, res: Response) => {
 // Get all containers stats for dashboard
 app.get('/api/stats', async (req: Request, res: Response) => {
   try {
-    const dockerController = DockerController.getInstance(req.nodeId);
-    const containers = await dockerController.getRunningContainers();
+    const [dockerController, knownStacks] = [
+      DockerController.getInstance(req.nodeId),
+      await FileSystemService.getInstance(req.nodeId).getStacks(),
+    ];
     const allContainers = await dockerController.getAllContainers();
+    const knownSet = new Set(knownStacks);
 
-    const active = containers.length;
-    const exited = allContainers.filter((c: { State: string }) => c.State === 'exited').length;
+    const active = allContainers.filter((c: any) => c.State === 'running').length;
+    const exited = allContainers.filter((c: any) => c.State === 'exited').length;
     const total = allContainers.length;
+    const managed = allContainers.filter((c: any) => {
+      const project: string | undefined = c.Labels?.['com.docker.compose.project'];
+      return project && knownSet.has(project) && c.State === 'running';
+    }).length;
+    const unmanaged = allContainers.filter((c: any) => {
+      const project: string | undefined = c.Labels?.['com.docker.compose.project'];
+      return project && !knownSet.has(project) && c.State === 'running';
+    }).length;
 
-    res.json({ active, exited, total, inactive: total - active - exited });
+    res.json({ active, managed, unmanaged, exited, total });
   } catch (error) {
     res.status(500).json({ error: 'Failed to fetch stats' });
   }
@@ -1624,13 +1635,24 @@ app.post('/api/system/prune/orphans', async (req: Request, res: Response) => {
 
 app.post('/api/system/prune/system', async (req: Request, res: Response) => {
   try {
-    const { target } = req.body; // 'containers', 'images', 'networks', 'volumes'
+    const { target, scope } = req.body as { target: string; scope?: string };
     if (!['containers', 'images', 'networks', 'volumes'].includes(target)) {
       return res.status(400).json({ error: 'Invalid prune target' });
     }
 
     const dockerController = DockerController.getInstance(req.nodeId);
-    const result = await dockerController.pruneSystem(target);
+    const pruneScope = scope === 'managed' ? 'managed' : 'all';
+
+    let result: { success: boolean; reclaimedBytes: number };
+    if (pruneScope === 'managed' && target !== 'containers') {
+      const knownStacks = await FileSystemService.getInstance(req.nodeId).getStacks();
+      result = await dockerController.pruneManagedOnly(
+        target as 'images' | 'volumes' | 'networks',
+        knownStacks
+      );
+    } else {
+      result = await dockerController.pruneSystem(target as 'containers' | 'images' | 'networks' | 'volumes');
+    }
 
     res.json({ message: 'Prune completed', ...result });
   } catch (error: any) {
@@ -1641,8 +1663,8 @@ app.post('/api/system/prune/system', async (req: Request, res: Response) => {
 
 app.get('/api/system/docker-df', async (req: Request, res: Response) => {
   try {
-    const dockerController = DockerController.getInstance(req.nodeId);
-    const df = await dockerController.getDiskUsage();
+    const knownStacks = await FileSystemService.getInstance(req.nodeId).getStacks();
+    const df = await DockerController.getInstance(req.nodeId).getDiskUsageClassified(knownStacks);
     res.json(df);
   } catch (error) {
     console.error('Failed to fetch docker disk usage:', error);
@@ -1650,10 +1672,23 @@ app.get('/api/system/docker-df', async (req: Request, res: Response) => {
   }
 });
 
+// Single endpoint returning classified images, volumes, and networks in one call
+app.get('/api/system/resources', async (req: Request, res: Response) => {
+  try {
+    const knownStacks = await FileSystemService.getInstance(req.nodeId).getStacks();
+    const result = await DockerController.getInstance(req.nodeId).getClassifiedResources(knownStacks);
+    res.json(result);
+  } catch (error) {
+    console.error('Failed to fetch classified resources:', error);
+    res.status(500).json({ error: 'Failed to fetch resources' });
+  }
+});
+
+// Keep legacy endpoints for backward compat with remote proxy routing
 app.get('/api/system/images', async (req: Request, res: Response) => {
   try {
-    const dockerController = DockerController.getInstance(req.nodeId);
-    const images = await dockerController.getImages();
+    const knownStacks = await FileSystemService.getInstance(req.nodeId).getStacks();
+    const { images } = await DockerController.getInstance(req.nodeId).getClassifiedResources(knownStacks);
     res.json(images);
   } catch (error) {
     console.error('Failed to fetch images:', error);
@@ -1663,8 +1698,8 @@ app.get('/api/system/images', async (req: Request, res: Response) => {
 
 app.get('/api/system/volumes', async (req: Request, res: Response) => {
   try {
-    const dockerController = DockerController.getInstance(req.nodeId);
-    const volumes = await dockerController.getVolumes();
+    const knownStacks = await FileSystemService.getInstance(req.nodeId).getStacks();
+    const { volumes } = await DockerController.getInstance(req.nodeId).getClassifiedResources(knownStacks);
     res.json(volumes);
   } catch (error) {
     console.error('Failed to fetch volumes:', error);
@@ -1674,8 +1709,8 @@ app.get('/api/system/volumes', async (req: Request, res: Response) => {
 
 app.get('/api/system/networks', async (req: Request, res: Response) => {
   try {
-    const dockerController = DockerController.getInstance(req.nodeId);
-    const networks = await dockerController.getNetworks();
+    const knownStacks = await FileSystemService.getInstance(req.nodeId).getStacks();
+    const { networks } = await DockerController.getInstance(req.nodeId).getClassifiedResources(knownStacks);
     res.json(networks);
   } catch (error) {
     console.error('Failed to fetch networks:', error);

--- a/backend/src/services/DockerController.ts
+++ b/backend/src/services/DockerController.ts
@@ -11,6 +11,32 @@ import { NodeRegistry } from './NodeRegistry';
 const execAsync = promisify(exec);
 const COMPOSE_DIR = process.env.COMPOSE_DIR || '/app/compose';
 
+export interface ClassifiedImage {
+  Id: string;
+  RepoTags: string[];
+  Size: number;
+  Containers: number;
+  managedBy: string | null;
+  managedStatus: 'managed' | 'unmanaged' | 'unused';
+}
+
+export interface ClassifiedVolume {
+  Name: string;
+  Driver: string;
+  Mountpoint: string;
+  managedBy: string | null;
+  managedStatus: 'managed' | 'unmanaged';
+}
+
+export interface ClassifiedNetwork {
+  Id: string;
+  Name: string;
+  Driver: string;
+  Scope: string;
+  managedBy: string | null;
+  managedStatus: 'managed' | 'unmanaged' | 'system';
+}
+
 class DockerController {
   private docker: Docker;
   private nodeId: number;
@@ -110,6 +136,172 @@ class DockerController {
   public async getNetworks() {
     const data = await this.docker.listNetworks();
     return this.validateApiData<any[]>(data);
+  }
+
+  public async getClassifiedResources(knownStackNames: string[]): Promise<{
+    images: ClassifiedImage[];
+    volumes: ClassifiedVolume[];
+    networks: ClassifiedNetwork[];
+  }> {
+    const SYSTEM_NETWORKS = new Set(['bridge', 'host', 'none']);
+    const knownSet = new Set(knownStackNames);
+
+    const [rawImages, rawVolumeData, rawNetworks, allContainers] = await Promise.all([
+      this.docker.listImages({ all: false }),
+      this.docker.listVolumes(),
+      this.docker.listNetworks(),
+      this.docker.listContainers({ all: true }),
+    ]);
+
+    const rawVolumes: any[] = (this.validateApiData<any>(rawVolumeData)).Volumes || [];
+
+    // Build imageId → project mapping from container labels
+    const imageToProject = new Map<string, string>();
+    for (const c of allContainers as any[]) {
+      const project: string | undefined = c.Labels?.['com.docker.compose.project'];
+      if (project && c.ImageID) imageToProject.set(c.ImageID, project);
+    }
+
+    const images: ClassifiedImage[] = this.validateApiData<any[]>(rawImages).map((img: any) => {
+      const project = imageToProject.get(img.Id) ?? null;
+      const managedStatus: ClassifiedImage['managedStatus'] =
+        img.Containers === 0 ? 'unused' :
+        project && knownSet.has(project) ? 'managed' : 'unmanaged';
+      return {
+        Id: img.Id,
+        RepoTags: img.RepoTags ?? [],
+        Size: img.Size ?? 0,
+        Containers: img.Containers ?? 0,
+        managedBy: managedStatus === 'managed' ? project : null,
+        managedStatus,
+      };
+    });
+
+    const volumes: ClassifiedVolume[] = rawVolumes.map((vol: any) => {
+      const project: string | undefined = vol.Labels?.['com.docker.compose.project'];
+      const managedStatus: ClassifiedVolume['managedStatus'] =
+        project && knownSet.has(project) ? 'managed' : 'unmanaged';
+      return {
+        Name: vol.Name,
+        Driver: vol.Driver,
+        Mountpoint: vol.Mountpoint,
+        managedBy: managedStatus === 'managed' ? project! : null,
+        managedStatus,
+      };
+    });
+
+    const networks: ClassifiedNetwork[] = this.validateApiData<any[]>(rawNetworks).map((net: any) => {
+      if (SYSTEM_NETWORKS.has(net.Name)) {
+        return { Id: net.Id, Name: net.Name, Driver: net.Driver, Scope: net.Scope, managedBy: null, managedStatus: 'system' as const };
+      }
+      const project: string | undefined = net.Labels?.['com.docker.compose.project'];
+      const managedStatus: ClassifiedNetwork['managedStatus'] =
+        project && knownSet.has(project) ? 'managed' : 'unmanaged';
+      return {
+        Id: net.Id,
+        Name: net.Name,
+        Driver: net.Driver,
+        Scope: net.Scope,
+        managedBy: managedStatus === 'managed' ? project! : null,
+        managedStatus,
+      };
+    });
+
+    return { images, volumes, networks };
+  }
+
+  public async pruneManagedOnly(
+    target: 'images' | 'volumes' | 'networks',
+    knownStackNames: string[]
+  ): Promise<{ success: boolean; reclaimedBytes: number }> {
+    const knownSet = new Set(knownStackNames);
+    let reclaimedBytes = 0;
+
+    if (target === 'volumes') {
+      const rawVolumeData = await this.docker.listVolumes();
+      const rawVolumes: any[] = (this.validateApiData<any>(rawVolumeData)).Volumes || [];
+      const prunable = rawVolumes.filter((v: any) => {
+        const project: string | undefined = v.Labels?.['com.docker.compose.project'];
+        return project && knownSet.has(project) && (v.UsageData?.RefCount ?? 1) === 0;
+      });
+      for (const vol of prunable) {
+        try {
+          await this.docker.getVolume(vol.Name).remove({ force: true });
+          reclaimedBytes += vol.UsageData?.Size ?? 0;
+        } catch (e) {
+          console.error(`[pruneManagedOnly] Failed to remove volume ${vol.Name}:`, e);
+        }
+      }
+    } else if (target === 'networks') {
+      const rawNetworks = await this.docker.listNetworks();
+      const prunable = (rawNetworks as any[]).filter((n: any) => {
+        const project: string | undefined = n.Labels?.['com.docker.compose.project'];
+        return project && knownSet.has(project);
+      });
+      for (const net of prunable) {
+        try {
+          await this.docker.getNetwork(net.Id).remove({ force: true });
+        } catch (e) {
+          console.error(`[pruneManagedOnly] Failed to remove network ${net.Name}:`, e);
+        }
+      }
+    } else if (target === 'images') {
+      const allContainers = await this.docker.listContainers({ all: true });
+      const unmanagedImageIds = new Set<string>();
+      for (const c of allContainers as any[]) {
+        const project: string | undefined = c.Labels?.['com.docker.compose.project'];
+        if (!project || !knownSet.has(project)) unmanagedImageIds.add(c.ImageID);
+      }
+      const rawImages = await this.docker.listImages({ all: false });
+      const prunable = (rawImages as any[]).filter((img: any) =>
+        img.Containers === 0 && !unmanagedImageIds.has(img.Id)
+      );
+      for (const img of prunable) {
+        try {
+          await this.docker.getImage(img.Id).remove({ force: true });
+          reclaimedBytes += img.Size ?? 0;
+        } catch (e) {
+          console.error(`[pruneManagedOnly] Failed to remove image ${img.Id}:`, e);
+        }
+      }
+    }
+
+    return { success: true, reclaimedBytes };
+  }
+
+  public async getDiskUsageClassified(knownStackNames: string[]): Promise<{
+    reclaimableImages: number;
+    reclaimableContainers: number;
+    reclaimableVolumes: number;
+    managedImageBytes: number;
+    unmanagedImageBytes: number;
+    managedVolumeBytes: number;
+    unmanagedVolumeBytes: number;
+  }> {
+    const [base, classified] = await Promise.all([
+      this.getDiskUsage(),
+      this.getClassifiedResources(knownStackNames),
+    ]);
+
+    const managedImageBytes = classified.images
+      .filter(i => i.managedStatus === 'managed')
+      .reduce((acc, i) => acc + i.Size, 0);
+    const unmanagedImageBytes = classified.images
+      .filter(i => i.managedStatus === 'unmanaged')
+      .reduce((acc, i) => acc + i.Size, 0);
+
+    const rawVolumeData = await this.docker.listVolumes();
+    const rawVolumes: any[] = (this.validateApiData<any>(rawVolumeData)).Volumes || [];
+    const knownSet = new Set(knownStackNames);
+
+    const managedVolumeBytes = rawVolumes
+      .filter((v: any) => knownSet.has(v.Labels?.['com.docker.compose.project'] ?? ''))
+      .reduce((acc: number, v: any) => acc + (v.UsageData?.Size ?? 0), 0);
+    const unmanagedVolumeBytes = rawVolumes
+      .filter((v: any) => !knownSet.has(v.Labels?.['com.docker.compose.project'] ?? ''))
+      .reduce((acc: number, v: any) => acc + (v.UsageData?.Size ?? 0), 0);
+
+    return { ...base, managedImageBytes, unmanagedImageBytes, managedVolumeBytes, unmanagedVolumeBytes };
   }
 
   public async removeImage(id: string) {

--- a/frontend/src/components/HomeDashboard.tsx
+++ b/frontend/src/components/HomeDashboard.tsx
@@ -13,9 +13,10 @@ import { Label } from './ui/label';
 
 interface Stats {
   active: number;
+  managed: number;
+  unmanaged: number;
   exited: number;
   total: number;
-  inactive: number;
 }
 
 interface MetricPoint {
@@ -66,7 +67,7 @@ export default function HomeDashboard() {
   const [convertedYaml, setConvertedYaml] = useState('');
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [newStackName, setNewStackName] = useState('');
-  const [stats, setStats] = useState<Stats>({ active: 0, exited: 0, total: 0, inactive: 0 });
+  const [stats, setStats] = useState<Stats>({ active: 0, managed: 0, unmanaged: 0, exited: 0, total: 0 });
   const [systemStats, setSystemStats] = useState<SystemStats | null>(null);
   const [metrics, setMetrics] = useState<MetricPoint[]>([]);
 
@@ -221,7 +222,9 @@ export default function HomeDashboard() {
           </CardHeader>
           <CardContent>
             <div className="text-3xl font-bold text-green-500">{stats.active}</div>
-            <p className="text-xs text-muted-foreground mt-1">Currently running</p>
+            <p className="text-xs text-muted-foreground mt-1">
+              {stats.managed} managed · {stats.unmanaged} external
+            </p>
           </CardContent>
         </Card>
 

--- a/frontend/src/components/HomeDashboard.tsx
+++ b/frontend/src/components/HomeDashboard.tsx
@@ -73,7 +73,7 @@ export default function HomeDashboard() {
 
   // Fetch container stats - re-runs when active node changes so stale data is cleared immediately
   useEffect(() => {
-    setStats({ active: 0, exited: 0, total: 0, inactive: 0 });
+    setStats({ active: 0, managed: 0, unmanaged: 0, exited: 0, total: 0 });
     const fetchStats = async () => {
       try {
         const res = await apiFetch('/stats');

--- a/frontend/src/components/ResourcesView.tsx
+++ b/frontend/src/components/ResourcesView.tsx
@@ -1,40 +1,58 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { apiFetch } from '@/lib/api';
 import { toast } from 'sonner';
-import { Trash2, HardDrive, Network, PackageMinus, MonitorX, PieChart as ChartIcon } from 'lucide-react';
+import { Trash2, HardDrive, Network, PackageMinus, MonitorX, MoreVertical, AlertTriangle, ShieldCheck } from 'lucide-react';
 import { useNodes } from '@/context/NodeContext';
-import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts';
 import { formatBytes } from '@/lib/utils';
+import { cn } from '@/lib/utils';
+
+// ── Interfaces ─────────────────────────────────────────────────────────────────
 
 interface UsageData {
     reclaimableImages: number;
     reclaimableContainers: number;
     reclaimableVolumes: number;
+    managedImageBytes: number;
+    unmanagedImageBytes: number;
+    managedVolumeBytes: number;
+    unmanagedVolumeBytes: number;
 }
+
 interface DockerImage {
     Id: string;
     RepoTags: string[];
     Size: number;
     Containers: number;
+    managedBy: string | null;
+    managedStatus: 'managed' | 'unmanaged' | 'unused';
 }
+
 interface DockerVolume {
     Name: string;
     Driver: string;
     Mountpoint: string;
+    managedBy: string | null;
+    managedStatus: 'managed' | 'unmanaged';
 }
+
 interface DockerNetwork {
     Id: string;
     Name: string;
     Driver: string;
     Scope: string;
+    managedBy: string | null;
+    managedStatus: 'managed' | 'unmanaged' | 'system';
 }
-interface OrphanContainer {
+
+interface UnmanagedContainer {
     Id: string;
     Names: string[];
     State: string;
@@ -42,40 +60,288 @@ interface OrphanContainer {
     Image: string;
 }
 
+type ResourceFilter = 'all' | 'managed' | 'unmanaged';
+type PruneTarget = 'containers' | 'images' | 'networks' | 'volumes';
+type PruneScope = 'managed' | 'all';
+
+// ── Disk Footprint Widget ──────────────────────────────────────────────────────
+
+interface FootprintWidgetProps {
+    usage: UsageData;
+    onFilter: (filter: ResourceFilter) => void;
+}
+
+function FootprintWidget({ usage, onFilter }: FootprintWidgetProps) {
+    const [animated, setAnimated] = useState(false);
+    const ref = useRef<HTMLDivElement>(null);
+
+    const managedBytes = usage.managedImageBytes + usage.managedVolumeBytes;
+    const unmanagedBytes = usage.unmanagedImageBytes + usage.unmanagedVolumeBytes;
+    const reclaimable = usage.reclaimableImages;
+    const total = managedBytes + unmanagedBytes + reclaimable;
+
+    useEffect(() => {
+        // Trigger bar animation on mount
+        const t = setTimeout(() => setAnimated(true), 60);
+        return () => clearTimeout(t);
+    }, []);
+
+    if (total === 0) {
+        return (
+            <div className="flex flex-col items-center justify-center h-28 text-muted-foreground text-sm gap-2 animate-in fade-in-0 duration-300">
+                <ShieldCheck className="w-8 h-8 opacity-40" />
+                <span>No disk usage data available.</span>
+            </div>
+        );
+    }
+
+    const pct = (n: number) => `${Math.max(0, (n / total) * 100).toFixed(1)}%`;
+
+    const segments: { bytes: number; color: string; label: string; filter: ResourceFilter | null; hoverClass: string }[] = [
+        { bytes: managedBytes, color: 'bg-emerald-500', label: 'Sencho Managed', filter: 'managed', hoverClass: 'hover:bg-emerald-400' },
+        { bytes: unmanagedBytes, color: 'bg-orange-500', label: 'External Projects', filter: 'unmanaged', hoverClass: 'hover:bg-orange-400' },
+        { bytes: reclaimable, color: 'bg-muted-foreground/20', label: 'Reclaimable', filter: null, hoverClass: '' },
+    ];
+
+    return (
+        <div ref={ref} className="space-y-4 animate-in fade-in-0 duration-300">
+            {/* Stacked bar */}
+            <div className="relative flex h-4 w-full rounded-full overflow-hidden bg-muted gap-px">
+                {segments.map((seg, i) =>
+                    seg.bytes > 0 ? (
+                        <div
+                            key={i}
+                            title={`${seg.label}: ${formatBytes(seg.bytes)}`}
+                            className={cn(
+                                seg.color, seg.hoverClass,
+                                'transition-all duration-700 ease-out',
+                                seg.filter ? 'cursor-pointer' : 'cursor-default',
+                            )}
+                            style={{
+                                width: animated ? pct(seg.bytes) : '0%',
+                                transitionDelay: `${i * 80}ms`,
+                            }}
+                            onClick={() => seg.filter && onFilter(seg.filter)}
+                        />
+                    ) : null
+                )}
+            </div>
+
+            {/* Legend */}
+            <div className="space-y-2.5">
+                {segments.map((seg, i) =>
+                    seg.bytes > 0 ? (
+                        <button
+                            key={i}
+                            disabled={!seg.filter}
+                            onClick={() => seg.filter && onFilter(seg.filter)}
+                            className={cn(
+                                'flex items-center justify-between w-full text-sm group rounded-md px-1 py-0.5 -mx-1 transition-colors duration-150',
+                                seg.filter ? 'cursor-pointer hover:bg-muted/60' : 'cursor-default',
+                            )}
+                        >
+                            <div className="flex items-center gap-2.5 text-muted-foreground group-hover:text-foreground transition-colors">
+                                <span className={cn('w-2.5 h-2.5 rounded-sm shrink-0', seg.color)} />
+                                <span className="font-medium text-xs tracking-wide">{seg.label}</span>
+                            </div>
+                            <span className="font-mono text-xs text-muted-foreground tabular-nums">
+                                {formatBytes(seg.bytes)}
+                            </span>
+                        </button>
+                    ) : null
+                )}
+            </div>
+        </div>
+    );
+}
+
+// ── Filter Toggle — Segmented Control ─────────────────────────────────────────
+
+interface FilterToggleProps {
+    value: ResourceFilter;
+    onChange: (v: ResourceFilter) => void;
+    counts: { all: number; managed: number; unmanaged: number };
+}
+
+function FilterToggle({ value, onChange, counts }: FilterToggleProps) {
+    const options: { key: ResourceFilter; label: string; count: number }[] = [
+        { key: 'all', label: 'All', count: counts.all },
+        { key: 'managed', label: 'Managed', count: counts.managed },
+        { key: 'unmanaged', label: 'External', count: counts.unmanaged },
+    ];
+
+    return (
+        <div className="flex items-center gap-1 px-3 py-2.5 border-b bg-muted/10">
+            <div className="flex items-center gap-0.5 bg-muted/50 rounded-lg p-0.5">
+                {options.map(({ key, label, count }) => (
+                    <button
+                        key={key}
+                        onClick={() => onChange(key)}
+                        className={cn(
+                            'flex items-center gap-1.5 px-3 py-1 rounded-md text-xs font-medium transition-all duration-200',
+                            value === key
+                                ? 'bg-background text-foreground shadow-sm'
+                                : 'text-muted-foreground hover:text-foreground',
+                        )}
+                    >
+                        {label}
+                        <span className={cn(
+                            'inline-flex items-center justify-center h-4 min-w-4 px-1 rounded-sm text-[10px] font-mono transition-colors duration-200',
+                            value === key ? 'bg-muted text-foreground' : 'text-muted-foreground/70',
+                        )}>
+                            {count}
+                        </span>
+                    </button>
+                ))}
+            </div>
+        </div>
+    );
+}
+
+// ── Managed Status Badge ───────────────────────────────────────────────────────
+
+function ManagedBadge({ status, managedBy }: {
+    status: 'managed' | 'unmanaged' | 'unused' | 'system';
+    managedBy: string | null;
+}) {
+    if (status === 'managed') {
+        return (
+            <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded border border-emerald-500/25 bg-emerald-500/8 text-emerald-500 text-[10px] font-medium">
+                <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 shrink-0" />
+                {managedBy}
+            </span>
+        );
+    }
+    if (status === 'unmanaged') {
+        return (
+            <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded border border-orange-500/25 bg-orange-500/8 text-orange-500 text-[10px] font-medium">
+                <span className="w-1.5 h-1.5 rounded-full bg-orange-500 shrink-0" />
+                External
+            </span>
+        );
+    }
+    if (status === 'system') {
+        return (
+            <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded border border-border bg-muted/40 text-muted-foreground text-[10px] font-medium">
+                <span className="w-1.5 h-1.5 rounded-full bg-muted-foreground/40 shrink-0" />
+                System
+            </span>
+        );
+    }
+    return null;
+}
+
+// ── Quick Clean Prune Button ───────────────────────────────────────────────────
+
+interface PruneButtonProps {
+    target: PruneTarget;
+    icon: React.ReactNode;
+    label: string;
+    accentClass: string;
+    onManaged: () => void;
+    onAll: () => void;
+}
+
+function PruneButton({ target, icon, label, accentClass, onManaged, onAll }: PruneButtonProps) {
+    return (
+        <div className={cn(
+            'group flex flex-col rounded-lg border bg-card overflow-hidden',
+            'transition-shadow duration-200 hover:shadow-md',
+        )}>
+            <button
+                onClick={onManaged}
+                className="flex-1 flex flex-col items-center justify-center gap-2 p-3 pt-4 hover:bg-muted/40 transition-colors duration-150"
+            >
+                <span className={cn('transition-transform duration-200 group-hover:scale-110', accentClass)}>
+                    {icon}
+                </span>
+                <span className="text-xs font-semibold text-center leading-tight text-foreground">{label}</span>
+                <span className="text-[10px] text-brand font-mono tracking-wide">Sencho only</span>
+            </button>
+            {target !== 'containers' && (
+                <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                        <button className={cn(
+                            'flex items-center justify-center gap-1 border-t h-7 w-full text-[10px] text-muted-foreground',
+                            'hover:bg-muted/40 hover:text-foreground transition-colors duration-150',
+                        )}>
+                            <MoreVertical className="w-3 h-3" />
+                            <span>More options</span>
+                        </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="start" className="w-52">
+                        <DropdownMenuItem
+                            className="text-destructive focus:text-destructive focus:bg-destructive/10 gap-2 text-xs"
+                            onClick={onAll}
+                        >
+                            <AlertTriangle className="w-3.5 h-3.5 shrink-0" />
+                            <span>All Docker <span className="text-muted-foreground">(includes external)</span></span>
+                        </DropdownMenuItem>
+                    </DropdownMenuContent>
+                </DropdownMenu>
+            )}
+        </div>
+    );
+}
+
+// ── Table Skeleton ─────────────────────────────────────────────────────────────
+
+function TableSkeleton({ cols, rows = 5 }: { cols: number; rows?: number }) {
+    return (
+        <TableBody>
+            {Array.from({ length: rows }).map((_, r) => (
+                <TableRow key={r} className="animate-in fade-in-0" style={{ animationDelay: `${r * 40}ms` }}>
+                    {Array.from({ length: cols }).map((_, c) => (
+                        <TableCell key={c}>
+                            <Skeleton className={cn('h-4', c === 0 ? 'w-24' : c === 1 ? 'w-48' : 'w-16')} />
+                        </TableCell>
+                    ))}
+                </TableRow>
+            ))}
+        </TableBody>
+    );
+}
+
+// ── Main Component ─────────────────────────────────────────────────────────────
+
 export default function ResourcesView() {
     const { activeNode } = useNodes();
     const [usage, setUsage] = useState<UsageData | null>(null);
     const [images, setImages] = useState<DockerImage[]>([]);
     const [volumes, setVolumes] = useState<DockerVolume[]>([]);
     const [networks, setNetworks] = useState<DockerNetwork[]>([]);
-    const [orphans, setOrphans] = useState<Record<string, OrphanContainer[]>>({});
+    const [orphans, setOrphans] = useState<Record<string, UnmanagedContainer[]>>({});
 
     const [isLoading, setIsLoading] = useState(true);
     const [isActioning, setIsActioning] = useState(false);
 
-    // Modal states
-    const [confirmPruneType, setConfirmPruneType] = useState<'containers' | 'images' | 'networks' | 'volumes' | null>(null);
-    const [confirmDelete, setConfirmDelete] = useState<{ type: 'images' | 'volumes' | 'networks', id: string, name?: string } | null>(null);
+    // Filter state
+    const [imageFilter, setImageFilter] = useState<ResourceFilter>('all');
+    const [volumeFilter, setVolumeFilter] = useState<ResourceFilter>('all');
+    const [networkFilter, setNetworkFilter] = useState<ResourceFilter>('all');
 
-    // Ghost hunting state
+    // Modal states
+    const [confirmPrune, setConfirmPrune] = useState<{ target: PruneTarget; scope: PruneScope } | null>(null);
+    const [confirmDelete, setConfirmDelete] = useState<{ type: 'images' | 'volumes' | 'networks'; id: string; name?: string } | null>(null);
+
+    // Unmanaged container state
     const [selectedOrphans, setSelectedOrphans] = useState<string[]>([]);
     const [bulkPurgeConfirm, setBulkPurgeConfirm] = useState(false);
 
     const fetchAllData = async () => {
         setIsLoading(true);
         try {
-            const [usageRes, imagesRes, volumesRes, networksRes, orphansRes] = await Promise.all([
+            const [usageRes, resourcesRes, orphansRes] = await Promise.all([
                 apiFetch('/system/docker-df'),
-                apiFetch('/system/images'),
-                apiFetch('/system/volumes'),
-                apiFetch('/system/networks'),
+                apiFetch('/system/resources'),
                 apiFetch('/system/orphans'),
             ]);
 
             setUsage(await usageRes.json());
-            setImages(await imagesRes.json());
-            setVolumes(await volumesRes.json());
-            setNetworks(await networksRes.json());
+            const resources = await resourcesRes.json();
+            setImages(resources.images ?? []);
+            setVolumes(resources.volumes ?? []);
+            setNetworks(resources.networks ?? []);
             setOrphans(await orphansRes.json());
             setSelectedOrphans([]);
         } catch (err) {
@@ -86,30 +352,29 @@ export default function ResourcesView() {
         }
     };
 
-    useEffect(() => {
-        fetchAllData();
-    }, []);
+    useEffect(() => { fetchAllData(); }, [activeNode]);
 
     const handlePrune = async () => {
-        if (!confirmPruneType) return;
+        if (!confirmPrune) return;
         setIsActioning(true);
         try {
             const res = await apiFetch('/system/prune/system', {
                 method: 'POST',
-                body: JSON.stringify({ target: confirmPruneType })
+                body: JSON.stringify({ target: confirmPrune.target, scope: confirmPrune.scope })
             });
             const data = await res.json();
-            if (data.reclaimedBytes !== undefined) {
-                toast.success(`Pruned ${confirmPruneType}. Reclaimed ${formatBytes(data.reclaimedBytes)}.`);
-            } else {
-                toast.success(`Pruned ${confirmPruneType}.`);
-            }
+            const scopeLabel = confirmPrune.scope === 'managed' ? 'Sencho-managed' : 'all';
+            toast.success(
+                data.reclaimedBytes !== undefined
+                    ? `Pruned ${scopeLabel} ${confirmPrune.target}. Reclaimed ${formatBytes(data.reclaimedBytes)}.`
+                    : `Pruned ${scopeLabel} ${confirmPrune.target}.`
+            );
             await fetchAllData();
         } catch {
-            toast.error(`Failed to prune ${confirmPruneType}`);
+            toast.error(confirmPrune ? `Failed to prune ${confirmPrune.target}` : 'Prune failed');
         } finally {
             setIsActioning(false);
-            setConfirmPruneType(null);
+            setConfirmPrune(null);
         }
     };
 
@@ -132,15 +397,13 @@ export default function ResourcesView() {
         }
     };
 
-    const toggleOrphanSelection = (containerId: string) => {
-        setSelectedOrphans(prev => prev.includes(containerId) ? prev.filter(id => id !== containerId) : [...prev, containerId]);
-    };
+    const toggleOrphan = (id: string) =>
+        setSelectedOrphans(prev => prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id]);
 
     const totalOrphansCount = Object.values(orphans).flat().length;
     const selectAllOrphans = () => {
         const allIds = Object.values(orphans).flat().map(c => c.Id);
-        if (selectedOrphans.length === allIds.length) setSelectedOrphans([]);
-        else setSelectedOrphans(allIds);
+        setSelectedOrphans(selectedOrphans.length === allIds.length ? [] : allIds);
     };
 
     const handlePurgeOrphans = async () => {
@@ -151,7 +414,7 @@ export default function ResourcesView() {
                 body: JSON.stringify({ containerIds: selectedOrphans })
             });
             if (!res.ok) throw new Error();
-            toast.success(`Purged ${selectedOrphans.length} ghost container(s)`);
+            toast.success(`Purged ${selectedOrphans.length} unmanaged container(s)`);
             setBulkPurgeConfirm(false);
             await fetchAllData();
         } catch {
@@ -161,120 +424,139 @@ export default function ResourcesView() {
         }
     };
 
-    const chartData = [
-        { name: 'Unused Images', value: usage?.reclaimableImages || 0, color: '#3b82f6' },
-        { name: 'Unused Volumes', value: usage?.reclaimableVolumes || 0, color: '#a855f7' },
-        { name: 'Stopped Containers', value: usage?.reclaimableContainers || 0, color: '#f97316' },
-    ];
+    // Derived filtered lists
+    const filteredImages = images.filter(img =>
+        imageFilter === 'managed' ? img.managedStatus === 'managed' :
+        imageFilter === 'unmanaged' ? img.managedStatus !== 'managed' : true
+    );
+    const filteredVolumes = volumes.filter(vol =>
+        volumeFilter === 'managed' ? vol.managedStatus === 'managed' :
+        volumeFilter === 'unmanaged' ? vol.managedStatus !== 'managed' : true
+    );
+    const filteredNetworks = networks.filter(net =>
+        networkFilter === 'managed' ? net.managedStatus === 'managed' :
+        networkFilter === 'unmanaged' ? net.managedStatus !== 'managed' : true
+    );
 
-    const totalReclaimable = chartData.reduce((acc, curr) => acc + curr.value, 0);
-
-    const CustomTooltip = ({ active, payload }: { active?: boolean; payload?: Array<{ name: string; value: number }> }) => {
-        if (active && payload && payload.length) {
-            return (
-                <div className="bg-popover text-popover-foreground border rounded-lg shadow-md p-3 text-sm">
-                    <p className="font-semibold">{payload[0].name}</p>
-                    <p>{formatBytes(payload[0].value)}</p>
-                </div>
-            );
-        }
-        return null;
+    const handleFootprintFilter = (filter: ResourceFilter) => {
+        setImageFilter(filter);
+        setVolumeFilter(filter);
     };
 
-    if (isLoading && !usage) {
-        return <div className="p-6 flex justify-center items-center h-full text-muted-foreground animate-pulse">Loading resources...</div>;
-    }
-
     return (
-        <div className="p-6 h-full overflow-auto text-foreground flex flex-col gap-6">
-            <div className="flex items-center gap-2">
-                <HardDrive className="w-6 h-6" />
-                <h1 className="text-2xl font-bold">Resources Hub</h1>
+        <div className="p-6 h-full overflow-auto text-foreground flex flex-col gap-6 animate-in fade-in-0 duration-300">
+
+            {/* Header */}
+            <div className="flex items-center gap-3">
+                <HardDrive className="w-5 h-5 text-muted-foreground" />
+                <h1 className="text-xl font-semibold tracking-tight">Resources Hub</h1>
                 {activeNode?.type === 'remote' && (
-                    <span className="text-sm font-normal text-muted-foreground">- {activeNode.name}</span>
+                    <span className="text-sm text-muted-foreground">— {activeNode.name}</span>
                 )}
             </div>
 
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                <Card className="col-span-1 border-border shadow-sm">
-                    <CardHeader className="pb-2">
-                        <CardTitle className="flex items-center gap-2 text-lg">
-                            <ChartIcon className="w-5 h-5 text-muted-foreground" /> Reclaimable Space
+            {/* Top row: Footprint + Quick Clean */}
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+
+                {/* Disk Footprint */}
+                <Card className="col-span-1 border-border shadow-sm animate-in fade-in-0 slide-in-from-bottom-2 duration-300">
+                    <CardHeader className="pb-3">
+                        <CardTitle className="text-sm font-medium text-muted-foreground tracking-wide uppercase">
+                            Docker Disk Footprint
                         </CardTitle>
+                        <CardDescription className="text-xs">
+                            Click a segment to filter the tabs below
+                        </CardDescription>
                     </CardHeader>
-                    <CardContent className="h-48 flex flex-col items-center justify-center">
-                        {totalReclaimable > 0 ? (
-                            <ResponsiveContainer width="100%" height="80%">
-                                <PieChart>
-                                    <Pie
-                                        data={chartData}
-                                        cx="50%"
-                                        cy="50%"
-                                        outerRadius={50}
-                                        stroke="none"
-                                        dataKey="value"
-                                    >
-                                        {chartData.map((entry, index) => (
-                                            <Cell key={`cell-${index}`} fill={entry.color} />
-                                        ))}
-                                    </Pie>
-                                    <Tooltip content={<CustomTooltip />} />
-                                </PieChart>
-                            </ResponsiveContainer>
+                    <CardContent>
+                        {usage ? (
+                            <FootprintWidget usage={usage} onFilter={handleFootprintFilter} />
                         ) : (
-                            <div className="flex-1 flex flex-col items-center justify-center text-muted-foreground">
-                                <span className="text-sm font-medium">Your system is clean</span>
+                            <div className="space-y-3">
+                                <Skeleton className="h-4 w-full rounded-full" />
+                                <div className="space-y-2">
+                                    <Skeleton className="h-4 w-full" />
+                                    <Skeleton className="h-4 w-3/4" />
+                                    <Skeleton className="h-4 w-1/2" />
+                                </div>
                             </div>
                         )}
-                        <div className="flex gap-4 text-xs font-semibold justify-center mt-2 flex-wrap">
-                            {chartData.filter(d => d.value > 0).map((entry, index) => (
-                                <div key={index} className="flex items-center gap-1">
-                                    <span className="w-2 h-2 rounded-full" style={{ backgroundColor: entry.color }} />
-                                    {entry.name}
-                                </div>
-                            ))}
-                        </div>
                     </CardContent>
                 </Card>
 
-                <Card className="col-span-1 md:col-span-2 border-border shadow-sm flex flex-col">
-                    <CardHeader className="pb-2">
-                        <CardTitle className="text-lg">Quick Clean</CardTitle>
-                        <CardDescription>Free up disk space with bulk prune operations</CardDescription>
+                {/* Quick Clean */}
+                <Card className="col-span-1 md:col-span-2 border-border shadow-sm flex flex-col animate-in fade-in-0 slide-in-from-bottom-2 duration-300 delay-75">
+                    <CardHeader className="pb-3">
+                        <CardTitle className="text-sm font-medium text-muted-foreground tracking-wide uppercase">
+                            Quick Clean
+                        </CardTitle>
+                        <CardDescription className="text-xs">
+                            Primary actions target <span className="text-foreground font-medium">Sencho-managed</span> resources only.
+                            Use <MoreVertical className="inline w-3 h-3" /> for all-Docker operations.
+                        </CardDescription>
                     </CardHeader>
                     <CardContent className="flex-1 flex flex-col justify-center">
-                        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-                            <Button variant="outline" className="h-24 flex flex-col gap-2 hover:bg-muted/50 transition-colors whitespace-normal" onClick={() => setConfirmPruneType('images')}>
-                                <PackageMinus className="w-8 h-8 text-blue-500 shrink-0" />
-                                <span className="text-xs font-semibold text-center leading-tight">Prune Unused Images</span>
-                            </Button>
-                            <Button variant="outline" className="h-24 flex flex-col gap-2 hover:bg-muted/50 transition-colors whitespace-normal" onClick={() => setConfirmPruneType('volumes')}>
-                                <HardDrive className="w-8 h-8 text-purple-500 shrink-0" />
-                                <span className="text-xs font-semibold text-center leading-tight">Prune Unused Volumes</span>
-                            </Button>
-                            <Button variant="outline" className="h-24 flex flex-col gap-2 hover:bg-muted/50 transition-colors whitespace-normal" onClick={() => setConfirmPruneType('networks')}>
-                                <Network className="w-8 h-8 text-green-500 shrink-0" />
-                                <span className="text-xs font-semibold text-center leading-tight">Prune Dead Networks</span>
-                            </Button>
-                            <Button variant="outline" className="h-24 flex flex-col gap-2 hover:bg-muted/50 transition-colors whitespace-normal" onClick={() => setConfirmPruneType('containers')}>
-                                <MonitorX className="w-8 h-8 text-orange-500 shrink-0" />
-                                <span className="text-xs font-semibold text-center leading-tight">Purge Ghost Containers</span>
-                            </Button>
+                        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+                            <PruneButton
+                                target="images"
+                                icon={<PackageMinus className="w-6 h-6" />}
+                                label="Prune Unused Images"
+                                accentClass="text-blue-500"
+                                onManaged={() => setConfirmPrune({ target: 'images', scope: 'managed' })}
+                                onAll={() => setConfirmPrune({ target: 'images', scope: 'all' })}
+                            />
+                            <PruneButton
+                                target="volumes"
+                                icon={<HardDrive className="w-6 h-6" />}
+                                label="Prune Unused Volumes"
+                                accentClass="text-purple-500"
+                                onManaged={() => setConfirmPrune({ target: 'volumes', scope: 'managed' })}
+                                onAll={() => setConfirmPrune({ target: 'volumes', scope: 'all' })}
+                            />
+                            <PruneButton
+                                target="networks"
+                                icon={<Network className="w-6 h-6" />}
+                                label="Prune Dead Networks"
+                                accentClass="text-emerald-500"
+                                onManaged={() => setConfirmPrune({ target: 'networks', scope: 'managed' })}
+                                onAll={() => setConfirmPrune({ target: 'networks', scope: 'all' })}
+                            />
+                            <PruneButton
+                                target="containers"
+                                icon={<MonitorX className="w-6 h-6" />}
+                                label="Purge Unmanaged Containers"
+                                accentClass="text-orange-500"
+                                onManaged={() => setConfirmPrune({ target: 'containers', scope: 'managed' })}
+                                onAll={() => setConfirmPrune({ target: 'containers', scope: 'all' })}
+                            />
                         </div>
                     </CardContent>
                 </Card>
             </div>
 
-            <Tabs defaultValue="images" className="flex-1 flex flex-col w-full rounded-lg border bg-card shadow-sm overflow-hidden min-h-[400px]">
-                <div className="p-4 border-b bg-muted/20">
-                    <TabsList className="grid grid-cols-4 w-full md:w-[600px]">
-                        <TabsTrigger value="images">Images</TabsTrigger>
-                        <TabsTrigger value="volumes">Volumes</TabsTrigger>
-                        <TabsTrigger value="networks">Networks</TabsTrigger>
-                        <TabsTrigger value="ghosts" className="relative">
-                            Ghost Containers
+            {/* Resource Tabs */}
+            <Tabs
+                defaultValue="images"
+                className="flex-1 flex flex-col w-full rounded-lg border bg-card shadow-sm overflow-hidden min-h-[400px] animate-in fade-in-0 slide-in-from-bottom-2 duration-300 delay-150"
+            >
+                <div className="px-4 pt-3 pb-0 border-b bg-muted/10">
+                    <TabsList className="grid grid-cols-4 w-full md:w-[680px] h-9 bg-transparent gap-1 p-0">
+                        {(['images', 'volumes', 'networks'] as const).map(tab => (
+                            <TabsTrigger
+                                key={tab}
+                                value={tab}
+                                className="capitalize text-xs data-[state=active]:bg-background data-[state=active]:shadow-sm rounded-t-md rounded-b-none border-b-2 border-transparent data-[state=active]:border-foreground transition-all duration-200"
+                            >
+                                {tab}
+                            </TabsTrigger>
+                        ))}
+                        <TabsTrigger
+                            value="unmanaged"
+                            className="relative text-xs data-[state=active]:bg-background data-[state=active]:shadow-sm rounded-t-md rounded-b-none border-b-2 border-transparent data-[state=active]:border-foreground transition-all duration-200"
+                        >
+                            Unmanaged
                             {totalOrphansCount > 0 && (
-                                <span className="absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-[10px] text-white font-bold">
+                                <span className="absolute -top-1.5 -right-1 flex h-4 min-w-4 px-1 items-center justify-center rounded-full bg-orange-500 text-[9px] text-white font-bold animate-in zoom-in-75 duration-200">
                                     {totalOrphansCount}
                                 </span>
                             )}
@@ -282,158 +564,237 @@ export default function ResourcesView() {
                     </TabsList>
                 </div>
 
-                <div className="flex-1 overflow-auto bg-background m-4 border rounded-md relative text-sm">
-                    <TabsContent value="images" className="m-0 border-0 p-0">
+                <div className="flex-1 overflow-auto bg-background relative text-sm">
+
+                    {/* Images */}
+                    <TabsContent value="images" className="m-0 border-0 p-0 animate-in fade-in-0 duration-200">
+                        <FilterToggle
+                            value={imageFilter}
+                            onChange={setImageFilter}
+                            counts={{
+                                all: images.length,
+                                managed: images.filter(i => i.managedStatus === 'managed').length,
+                                unmanaged: images.filter(i => i.managedStatus !== 'managed').length,
+                            }}
+                        />
                         <Table>
                             <TableHeader>
-                                <TableRow>
-                                    <TableHead className="w-[120px]">ID</TableHead>
-                                    <TableHead>Repository:Tag</TableHead>
-                                    <TableHead>Size</TableHead>
-                                    <TableHead>Status</TableHead>
-                                    <TableHead className="text-right">Action</TableHead>
+                                <TableRow className="hover:bg-transparent">
+                                    <TableHead className="w-[120px] text-[11px]">ID</TableHead>
+                                    <TableHead className="text-[11px]">Repository:Tag</TableHead>
+                                    <TableHead className="text-[11px]">Size</TableHead>
+                                    <TableHead className="text-[11px]">Status</TableHead>
+                                    <TableHead className="text-right text-[11px]">Action</TableHead>
                                 </TableRow>
                             </TableHeader>
-                            <TableBody>
-                                {images.length === 0 ? (
-                                    <TableRow><TableCell colSpan={5} className="text-center py-6 text-muted-foreground">No images found.</TableCell></TableRow>
-                                ) : images.map((img) => (
-                                    <TableRow key={img.Id}>
-                                        <TableCell className="font-mono text-xs">{img.Id.split(':')[1]?.substring(0, 12)}</TableCell>
-                                        <TableCell className="font-medium">{img.RepoTags?.[0] || '<none>:<none>'}</TableCell>
-                                        <TableCell>{formatBytes(img.Size)}</TableCell>
-                                        <TableCell>
-                                            <Badge variant={img.Containers > 0 ? "default" : "secondary"}>
-                                                {img.Containers > 0 ? "In Use" : "Unused"}
-                                            </Badge>
-                                        </TableCell>
-                                        <TableCell className="text-right">
-                                            <Button variant="ghost" size="icon" className="hover:text-red-500 hover:bg-red-500/10" onClick={() => setConfirmDelete({ type: 'images', id: img.Id, name: img.RepoTags?.[0] })}>
-                                                <Trash2 className="w-4 h-4" />
-                                            </Button>
-                                        </TableCell>
-                                    </TableRow>
-                                ))}
-                            </TableBody>
+                            {isLoading ? <TableSkeleton cols={5} /> : (
+                                <TableBody>
+                                    {filteredImages.length === 0 ? (
+                                        <TableRow><TableCell colSpan={5} className="text-center py-8 text-muted-foreground text-sm">No images found.</TableCell></TableRow>
+                                    ) : filteredImages.map((img, i) => (
+                                        <TableRow
+                                            key={img.Id}
+                                            className="animate-in fade-in-0 duration-200 hover:bg-muted/30 transition-colors"
+                                            style={{ animationDelay: `${Math.min(i * 20, 200)}ms` }}
+                                        >
+                                            <TableCell className="font-mono text-xs text-muted-foreground">{img.Id.split(':')[1]?.substring(0, 12)}</TableCell>
+                                            <TableCell className="font-medium">{img.RepoTags?.[0] || '<none>:<none>'}</TableCell>
+                                            <TableCell className="font-mono text-xs tabular-nums">{formatBytes(img.Size)}</TableCell>
+                                            <TableCell>
+                                                <div className="flex items-center gap-1.5 flex-wrap">
+                                                    <Badge variant={img.Containers > 0 ? "default" : "secondary"} className="text-[10px] h-5">
+                                                        {img.Containers > 0 ? "In Use" : "Unused"}
+                                                    </Badge>
+                                                    <ManagedBadge status={img.managedStatus} managedBy={img.managedBy} />
+                                                </div>
+                                            </TableCell>
+                                            <TableCell className="text-right">
+                                                <Button variant="ghost" size="icon" className="h-7 w-7 hover:text-red-500 hover:bg-red-500/10 transition-colors" onClick={() => setConfirmDelete({ type: 'images', id: img.Id, name: img.RepoTags?.[0] })}>
+                                                    <Trash2 className="w-3.5 h-3.5" />
+                                                </Button>
+                                            </TableCell>
+                                        </TableRow>
+                                    ))}
+                                </TableBody>
+                            )}
                         </Table>
                     </TabsContent>
 
-                    <TabsContent value="volumes" className="m-0 border-0 p-0">
+                    {/* Volumes */}
+                    <TabsContent value="volumes" className="m-0 border-0 p-0 animate-in fade-in-0 duration-200">
+                        <FilterToggle
+                            value={volumeFilter}
+                            onChange={setVolumeFilter}
+                            counts={{
+                                all: volumes.length,
+                                managed: volumes.filter(v => v.managedStatus === 'managed').length,
+                                unmanaged: volumes.filter(v => v.managedStatus !== 'managed').length,
+                            }}
+                        />
                         <Table>
                             <TableHeader>
-                                <TableRow>
-                                    <TableHead>Name</TableHead>
-                                    <TableHead>Driver</TableHead>
-                                    <TableHead className="hidden md:table-cell">Mountpoint</TableHead>
-                                    <TableHead className="text-right">Action</TableHead>
+                                <TableRow className="hover:bg-transparent">
+                                    <TableHead className="text-[11px]">Name</TableHead>
+                                    <TableHead className="text-[11px]">Driver</TableHead>
+                                    <TableHead className="hidden md:table-cell text-[11px]">Mountpoint</TableHead>
+                                    <TableHead className="text-[11px]">Status</TableHead>
+                                    <TableHead className="text-right text-[11px]">Action</TableHead>
                                 </TableRow>
                             </TableHeader>
-                            <TableBody>
-                                {volumes.length === 0 ? (
-                                    <TableRow><TableCell colSpan={4} className="text-center py-6 text-muted-foreground">No volumes found.</TableCell></TableRow>
-                                ) : volumes.map((vol) => (
-                                    <TableRow key={vol.Name}>
-                                        <TableCell className="font-mono text-xs max-w-[200px] truncate">{vol.Name}</TableCell>
-                                        <TableCell><Badge variant="outline">{vol.Driver}</Badge></TableCell>
-                                        <TableCell className="hidden md:table-cell text-xs text-muted-foreground truncate max-w-[300px]">{vol.Mountpoint}</TableCell>
-                                        <TableCell className="text-right">
-                                            <Button variant="ghost" size="icon" className="hover:text-red-500 hover:bg-red-500/10" onClick={() => setConfirmDelete({ type: 'volumes', id: vol.Name, name: vol.Name })}>
-                                                <Trash2 className="w-4 h-4" />
-                                            </Button>
-                                        </TableCell>
-                                    </TableRow>
-                                ))}
-                            </TableBody>
+                            {isLoading ? <TableSkeleton cols={5} /> : (
+                                <TableBody>
+                                    {filteredVolumes.length === 0 ? (
+                                        <TableRow><TableCell colSpan={5} className="text-center py-8 text-muted-foreground text-sm">No volumes found.</TableCell></TableRow>
+                                    ) : filteredVolumes.map((vol, i) => (
+                                        <TableRow
+                                            key={vol.Name}
+                                            className="animate-in fade-in-0 duration-200 hover:bg-muted/30 transition-colors"
+                                            style={{ animationDelay: `${Math.min(i * 20, 200)}ms` }}
+                                        >
+                                            <TableCell className="font-mono text-xs max-w-[200px] truncate">{vol.Name}</TableCell>
+                                            <TableCell><Badge variant="outline" className="text-[10px] h-5">{vol.Driver}</Badge></TableCell>
+                                            <TableCell className="hidden md:table-cell text-xs text-muted-foreground truncate max-w-[300px]">{vol.Mountpoint}</TableCell>
+                                            <TableCell><ManagedBadge status={vol.managedStatus} managedBy={vol.managedBy} /></TableCell>
+                                            <TableCell className="text-right">
+                                                <Button variant="ghost" size="icon" className="h-7 w-7 hover:text-red-500 hover:bg-red-500/10 transition-colors" onClick={() => setConfirmDelete({ type: 'volumes', id: vol.Name, name: vol.Name })}>
+                                                    <Trash2 className="w-3.5 h-3.5" />
+                                                </Button>
+                                            </TableCell>
+                                        </TableRow>
+                                    ))}
+                                </TableBody>
+                            )}
                         </Table>
                     </TabsContent>
 
-                    <TabsContent value="networks" className="m-0 border-0 p-0">
+                    {/* Networks */}
+                    <TabsContent value="networks" className="m-0 border-0 p-0 animate-in fade-in-0 duration-200">
+                        <FilterToggle
+                            value={networkFilter}
+                            onChange={setNetworkFilter}
+                            counts={{
+                                all: networks.length,
+                                managed: networks.filter(n => n.managedStatus === 'managed').length,
+                                unmanaged: networks.filter(n => n.managedStatus !== 'managed').length,
+                            }}
+                        />
                         <Table>
                             <TableHeader>
-                                <TableRow>
-                                    <TableHead className="w-[120px]">ID</TableHead>
-                                    <TableHead>Name</TableHead>
-                                    <TableHead>Driver</TableHead>
-                                    <TableHead>Scope</TableHead>
-                                    <TableHead className="text-right">Action</TableHead>
+                                <TableRow className="hover:bg-transparent">
+                                    <TableHead className="w-[120px] text-[11px]">ID</TableHead>
+                                    <TableHead className="text-[11px]">Name</TableHead>
+                                    <TableHead className="text-[11px]">Driver</TableHead>
+                                    <TableHead className="text-[11px]">Scope</TableHead>
+                                    <TableHead className="text-[11px]">Status</TableHead>
+                                    <TableHead className="text-right text-[11px]">Action</TableHead>
                                 </TableRow>
                             </TableHeader>
-                            <TableBody>
-                                {networks.length === 0 ? (
-                                    <TableRow><TableCell colSpan={5} className="text-center py-6 text-muted-foreground">No networks found.</TableCell></TableRow>
-                                ) : networks.map((net) => (
-                                    <TableRow key={net.Id}>
-                                        <TableCell className="font-mono text-xs">{net.Id.substring(0, 12)}</TableCell>
-                                        <TableCell className="font-medium max-w-[200px] truncate">{net.Name}</TableCell>
-                                        <TableCell>{net.Driver}</TableCell>
-                                        <TableCell><Badge variant="outline">{net.Scope}</Badge></TableCell>
-                                        <TableCell className="text-right">
-                                            <Button variant="ghost" size="icon" className="hover:text-red-500 hover:bg-red-500/10" onClick={() => setConfirmDelete({ type: 'networks', id: net.Id, name: net.Name })}>
-                                                <Trash2 className="w-4 h-4" />
-                                            </Button>
-                                        </TableCell>
-                                    </TableRow>
-                                ))}
-                            </TableBody>
+                            {isLoading ? <TableSkeleton cols={6} /> : (
+                                <TableBody>
+                                    {filteredNetworks.length === 0 ? (
+                                        <TableRow><TableCell colSpan={6} className="text-center py-8 text-muted-foreground text-sm">No networks found.</TableCell></TableRow>
+                                    ) : filteredNetworks.map((net, i) => (
+                                        <TableRow
+                                            key={net.Id}
+                                            className="animate-in fade-in-0 duration-200 hover:bg-muted/30 transition-colors"
+                                            style={{ animationDelay: `${Math.min(i * 20, 200)}ms` }}
+                                        >
+                                            <TableCell className="font-mono text-xs text-muted-foreground">{net.Id.substring(0, 12)}</TableCell>
+                                            <TableCell className="font-medium max-w-[200px] truncate">{net.Name}</TableCell>
+                                            <TableCell className="text-xs">{net.Driver}</TableCell>
+                                            <TableCell><Badge variant="outline" className="text-[10px] h-5">{net.Scope}</Badge></TableCell>
+                                            <TableCell><ManagedBadge status={net.managedStatus} managedBy={net.managedBy} /></TableCell>
+                                            <TableCell className="text-right">
+                                                <Button
+                                                    variant="ghost"
+                                                    size="icon"
+                                                    className="h-7 w-7 hover:text-red-500 hover:bg-red-500/10 transition-colors disabled:opacity-30"
+                                                    disabled={net.managedStatus === 'system'}
+                                                    onClick={() => setConfirmDelete({ type: 'networks', id: net.Id, name: net.Name })}
+                                                >
+                                                    <Trash2 className="w-3.5 h-3.5" />
+                                                </Button>
+                                            </TableCell>
+                                        </TableRow>
+                                    ))}
+                                </TableBody>
+                            )}
                         </Table>
                     </TabsContent>
 
-                    <TabsContent value="ghosts" className="m-0 border-0 p-0 h-full flex flex-col">
-                        <div className="flex justify-between items-center p-3 border-b bg-muted/10 sticky top-0 z-10">
-                            <div className="flex items-center gap-2">
+                    {/* Unmanaged Containers */}
+                    <TabsContent value="unmanaged" className="m-0 border-0 p-0 h-full flex flex-col animate-in fade-in-0 duration-200">
+                        <div className="flex justify-between items-center px-4 py-2.5 border-b bg-muted/10 sticky top-0 z-10 backdrop-blur-sm">
+                            <div className="flex items-center gap-2.5">
                                 <input
                                     type="checkbox"
                                     onChange={selectAllOrphans}
                                     checked={selectedOrphans.length === totalOrphansCount && totalOrphansCount > 0}
-                                    className="rounded border-gray-300 focus:ring-primary h-4 w-4 ml-2"
+                                    className="rounded border-border focus:ring-ring h-4 w-4 accent-foreground"
                                 />
-                                <span className="text-sm font-medium">Select All</span>
+                                <span className="text-xs font-medium text-muted-foreground">Select all</span>
                             </div>
                             <Button
                                 variant="destructive"
                                 size="sm"
+                                className="h-7 text-xs gap-1.5"
                                 onClick={() => setBulkPurgeConfirm(true)}
                                 disabled={selectedOrphans.length === 0 || isActioning}
                             >
-                                <Trash2 className="w-4 h-4 mr-2" />
+                                <Trash2 className="w-3.5 h-3.5" />
                                 {isActioning ? 'Purging...' : `Purge Selected (${selectedOrphans.length})`}
                             </Button>
                         </div>
 
                         {totalOrphansCount === 0 ? (
-                            <div className="flex-1 flex flex-col items-center justify-center p-12 text-muted-foreground">
-                                <MonitorX className="w-12 h-12 mb-2 opacity-50 text-green-500" />
-                                <p>No orphaned containers detected.</p>
-                                <p className="text-xs mt-1">Your system is clean!</p>
+                            <div className="flex-1 flex flex-col items-center justify-center p-12 text-muted-foreground animate-in fade-in-0 duration-300">
+                                <div className="w-12 h-12 rounded-full bg-emerald-500/10 flex items-center justify-center mb-3">
+                                    <ShieldCheck className="w-6 h-6 text-emerald-500" />
+                                </div>
+                                <p className="font-medium text-sm">No unmanaged containers</p>
+                                <p className="text-xs mt-1 opacity-70">All running containers are managed by Sencho.</p>
                             </div>
                         ) : (
-                            <div className="p-4 space-y-4 pb-12">
-                                {Object.entries(orphans).map(([project, containers]) => (
-                                    <div key={project} className="bg-card rounded-lg border shadow-sm overflow-hidden text-sm">
-                                        <div className="bg-muted px-4 py-2 border-b font-medium text-xs flex items-center gap-2">
-                                            <span className="w-2 h-2 rounded-full bg-red-500/80"></span>
-                                            Project: {project}
+                            <div className="p-4 space-y-3 pb-12">
+                                {Object.entries(orphans).map(([project, containers], gi) => (
+                                    <div
+                                        key={project}
+                                        className="bg-card rounded-lg border shadow-sm overflow-hidden text-sm animate-in fade-in-0 slide-in-from-bottom-1 duration-200"
+                                        style={{ animationDelay: `${gi * 60}ms` }}
+                                    >
+                                        {/* Project header */}
+                                        <div className="bg-orange-500/8 border-b border-orange-500/15 px-4 py-2 font-medium text-xs flex items-center gap-2">
+                                            <span className="w-1.5 h-1.5 rounded-full bg-orange-500 animate-pulse shrink-0" />
+                                            <span className="text-orange-600 dark:text-orange-400">External Project:</span>
+                                            <span className="font-mono text-foreground">{project}</span>
+                                            <span className="ml-auto text-muted-foreground font-normal">{containers.length} container{containers.length !== 1 ? 's' : ''}</span>
                                         </div>
-                                        <div className="divide-y">
-                                            {containers.map((container: OrphanContainer) => (
-                                                <div key={container.Id} className="flex items-center gap-4 p-3 hover:bg-muted/50 transition-colors">
+                                        <div className="divide-y divide-border/50">
+                                            {containers.map((container: UnmanagedContainer) => (
+                                                <div
+                                                    key={container.Id}
+                                                    className="flex items-center gap-3 px-4 py-2.5 hover:bg-muted/30 transition-colors duration-150"
+                                                >
                                                     <input
                                                         type="checkbox"
                                                         checked={selectedOrphans.includes(container.Id)}
-                                                        onChange={() => toggleOrphanSelection(container.Id)}
-                                                        className="rounded border-gray-300 h-4 w-4"
+                                                        onChange={() => toggleOrphan(container.Id)}
+                                                        className="rounded border-border h-4 w-4 accent-foreground"
                                                     />
                                                     <div className="flex-1 min-w-0">
                                                         <div className="flex items-center gap-2">
-                                                            <span className="font-mono font-semibold truncate">
+                                                            <span className="font-mono text-xs font-semibold truncate">
                                                                 {container.Names[0]?.replace(/^\//, '') || container.Id.substring(0, 12)}
                                                             </span>
-                                                            <Badge variant={container.State === 'running' ? 'default' : 'secondary'} className="text-[10px] h-4">
+                                                            <Badge
+                                                                variant={container.State === 'running' ? 'default' : 'secondary'}
+                                                                className="text-[9px] h-4 px-1.5"
+                                                            >
                                                                 {container.State}
                                                             </Badge>
                                                         </div>
-                                                        <div className="text-xs text-muted-foreground truncate mt-1">
-                                                            Image: {container.Image}
+                                                        <div className="text-[11px] text-muted-foreground truncate mt-0.5 font-mono">
+                                                            {container.Image}
                                                         </div>
                                                     </div>
                                                 </div>
@@ -447,31 +808,53 @@ export default function ResourcesView() {
                 </div>
             </Tabs>
 
-            {/* Prune Bulk Action Confirm Dialog */}
-            <AlertDialog open={!!confirmPruneType} onOpenChange={(open) => !open && setConfirmPruneType(null)}>
-                <AlertDialogContent>
+            {/* ── Dialogs ── */}
+
+            {/* Prune Confirm */}
+            <AlertDialog open={!!confirmPrune} onOpenChange={(open) => !open && setConfirmPrune(null)}>
+                <AlertDialogContent className="animate-in fade-in-0 zoom-in-95 duration-200">
                     <AlertDialogHeader>
-                        <AlertDialogTitle>Prune {confirmPruneType}</AlertDialogTitle>
-                        <AlertDialogDescription>
-                            Are you sure you want to prune all unused {confirmPruneType}? This action cannot be undone and will permanently free up disk space.
-                        </AlertDialogDescription>
+                        {confirmPrune?.scope === 'all' ? (
+                            <>
+                                <AlertDialogTitle className="flex items-center gap-2 text-destructive">
+                                    <AlertTriangle className="w-4 h-4" />
+                                    Prune All Docker {confirmPrune?.target}
+                                </AlertDialogTitle>
+                                <AlertDialogDescription>
+                                    This will prune <span className="font-semibold text-foreground">all</span> unused {confirmPrune?.target} from the Docker daemon —
+                                    including those from <span className="font-semibold text-foreground">external projects not managed by Sencho</span>. This cannot be undone.
+                                </AlertDialogDescription>
+                            </>
+                        ) : (
+                            <>
+                                <AlertDialogTitle>Prune Sencho-Managed {confirmPrune?.target}</AlertDialogTitle>
+                                <AlertDialogDescription>
+                                    Only unused {confirmPrune?.target} belonging to your Sencho stacks will be removed.
+                                    External Docker resources are <span className="font-semibold text-foreground">not affected</span>.
+                                </AlertDialogDescription>
+                            </>
+                        )}
                     </AlertDialogHeader>
                     <AlertDialogFooter>
                         <AlertDialogCancel disabled={isActioning}>Cancel</AlertDialogCancel>
-                        <AlertDialogAction disabled={isActioning} className="bg-destructive text-destructive-foreground hover:bg-destructive/90" onClick={handlePrune}>
-                            {isActioning ? 'Pruning...' : 'Prune'}
+                        <AlertDialogAction
+                            disabled={isActioning}
+                            className={confirmPrune?.scope === 'all' ? 'bg-destructive text-destructive-foreground hover:bg-destructive/90' : ''}
+                            onClick={handlePrune}
+                        >
+                            {isActioning ? 'Pruning...' : confirmPrune?.scope === 'all' ? 'Prune All' : 'Prune'}
                         </AlertDialogAction>
                     </AlertDialogFooter>
                 </AlertDialogContent>
             </AlertDialog>
 
-            {/* Granular Delete Confirm Dialog */}
+            {/* Delete Confirm */}
             <AlertDialog open={!!confirmDelete} onOpenChange={(open) => !open && setConfirmDelete(null)}>
                 <AlertDialogContent>
                     <AlertDialogHeader>
                         <AlertDialogTitle>Delete {confirmDelete?.type.slice(0, -1)}</AlertDialogTitle>
                         <AlertDialogDescription>
-                            Are you sure you want to delete <span className="font-mono font-bold text-foreground">{confirmDelete?.name || confirmDelete?.id.substring(0, 12)}</span>? This cannot be undone.
+                            Permanently delete <span className="font-mono font-bold text-foreground">{confirmDelete?.name || confirmDelete?.id.substring(0, 12)}</span>? This cannot be undone.
                         </AlertDialogDescription>
                     </AlertDialogHeader>
                     <AlertDialogFooter>
@@ -483,13 +866,14 @@ export default function ResourcesView() {
                 </AlertDialogContent>
             </AlertDialog>
 
-            {/* Ghost Container Purge Confirm Dialog */}
+            {/* Unmanaged Container Purge Confirm */}
             <AlertDialog open={bulkPurgeConfirm} onOpenChange={setBulkPurgeConfirm}>
                 <AlertDialogContent>
                     <AlertDialogHeader>
-                        <AlertDialogTitle>Purge Selected Ghosts</AlertDialogTitle>
+                        <AlertDialogTitle>Purge Selected Unmanaged Containers</AlertDialogTitle>
                         <AlertDialogDescription>
-                            Are you sure you want to permanently remove the {selectedOrphans.length} selected orphan container(s)?
+                            Permanently remove {selectedOrphans.length} container{selectedOrphans.length !== 1 ? 's' : ''} from external projects?
+                            This will force-stop and remove them. This cannot be undone.
                         </AlertDialogDescription>
                     </AlertDialogHeader>
                     <AlertDialogFooter>


### PR DESCRIPTION
## Summary

- **Resource classification** — all Docker images, volumes, and networks now carry a `managedStatus` of `managed`, `unmanaged`, or `unused`/`system`, derived via a single `GET /api/system/resources` endpoint (4 parallel Docker API calls; images classified via container→image label mapping since images have no compose labels)
- **Scoped prune** — Quick Clean buttons default to Sencho-managed resources only; "All Docker" option hidden in a `⋮` dropdown per target with a distinct destructive confirmation dialog; backend `POST /api/system/prune/system` accepts `scope: 'managed' | 'all'`
- **Docker Disk Footprint widget** — replaces the Reclaimable Space donut chart with an interactive horizontal stacked bar (green = Sencho managed, orange = external, muted = reclaimable); clicking a segment filters the Images + Volumes tabs simultaneously
- **Filter toggles + classification badges** — each resource tab (Images, Volumes, Networks) has All / Managed / External pill toggles with live counts; rows display green stack-name badge, orange "External" badge, or muted "System" badge; system networks (`bridge`, `host`, `none`) have delete disabled
- **Active Containers split stat** — `GET /api/stats` returns `managed` + `unmanaged` counts; Home Dashboard subtitle shows "N managed · N external"
- **Renamed "Ghost Containers" → "Unmanaged Containers"** — tab, dialogs, toasts, empty state

## Test plan

- [x] `curl /api/stats` returns `{"active":12,"managed":1,"unmanaged":11,"exited":0,"total":12}` ✓
- [x] `curl /api/system/resources` returns images with `managedStatus: "managed"` (code-server) and `managedStatus: "unmanaged"` (Supabase) ✓
- [x] `curl /api/system/docker-df` returns all 4 classified byte fields ✓
- [x] Home Dashboard "Active Containers" card shows "1 managed · 11 external" subtitle (Playwright confirmed) ✓
- [x] Resources Hub FootprintWidget renders stacked bar with correct byte labels (Playwright confirmed) ✓
- [x] Images tab filter toggles (All 13 / Managed 1 / External 12) work correctly ✓
- [x] Green/orange classification badges render per row; "Unmanaged" tab shows count 11 ✓
- [x] `npx tsc --noEmit` passes on both backend and frontend with zero errors ✓