### PR TITLE
fix(docker): entrypoint for volume permission handling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Force LF line endings for shell scripts regardless of the developer's OS.
+# Shell scripts with CRLF endings will fail with "exec format error" in Linux containers.
+*.sh text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Docker volume permissions on startup:** A new `docker-entrypoint.sh` script now runs as root at container start, fixes ownership of the `$DATA_DIR` volume (only files with wrong user or group), then drops to the non-root `sencho` user via `su-exec` before starting Node. This eliminates the `SQLITE_READONLY` crash experienced when a host-mounted data volume was previously created by root or a different UID. Uses the same privilege-drop pattern as the official PostgreSQL, Redis, and MariaDB Docker images. Node becomes PID 1, ensuring SIGTERM/SIGINT are handled correctly for graceful shutdown.
+
 ### Added
 - **Resources Hub — Managed/Unmanaged Separation:** All Docker resources (images, volumes, networks) are now classified as `managed` (belonging to a Sencho stack), `external` (belonging to another Compose project), or `unused`/`system`. Classification is exposed via a new `GET /api/system/resources` endpoint that makes 4 parallel Docker API calls once and returns all three resource types in a single round trip.
 - **Docker Disk Footprint widget:** Replaces the Reclaimable Space donut chart with an interactive horizontal stacked bar showing Sencho Managed vs External Projects vs Reclaimable bytes. Clicking a segment filters the Images and Volumes tabs simultaneously.

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN npm run build
 FROM node:20-alpine
 
 # Install Docker CLI, Docker Compose CLI, and Bash for Host Console
-RUN apk add --no-cache docker-cli docker-cli-compose bash
+RUN apk add --no-cache docker-cli docker-cli-compose bash su-exec
 
 WORKDIR /app
 
@@ -65,7 +65,17 @@ RUN addgroup -S sencho && adduser -S -G sencho sencho \
   && mkdir -p /app/data \
   && chown -R sencho:sencho /app
 
-USER sencho
+# Copy the entrypoint script that fixes data-volume ownership at startup and
+# then drops privileges to the sencho user via su-exec (the idiomatic Alpine
+# equivalent of gosu). This mirrors the pattern used by official Docker images
+# such as PostgreSQL, Redis, and MariaDB.
+#
+# NOTE: USER directive is intentionally absent here. The entrypoint starts as
+# root so it can chown the mounted data volume, then exec's as sencho. Static
+# security scanners (Trivy, Clair) may flag "running as root" — this is a known
+# and accepted trade-off for self-hosted apps with user-supplied volume mounts.
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 # Expose port
 EXPOSE 3000
@@ -74,5 +84,7 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
   CMD node -e "const h=require('http');h.get('http://localhost:3000/api/health',r=>{process.exit(r.statusCode===200?0:1)}).on('error',()=>process.exit(1))"
 
-# Start the server
+# Entrypoint fixes volume ownership as root then drops to sencho via su-exec.
+# CMD provides the default arguments passed through to the entrypoint.
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["node", "dist/index.js"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -e
+
+# Resolve the data directory, mirroring DatabaseService.ts logic.
+DATA_DIR="${DATA_DIR:-/app/data}"
+
+# If running as root (the default Docker container start), fix volume ownership
+# then drop privileges before executing the application.
+#
+# This handles the common case where the host-mounted data volume was created by
+# root (or a different UID) from a previous run or backup restore — causing
+# SQLITE_READONLY errors when the non-root sencho user tries to write.
+#
+# This is the industry-standard pattern used by the official PostgreSQL, Redis,
+# and MariaDB Docker images.
+#
+# The UID guard also ensures compatibility with strict environments like
+# Kubernetes (runAsNonRoot: true) or OpenShift, where the container is forced to
+# run as a random high UID. In that case the chown block is skipped entirely and
+# the app exec's directly without crashing.
+if [ "$(id -u)" = '0' ]; then
+    mkdir -p "$DATA_DIR"
+
+    # Fix files where user OR group is wrong — not just user. This covers the
+    # case where a file ends up as sencho:root after a partial previous fix.
+    # The -exec '{}' + form batches arguments for efficiency (like xargs).
+    find "$DATA_DIR" \( \! -user sencho -o \! -group sencho \) \
+        -exec chown sencho:sencho '{}' +
+
+    # Replace this shell process with su-exec so that Node becomes PID 1 and
+    # receives SIGTERM/SIGINT directly from Docker. Without exec the shell would
+    # intercept signals and the container would hang for 10s before SIGKILL.
+    exec su-exec sencho "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary

- Adds `docker-entrypoint.sh` — starts as root, fixes \`\$DATA_DIR\` volume ownership (only files with wrong user **or** group), then drops to \`sencho\` (uid=100) via \`su-exec\` before starting Node
- Installs \`su-exec\` in Stage 3 of the Dockerfile (10KB Alpine-native privilege-drop tool, the idiomatic alternative to gosu)
- Removes \`USER sencho\` Dockerfile directive — the entrypoint handles the privilege drop, which is the required pattern for self-hosted apps with user-supplied volume mounts
- Switches from \`CMD\` to \`ENTRYPOINT\` + \`CMD\` so Node becomes PID 1 and receives SIGTERM/SIGINT directly (correct graceful shutdown)
- Adds \`.gitattributes\` to enforce LF line endings for \`*.sh\` files — prevents CRLF corruption on Windows dev machines that would cause \`exec format error\` in Alpine containers

## Problem solved

After the non-root \`sencho\` user was introduced, containers mounting a pre-existing data volume (created by root or a prior installation) crashed on startup with \`SQLITE_READONLY\`. The \`sencho\` user (uid=100 in Alpine, **not** 1000) had no write access to the existing \`sencho.db\` file.

This pattern exactly mirrors the official PostgreSQL, Redis, and MariaDB Docker images.

## Test plan

- [ ] Build image locally: \`docker build -t sencho-test .\`
- [ ] Simulate broken scenario: create a root-owned data dir, run container against it, confirm no \`SQLITE_READONLY\` crash and \`GET /api/health\` returns \`{"status":"ok"}\`
- [ ] Verify process runs as non-root: \`docker exec <container> id\` should return \`uid=100(sencho)\`
- [ ] After CI pushes \`:dev\` tag, pull on remote and confirm \`docker logs\` shows clean startup