### PR TITLE
fix(ci): exclude .git from rsync --delete in sync-docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,9 @@ jobs:
           fi
 
       - name: Copy /docs into sencho-docs root
-        run: rsync -av --delete sencho/docs/ sencho-docs/
+        # --exclude='.git' prevents rsync --delete from wiping the .git
+        # directory that was just cloned/initialized in the previous step.
+        run: rsync -av --delete --exclude='.git' sencho/docs/ sencho-docs/
 
       - name: Commit and push to sencho-docs
         working-directory: sencho-docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - fix(ci): `update-screenshots` — add `pull-requests: write` permission and switch both `actions/checkout` and `peter-evans/create-pull-request` from `GITHUB_TOKEN` to `DOCS_REPO_TOKEN` (PAT with `repo` scope); `GITHUB_TOKEN` is blocked from creating PRs against protected branches
+- fix(ci): `sync-docs` — add `--exclude='.git'` to the rsync step; `rsync --delete` was deleting the `.git` directory cloned in the previous step because it doesn't exist in the source (`sencho/docs/`), causing `fatal: not in a git directory` in the commit step
 - fix(ci): `sync-docs` — replace `actions/checkout` + init fallback with a single controlled `git clone || git init` bash step; `actions/checkout@v4` leaves a `.git` in a broken state on empty repos, which the `[ ! -d .git ]` guard missed, causing `fatal: not in a git directory` in the commit step; also drop now-unnecessary `--global safe.directory` config
 
 ### Fixed


### PR DESCRIPTION
## Root cause

`rsync -av --delete sencho/docs/ sencho-docs/` was deleting `sencho-docs/.git/` on every run.

`--delete` removes anything in the destination that doesn't exist in the source. Since `sencho/docs/` has no `.git/` directory, rsync considered it extraneous and deleted it from `sencho-docs/`. By the time the commit step ran, there was no git repo left — hence `fatal: not in a git directory`.

This was the root cause behind every `sync-docs` failure across all previous fix PRs. It was masked in earlier runs by the checkout failures on the empty repo, and only became visible once the repo was properly initialized.

## Fix

```diff
- run: rsync -av --delete sencho/docs/ sencho-docs/
+ run: rsync -av --delete --exclude='.git' sencho/docs/ sencho-docs/
```

One flag. `--exclude='.git'` tells rsync to ignore the `.git` directory in both the source scan and the destination cleanup, so the cloned repo is never touched.

## Test plan

- [ ] Merge and trigger a push to `develop`
- [ ] `sync-docs` completes without error
- [ ] `sencho-docs` repo on GitHub reflects the latest `docs/` content