### PR TITLE
feat(docker): add linux/arm64 platform support via xx cross-compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,21 +49,28 @@ ARG TARGETARCH
 
 WORKDIR /app
 
-# clang/lld: the cross-compiler toolchain (runs natively on amd64).
-# xx-apk adds the target-arch musl headers + libgcc to the sysroot so
-# xx-clang can link native .node binaries for the target platform.
-RUN apk add --no-cache clang lld python3 make && \
-    xx-apk add --no-cache musl-dev gcc
+# Host tools (run natively on amd64):
+#   clang lld  — LLVM cross-compiler + linker used by xx-clang/xx-clang++
+#   python3 make g++  — required by node-gyp to drive the native build system
+#
+# Target sysroot (installed for the TARGET arch by xx-apk):
+#   g++          — libstdc++ headers/libs; all three native modules use C++
+#   musl-dev     — musl libc headers needed for any C/C++ target compilation
+#   linux-headers — <pty.h> / <termios.h> required by node-pty
+RUN apk add --no-cache clang lld python3 make g++ && \
+    xx-apk add --no-cache g++ musl-dev linux-headers
 
 COPY backend/package*.json ./
 
-# npm_config_arch=$TARGETARCH   → tells prebuild-install / node-pre-gyp which
-#                                  pre-built binary to fetch (arm64 vs amd64).
-# CC/CXX=xx-clang(++)           → cross-compiles from source if no pre-built
-#                                  binary is available for the target arch.
+# npm_config_arch=$TARGETARCH → tells prebuild-install / node-pre-gyp which
+#   pre-built binary to attempt (arm64 vs amd64). Falls back to source build.
+# CC/CXX=xx-clang(++) → LLVM cross-compiler targeting $TARGETPLATFORM.
+# AR=xx-ar → cross-archiver; without it node-gyp uses the host ar (amd64)
+#   and produces wrong-arch static libraries that fail to link.
 RUN npm_config_arch=$TARGETARCH \
     CC=xx-clang \
     CXX=xx-clang++ \
+    AR=xx-ar \
     npm ci --omit=dev
 
 # Stage 4: Production runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,34 +44,46 @@ FROM --platform=$BUILDPLATFORM node:20-alpine AS prod-deps
 # Copy xx cross-compilation tools into this stage
 COPY --from=xx / /
 
-ARG TARGETPLATFORM
 ARG TARGETARCH
+ARG BUILDARCH
 
 WORKDIR /app
 
-# Host tools (run natively on amd64):
-#   clang lld  — LLVM cross-compiler + linker used by xx-clang/xx-clang++
-#   python3 make g++  — required by node-gyp to drive the native build system
+# Two paths depending on whether we are cross-compiling:
 #
-# Target sysroot (installed for the TARGET arch by xx-apk):
-#   g++          — libstdc++ headers/libs; all three native modules use C++
-#   musl-dev     — musl libc headers needed for any C/C++ target compilation
-#   linux-headers — <pty.h> / <termios.h> required by node-pty
-RUN apk add --no-cache clang lld python3 make g++ && \
-    xx-apk add --no-cache g++ musl-dev linux-headers
+# Native (TARGETARCH == BUILDARCH, e.g. amd64 → amd64):
+#   Standard g++ is used. xx-clang introduces sysroot flags that conflict with
+#   node-gyp's header resolution on Alpine for same-platform builds, so we
+#   bypass it entirely and let npm ci use the host compiler directly.
+#
+# Cross (TARGETARCH != BUILDARCH, e.g. amd64 → arm64):
+#   xx-clang targets the foreign architecture without QEMU. The target sysroot
+#   is populated via xx-apk:
+#     g++           — libstdc++ headers/libs (all three native modules use C++)
+#     musl-dev      — musl libc headers for the target arch
+#     linux-headers — <pty.h> / <termios.h> required by node-pty
+RUN if [ "$TARGETARCH" = "$BUILDARCH" ]; then \
+      apk add --no-cache python3 make g++; \
+    else \
+      apk add --no-cache clang lld python3 make g++ && \
+      xx-apk add --no-cache g++ musl-dev linux-headers; \
+    fi
 
 COPY backend/package*.json ./
 
-# npm_config_arch=$TARGETARCH → tells prebuild-install / node-pre-gyp which
-#   pre-built binary to attempt (arm64 vs amd64). Falls back to source build.
-# CC/CXX=xx-clang(++) → LLVM cross-compiler targeting $TARGETPLATFORM.
-# AR=xx-ar → cross-archiver; without it node-gyp uses the host ar (amd64)
-#   and produces wrong-arch static libraries that fail to link.
-RUN npm_config_arch=$TARGETARCH \
-    CC=xx-clang \
-    CXX=xx-clang++ \
-    AR=xx-ar \
-    npm ci --omit=dev
+# Native: plain npm ci — g++ compiles native modules for the host arch.
+# Cross:  npm_config_arch tells prebuild-install/node-pre-gyp which pre-built
+#         binary to attempt; CC/CXX/AR route compilation through xx-clang so
+#         the output targets the foreign arch without any QEMU emulation.
+RUN if [ "$TARGETARCH" = "$BUILDARCH" ]; then \
+      npm ci --omit=dev; \
+    else \
+      npm_config_arch=$TARGETARCH \
+        CC=xx-clang \
+        CXX=xx-clang++ \
+        AR=xx-ar \
+        npm ci --omit=dev; \
+    fi
 
 # Stage 4: Production runtime
 # Runs on the TARGET platform — no compilation happens here.


### PR DESCRIPTION
## Summary

- Add `linux/arm64` to the Docker Hub publish workflow for ARM server support (Raspberry Pi 4/5, Oracle ARM VMs)
- Replace QEMU Node.js execution with `tonistiigi/xx` cross-compilation to eliminate `SIGILL` crashes caused by ARMv8.1 LSE atomic instructions unsupported by GitHub Actions QEMU
- Fix `docker/setup-qemu-action@v3` missing from CI workflow (multi-platform builds were hanging indefinitely)
- Use native `g++` for same-platform builds and `xx-clang` only for cross-compilation

## Test plan

- [ ] Docker Hub publish workflow completes without hanging
- [ ] ARM64 image boots without `SIGILL` crash on native ARM hardware
- [ ] AMD64 image unaffected