### PR TITLE
fix(ci): trigger docker-publish on v* tag push instead of GitHub Release event

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - develop
-  release:
-    types: [published]
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 jobs:
@@ -38,9 +38,9 @@ jobs:
           tags: |
             # If pushing to develop, tag as 'dev'
             type=raw,value=dev,enable=${{ github.ref == 'refs/heads/develop' }}
-            # If a release is published, tag as 'latest' and the specific version
-            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
-            type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
+            # If pushing a v* tag, tag as 'latest' and the specific semver version
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **fix(ci):** `docker-publish.yml` was triggered by `release: types: [published]` (GitHub Release event) instead of `push: tags: v*` — pushing a git tag never fired the workflow. Changed trigger to `push: tags: v*` and updated `enable` conditions from `github.event_name == 'release'` to `startsWith(github.ref, 'refs/tags/v')` so any `v*` tag push automatically builds and publishes `latest` + semver tags to Docker Hub without requiring a manual GitHub Release.
+
 ---
 
 ## [0.1.0] - 2026-03-24


### PR DESCRIPTION
## Problem

The `docker-publish.yml` workflow was gated on `release: types: [published]` — a GitHub Release must be manually created and published on GitHub for the workflow to fire. Pushing a git tag alone (e.g. `v0.1.0`) does **not** trigger it.

The `dev` tag worked because it uses `push: branches: develop`, which fires automatically. The `latest` and semver tags never fired.

## Fix

- Changed trigger from `release: types: [published]` → `push: tags: v*`
- Updated `enable` conditions from `github.event_name == 'release'` → `startsWith(github.ref, 'refs/tags/v')`

## Result

Any `git push origin vX.Y.Z` now automatically builds and pushes `latest` + `X.Y.Z` to Docker Hub without any manual GitHub Release step.