### PR TITLE
fix(ci): correct release-please changelog section names and tag format

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,21 +1,22 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "release-type": "node",
       "bump-minor-pre-major": true,
       "changelog-path": "CHANGELOG.md",
       "changelog-sections": [
-        { "type": "feat",     "section": "### Added" },
-        { "type": "fix",      "section": "### Fixed" },
-        { "type": "perf",     "section": "### Fixed" },
-        { "type": "revert",   "section": "### Fixed" },
-        { "type": "security", "section": "### Security" },
-        { "type": "docs",     "section": "### Documentation", "hidden": true },
-        { "type": "chore",    "section": "### Miscellaneous",  "hidden": true },
-        { "type": "ci",       "section": "### CI/CD",          "hidden": true },
-        { "type": "refactor", "section": "### Changed",        "hidden": true },
-        { "type": "test",     "section": "### Tests",          "hidden": true }
+        { "type": "feat",     "section": "Added" },
+        { "type": "fix",      "section": "Fixed" },
+        { "type": "perf",     "section": "Fixed" },
+        { "type": "revert",   "section": "Fixed" },
+        { "type": "security", "section": "Security" },
+        { "type": "docs",     "section": "Documentation", "hidden": true },
+        { "type": "chore",    "section": "Miscellaneous",  "hidden": true },
+        { "type": "ci",       "section": "CI/CD",          "hidden": true },
+        { "type": "refactor", "section": "Changed",        "hidden": true },
+        { "type": "test",     "section": "Tests",          "hidden": true }
       ]
     }
   }


### PR DESCRIPTION
Fixes two issues in the release-please config:
1. Section names had `###` prefix which release-please doubled to `### ###`
2. Added `include-component-in-tag: false` so tags use `v0.1.0` format (matching our existing tags) instead of `sencho-v0.1.0`