### PR TITLE
fix(editor): remove unused params from getWorker to satisfy ESLint

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -12,7 +12,7 @@ import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker'
 // that entirely. Sencho only needs YAML/plaintext so the base editorWorker
 // covers all language modes — no additional language workers required.
 window.MonacoEnvironment = {
-  getWorker(_workerId: string, _label: string): Worker {
+  getWorker(): Worker {
     return new editorWorker()
   },
 }


### PR DESCRIPTION
TypeScript allows implementing `(workerId: string, label: string) => Worker` with fewer parameters (standard function compatibility). Removing the unused names fixes `@typescript-eslint/no-unused-vars` without changing behavior.