### PR TITLE
docs: align documentation theme with Sencho app branding

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1551,16 +1551,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -3981,9 +3981,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -1,0 +1,8 @@
+/* Increase logo size in navbar and footer to match the Sencho app */
+#navbar .nav-logo {
+  height: 36px !important;
+}
+
+footer .nav-logo {
+  height: 36px !important;
+}

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -4,8 +4,8 @@
   "name": "Sencho",
   "colors": {
     "primary": "#00BEC7",
-    "light": "#0891B2",
-    "dark": "#22D3EE"
+    "light": "#007982",
+    "dark": "#00BEC7"
   },
   "logo": {
     "light": "/images/logo/logo-light.png",
@@ -22,7 +22,7 @@
   "background": {
     "decoration": "gradient",
     "color": {
-      "dark": "#0F172A"
+      "dark": "#090909"
     }
   },
   "navbar": {


### PR DESCRIPTION
## Summary

- **Background**: Changed dark mode background from `#0F172A` (blue-tinted slate) to `#090909` (neutral dark) to match the app's `oklch(0.14 0 0)`
- **Accent colors**: Updated `colors.light` to `#007982` and `colors.dark` to `#00BEC7` to match the app's brand color `oklch(0.72 0.14 200)`
- **Logo size**: Added `custom.css` to increase navbar and footer logo from 28px/26px to 36px

## Test plan

- [ ] Verify docs.sencho.io dark background is neutral dark (no blue tint)
- [ ] Confirm accent/link colors match the Sencho app's cyan brand
- [ ] Check navbar and footer logos are visibly larger