### PR TITLE
fix(license): default 14-day trial to Personal Pro instead of Team Pro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+* 14-day trial now defaults to Personal Pro instead of Team Pro — Team Pro features (SSO, audit log, unlimited accounts) require a Team Pro license
+
 ## [0.13.1](https://github.com/AnsoCode/Sencho/compare/v0.13.0...v0.13.1) (2026-03-28)
 
 

--- a/backend/src/services/LicenseService.ts
+++ b/backend/src/services/LicenseService.ts
@@ -179,12 +179,12 @@ export class LicenseService {
 
     /**
      * Get the license variant (personal or team) from stored metadata.
-     * Trial licenses default to "team" so users can explore all features.
+     * Trial licenses default to "personal" — Team Pro features require a Team Pro license.
      */
     public getVariant(): LicenseVariant {
         const db = DatabaseService.getInstance();
         const status = db.getSystemState('license_status');
-        if (status === 'trial') return 'team';
+        if (status === 'trial') return 'personal';
         const variantName = db.getSystemState('license_variant_name');
         if (!variantName) return null;
         const lower = variantName.toLowerCase();

--- a/docs/features/licensing.mdx
+++ b/docs/features/licensing.mdx
@@ -17,7 +17,7 @@ Lifetime pricing is an early-adopter offer available for a limited time only.
 
 ## Free trial
 
-Every new Sencho installation starts with a **14-day Pro trial** - no license key or credit card required. All Pro features are unlocked during the trial so you can evaluate them with your real infrastructure.
+Every new Sencho installation starts with a **14-day Personal Pro trial** - no license key or credit card required. Personal Pro features like fleet management, RBAC viewer accounts, webhooks, and atomic deployments are unlocked during the trial so you can evaluate them with your real infrastructure. Team Pro features (SSO, audit log, unlimited accounts) require a Team Pro license.
 
 When the trial expires, Sencho automatically reverts to the Community tier. No data is lost.
 


### PR DESCRIPTION
## Summary

- Trial `getVariant()` now returns `'personal'` instead of `'team'`, so new installations get Personal Pro features only during the 14-day trial
- Team Pro features (SSO, audit log, unlimited accounts) require activating a Team Pro license
- Updated licensing docs to clarify what's included in the trial vs what requires Team Pro

## Test plan

- [x] Backend unit tests pass (56/56)
- [x] Playwright validation: confirmed SSO tab hidden in Settings and Audit button hidden in nav bar on a trial account
- [x] License API returns `variant: "personal"` for trial status