### PR TITLE
ci: fix screenshot PR auto-merge on private repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
           GH_TOKEN: ${{ secrets.DOCS_REPO_TOKEN }}
         run: |
           gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} \
-            --auto --squash \
+            --squash \
             --repo ${{ github.repository }}
 
   sync-docs:


### PR DESCRIPTION
## Summary

- Fixes the "Refresh Doc Screenshots" CI failure that occurs after every release merge
- `gh pr merge --auto` requires branch protection with required status checks, which isn't available on private repos without GitHub Pro
- Removes `--auto` flag so the screenshots PR merges immediately after creation

## Root cause

The error `GraphQL: Pull request Pull request is in clean status (enablePullRequestAutoMerge)` means GitHub rejected the auto-merge request because there are no required checks to wait for — the PR is already immediately mergeable.

## Test plan

- [ ] Merge this PR, then merge the pending screenshots PR #263
- [ ] On next release, verify the screenshot job creates and merges the PR in one step