### PR TITLE
fix(docker): install Docker CLI v29.3.1 from static binaries to resolve CVEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **docker:** upgrade base image from `node:20-alpine` to `node:22-alpine` (Node 22.22.2 on Alpine 3.23.3) to remediate 31 CVEs (1 Critical, multiple High/Medium/Low) flagged by Docker Scout against the previous `node:20-alpine` base.
 * **docker:** add `apk upgrade --no-cache` to runtime stage to ensure all Alpine system packages are at their latest patched versions at build time.
 * **deps:** force `dompurify` to 3.3.3 via npm overrides to resolve two Dependabot advisories (Mutation-XSS via Re-Contextualization and Cross-site Scripting) in the transitive dependency pulled by `monaco-editor`.
+* **docker:** install Docker CLI v29.3.1 and Compose v2.40.3 from official static binaries instead of Alpine packages (which ship v29.1.3) to resolve CVE-2026-33186 (Critical), CVE-2026-34040 (High), CVE-2026-33747 (High), CVE-2026-33748 (High), and bundled Go stdlib CVEs.
 
 ### Fixed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,10 +91,25 @@ RUN if [ "$TARGETARCH" = "$BUILDARCH" ]; then \
 # Runs on the TARGET platform - no compilation happens here.
 FROM node:22-alpine
 
-# Upgrade all Alpine system packages to pick up security patches, then install
-# Docker CLI, Docker Compose CLI, and Bash for Host Console
+# Pin Docker CLI and Compose versions. Alpine 3.23 ships docker-cli 29.1.3
+# which contains unpatched CVEs (CVE-2026-33186 Critical, CVE-2026-34040 High,
+# CVE-2026-33747 High, CVE-2026-33748 High). Install from official static
+# binaries to get v29.3.1 which includes the fixes.
+ARG DOCKER_VERSION=29.3.1
+ARG COMPOSE_VERSION=v2.40.3
+
+# Upgrade all Alpine system packages, install runtime deps, then fetch Docker
+# CLI + Compose plugin from official static binaries.
 RUN apk upgrade --no-cache && \
-    apk add --no-cache docker-cli docker-cli-compose bash su-exec
+    apk add --no-cache bash su-exec curl && \
+    ARCH=$(uname -m) && \
+    curl -fsSL "https://download.docker.com/linux/static/stable/${ARCH}/docker-${DOCKER_VERSION}.tgz" \
+      | tar xz -C /usr/local/bin --strip-components=1 docker/docker && \
+    mkdir -p /usr/local/lib/docker/cli-plugins && \
+    curl -fsSL -o /usr/local/lib/docker/cli-plugins/docker-compose \
+      "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-linux-${ARCH}" && \
+    chmod +x /usr/local/lib/docker/cli-plugins/docker-compose && \
+    apk del curl
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

Alpine 3.23 ships `docker-cli 29.1.3` which contains unpatched CVEs. Docker Engine v29.3.1 (released 2026-03-25) includes the fixes, but Alpine hasn't packaged it yet. This PR replaces the Alpine `docker-cli` and `docker-cli-compose` packages with official static binaries.

**Resolves (Group A — Docker/Moby/BuildKit, fixed in v29.3.1):**
- CVE-2026-33186 (Critical) — gRPC-Go authorization bypass
- CVE-2026-34040 (High) — Moby AuthZ plugin bypass
- CVE-2026-33747 (High) — BuildKit path traversal via frontend
- CVE-2026-33748 (High) — BuildKit path traversal via git URL
- CVE-2026-33997 (Medium) — Moby plugin privilege validation bypass

**Likely resolves (Group B — Go stdlib bundled in docker-cli binary):**
- CVE-2025-47913 (High) — golang.org/x/crypto SSH client panic
- CVE-2024-25621 (High) — containerd directory permissions
- CVE-2025-64329 (Medium) — containerd CRI goroutine leak
- CVE-2025-47914 (Medium) — golang.org/x/crypto SSH agent OOB
- CVE-2025-47911 (Medium) — golang.org/x/net/html quadratic parse
- CVE-2025-58181 (Medium) — SSH GSSAPI memory consumption
- CVE-2025-58190 (Medium) — golang.org/x/net/html infinite loop

**Not applicable to this Linux image (scanner false positives):**
- CVE-2025-15558 (High) — Docker CLI Windows-only LPE
- CVE-2026-24051 (High) — OpenTelemetry Go macOS-only PATH hijack

**Scanner false positives (already at patched versions):**
- CVE-2026-33671 (High) — picomatch 2.3.2 IS the patched version for the 2.x branch; Docker Scout uses a simplified range that doesn't handle multi-branch fixes
- CVE-2026-33672 (Medium) — same as above
- CVE-2026-33750 (Medium) — brace-expansion is a dev-only dependency, not present in the production image

**Cannot fix (no upstream patch available):**
- CVE-2025-60876 (Medium) — BusyBox wget 1.37.0 HTTP request splitting; no patched version in Alpine 3.23; Sencho does not use wget at runtime

## Verification

- Docker image builds successfully
- `docker --version` → `Docker version 29.3.1, build c2be9cc`
- `docker compose version` → `Docker Compose version v2.40.3`
- `/api/health` returns 200
- Multi-arch: `$(uname -m)` correctly resolves to `x86_64`/`aarch64` for the download URLs

## Test plan

- [ ] CI passes (Docker image builds on both amd64 and arm64)
- [ ] Container starts and `/api/health` returns 200
- [ ] `docker compose up/down` works inside the container with a mounted Docker socket
- [ ] After merge + publish, re-run Docker Scout to confirm CVE reduction