### PR TITLE
fix(stacks): avoid resource busy error in Docker fallback deletion

### DIFF
--- a/backend/src/__tests__/filesystem.test.ts
+++ b/backend/src/__tests__/filesystem.test.ts
@@ -93,7 +93,7 @@ describe('FileSystemService.deleteStack', () => {
     await expect(promise).resolves.toBeUndefined();
     expect(mockSpawn).toHaveBeenCalledWith(
       'docker',
-      expect.arrayContaining(['run', '--rm', '-v', expect.stringContaining(':/cleanup'), 'alpine', 'rm', '-rf', '/cleanup']),
+      expect.arrayContaining(['run', '--rm', '-v', expect.stringContaining(':/cleanup'), 'alpine', 'sh', '-c', 'find /cleanup -mindepth 1 -maxdepth 1 -exec rm -rf {} +']),
       expect.objectContaining({ env: expect.any(Object) }),
     );
   });

--- a/backend/src/services/FileSystemService.ts
+++ b/backend/src/services/FileSystemService.ts
@@ -205,7 +205,7 @@ export class FileSystemService {
         'run', '--rm',
         '-v', `${dirPath}:/cleanup`,
         'alpine',
-        'rm', '-rf', '/cleanup'
+        'sh', '-c', 'find /cleanup -mindepth 1 -maxdepth 1 -exec rm -rf {} +'
       ], {
         env: {
           ...process.env,


### PR DESCRIPTION
## Summary

- Fixes `rm: can't remove '/cleanup': Resource busy` error during Docker-based fallback stack deletion
- The previous command `rm -rf /cleanup` attempted to remove the bind mount point itself, which the kernel rejects with EBUSY
- Changed to `find /cleanup -mindepth 1 -maxdepth 1 -exec rm -rf {} +` which removes all contents without touching the mount point
- The existing `fsPromises.rmdir()` call then cleans up the empty host directory

## Test plan

- [x] TypeScript compiles without errors
- [x] All 8 filesystem unit tests pass (updated assertion)
- [x] Backend lint: 0 errors
- [ ] Deploy to server, delete a stack with root-owned files — should succeed without toast error