### PR TITLE
fix(ui): settings modal sidebar nav clipped on smaller viewports

### DIFF
--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -301,14 +301,14 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                 <VisuallyHidden><DialogDescription>Configure Sencho settings</DialogDescription></VisuallyHidden>
 
                 {/* Sidebar */}
-                <div className="w-[200px] bg-glass border-r border-glass-border flex flex-col p-4 shrink-0">
+                <div className="w-[200px] bg-glass border-r border-glass-border flex flex-col p-4 shrink-0 min-h-0">
                     <div className="font-medium text-lg mb-1 text-foreground tracking-tight">Settings Hub</div>
                     {isRemote ? (
                         <div className="text-xs text-muted-foreground mb-5 truncate">{activeNode!.name}</div>
                     ) : (
                         <div className="mb-5" />
                     )}
-                    <nav className="space-y-1.5 flex flex-col">
+                    <nav className="space-y-1.5 flex flex-col flex-1 overflow-y-auto">
                         {/* Account / License */}
                         {!isRemote && (
                             <NavButton section="account" icon={<Shield className="w-4 h-4 mr-2" />} label="Account" />


### PR DESCRIPTION
## Summary

- Settings Hub sidebar nav was clipped — Support and About items were unreachable at the bottom
- Added `min-h-0` to the sidebar flex container and `flex-1 overflow-y-auto` to the `<nav>` element so it scrolls when items exceed available height

## Test plan

- [x] Open Settings Hub modal at 1280x800 — all 14 nav items accessible via scroll
- [x] Verified `scrollHeight > clientHeight` confirms scrollable area
- [x] TypeScript compiles cleanly