### PR TITLE
fix(docker): upgrade Compose to v5.1.1, remediate dependency CVEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+* **docker:** upgrade Docker Compose from v2.40.3 to v5.1.1 to remediate 5 Go stdlib/x/crypto CVEs (CVE-2025-68121, CVE-2025-61726, CVE-2025-61729, CVE-2026-25679, CVE-2025-47913). Compose v2.40.3 was compiled with Go 1.24.9 and x/crypto 0.38.0; v5.1.1 ships Go 1.25.8 and x/crypto 0.46.0. Docker CLI remains at v29.3.1 (already patched). CVE-2026-33186 (grpc ≥1.79.3) cannot be resolved until upstream Docker/Compose releases upgrade past grpc 1.78.0.
+
 ## [0.21.1](https://github.com/AnsoCode/Sencho/compare/v0.21.0...v0.21.1) (2026-03-30)
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,12 +91,24 @@ RUN if [ "$TARGETARCH" = "$BUILDARCH" ]; then \
 # Runs on the TARGET platform - no compilation happens here.
 FROM node:22-alpine
 
-# Pin Docker CLI and Compose versions. Alpine 3.23 ships docker-cli 29.1.3
-# which contains unpatched CVEs (CVE-2026-33186 Critical, CVE-2026-34040 High,
-# CVE-2026-33747 High, CVE-2026-33748 High). Install from official static
-# binaries to get v29.3.1 which includes the fixes.
+# Pin Docker CLI and Compose versions.
+#
+# Docker CLI v29.3.1 — compiled with Go 1.25.8, buildkit 0.28.1, x/crypto 0.48.0.
+# Fixes: CVE-2026-34040, CVE-2026-33997, CVE-2026-33747, CVE-2026-33748,
+#        CVE-2025-68121, CVE-2025-61726, CVE-2025-61729, CVE-2026-25679,
+#        CVE-2025-47913.
+#
+# Compose v5.1.1 — compiled with Go 1.25.8, x/crypto 0.46.0.
+# Upgraded from v2.40.3 (Go 1.24.9 / grpc 1.74.2 / x/crypto 0.38.0) to
+# resolve CVE-2025-68121, CVE-2025-61726, CVE-2025-61729, CVE-2026-25679,
+# CVE-2025-47913.
+#
+# NOTE: CVE-2026-33186 (google.golang.org/grpc ≥1.79.3) remains unpatched —
+# both Docker CLI 29.3.1 and Compose v5.1.1 ship grpc 1.78.0. No upstream
+# release includes the fix yet. This will be resolved when a new Docker CLI
+# or Compose release upgrades grpc.
 ARG DOCKER_VERSION=29.3.1
-ARG COMPOSE_VERSION=v2.40.3
+ARG COMPOSE_VERSION=v5.1.1
 
 # Upgrade all Alpine system packages, install runtime deps, then fetch Docker
 # CLI + Compose plugin from official static binaries.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -107,7 +107,8 @@
       {
         "group": "Reference",
         "pages": [
-          "reference/settings"
+          "reference/settings",
+          "reference/security-advisories"
         ]
       },
       {

--- a/docs/reference/security-advisories.mdx
+++ b/docs/reference/security-advisories.mdx
@@ -1,0 +1,70 @@
+---
+title: Security Advisories
+description: Tracked CVEs, remediation status, and dependency security notes for Sencho's Docker image.
+---
+
+Sencho's Docker image bundles the Docker CLI and Docker Compose plugin as statically linked binaries. Because these tools are compiled Go programs, vulnerabilities in Go's standard library or their Go dependencies surface as CVEs against the Sencho image even though Sencho itself contains no Go source code.
+
+This page tracks known CVEs, their resolution status, and the minimum safe versions.
+
+## March 2026 Audit
+
+The following vulnerabilities were identified against the Sencho Docker image built with Docker CLI v29.3.1 and Docker Compose v2.40.3.
+
+### Remediation Summary
+
+Docker Compose was upgraded from **v2.40.3** to **v5.1.1**, which ships Go 1.25.8 and `golang.org/x/crypto` v0.46.0. Docker CLI remains at **v29.3.1**, which was already compiled with Go 1.25.8, BuildKit v0.28.1, and `golang.org/x/crypto` v0.48.0.
+
+### CVE Table
+
+| CVE | Ecosystem | Package | Previous Version | Required Version | Resolved Version | Status |
+|-----|-----------|---------|-----------------|-----------------|-----------------|--------|
+| CVE-2025-68121 | Go | `stdlib` | 1.24.9 | 1.24.13 | 1.25.8 | Fixed |
+| CVE-2025-61726 | Go | `stdlib` | 1.24.9 | 1.24.12 | 1.25.8 | Fixed |
+| CVE-2025-61729 | Go | `stdlib` | 1.24.9 | 1.24.11 | 1.25.8 | Fixed |
+| CVE-2026-25679 | Go | `stdlib` | 1.24.9 | 1.25.8 | 1.25.8 | Fixed |
+| CVE-2025-47913 | Go | `golang.org/x/crypto` | 0.38.0 | 0.43.0 | 0.46.0 (Compose) / 0.48.0 (CLI) | Fixed |
+| CVE-2026-33747 | Go | `github.com/moby/buildkit` | 0.25.1 | 0.28.1 | 0.28.1 | Fixed |
+| CVE-2026-33748 | Go | `github.com/moby/buildkit` | 0.25.1 | 0.28.1 | 0.28.1 | Fixed |
+| CVE-2026-33186 | Go | `google.golang.org/grpc` | 1.74.2 | 1.79.3 | 1.78.0 | Unresolved |
+| CVE-2026-33671 | npm | `picomatch` | 4.0.3 | 4.0.4 | 4.0.4 | Fixed |
+
+### Details
+
+#### Go stdlib (CVE-2025-68121, CVE-2025-61726, CVE-2025-61729, CVE-2026-25679)
+
+These four CVEs affect the Go standard library used to compile Docker CLI and Docker Compose.
+The previous Compose version (v2.40.3) was built with Go 1.24.9.
+Upgrading Compose to v5.1.1 (Go 1.25.8) resolves all four.
+Docker CLI v29.3.1 was already compiled with Go 1.25.8.
+
+#### golang.org/x/crypto (CVE-2025-47913)
+
+The `golang.org/x/crypto` package had a vulnerability fixed in v0.43.0.
+Docker CLI v29.3.1 ships v0.48.0 and Compose v5.1.1 ships v0.46.0 — both above the minimum.
+
+#### BuildKit (CVE-2026-33747, CVE-2026-33748)
+
+Two BuildKit vulnerabilities related to Git URL fragment validation and file writes outside the state directory.
+Both were fixed in BuildKit v0.28.1, which is included in Docker CLI v29.3.1.
+
+#### gRPC (CVE-2026-33186)
+
+<Note>
+  This CVE **cannot be resolved** at this time. Both Docker CLI v29.3.1 and Compose v5.1.1 ship `google.golang.org/grpc` v1.78.0, while the fix requires v1.79.3. No upstream Docker release includes the patched version yet. This will be resolved when a new Docker CLI or Compose release upgrades past grpc v1.78.0.
+</Note>
+
+#### picomatch (CVE-2026-33671)
+
+The npm `picomatch` package v4.0.3 had a vulnerability fixed in v4.0.4.
+All Sencho lock files (frontend, backend, website) already resolve picomatch 4.x to v4.0.4.
+The backend also has picomatch v2.3.2 as a transitive dependency of `micromatch` (used by `http-proxy-middleware` and `chokidar`) — this is a separate major version line and is **not affected** by CVE-2026-33671.
+
+## Pinned Binary Versions
+
+Sencho's Dockerfile pins explicit versions for Docker CLI and Compose rather than relying on Alpine's package manager. This ensures reproducible builds and allows targeted CVE remediation independent of Alpine's release cycle.
+
+| Binary | Current Version | Go Toolchain | Key Dependencies |
+|--------|----------------|-------------|-----------------|
+| Docker CLI | v29.3.1 | Go 1.25.8 | BuildKit 0.28.1, grpc 1.78.0, x/crypto 0.48.0 |
+| Docker Compose | v5.1.1 | Go 1.25.8 | grpc 1.78.0, x/crypto 0.46.0 |


### PR DESCRIPTION
## Summary

- Upgrades Docker Compose from v2.40.3 → v5.1.1 in the Dockerfile to resolve 5 Go stdlib/x/crypto CVEs (CVE-2025-68121, CVE-2025-61726, CVE-2025-61729, CVE-2026-25679, CVE-2025-47913)
- Documents CVE-2026-33186 (grpc ≥1.79.3) as unresolvable — no upstream Docker release includes the fix yet
- Confirms CVE-2026-33671 (picomatch), CVE-2026-33747/33748 (buildkit) were already patched
- Adds a Security Advisories reference page to the docs site

## CVE Resolution

| CVE | Status |
|-----|--------|
| CVE-2025-68121 (stdlib) | Fixed — Compose v5.1.1 (Go 1.25.8) |
| CVE-2025-61726 (stdlib) | Fixed — Compose v5.1.1 (Go 1.25.8) |
| CVE-2025-61729 (stdlib) | Fixed — Compose v5.1.1 (Go 1.25.8) |
| CVE-2026-25679 (stdlib) | Fixed — Compose v5.1.1 (Go 1.25.8) |
| CVE-2025-47913 (x/crypto) | Fixed — Compose v5.1.1 (x/crypto 0.46.0) |
| CVE-2026-33186 (grpc) | Unresolved — upstream ships grpc 1.78.0, fix requires 1.79.3 |
| CVE-2026-33747 (buildkit) | Already fixed in Docker CLI 29.3.1 |
| CVE-2026-33748 (buildkit) | Already fixed in Docker CLI 29.3.1 |
| CVE-2026-33671 (picomatch) | Already fixed — lock files have 4.0.4 |

## Test plan

- [x] Backend tests pass (93/93)
- [x] Frontend build succeeds
- [x] Backend build succeeds
- [ ] Docker build succeeds with Compose v5.1.1 binary download
- [ ] Verify `docker compose version` inside container reports v5.1.1