### PR TITLE
docs: disable API playground for self-hosted compatibility

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -71,6 +71,9 @@
     "auth": {
       "method": "bearer",
       "name": "Authorization"
+    },
+    "playground": {
+      "display": "simple"
     }
   },
   "navigation": {


### PR DESCRIPTION
## Summary
- Switches Mintlify API playground from `interactive` to `simple` mode
- The "Try it" / "Send" button can never work for self-hosted software (CORS + no central API server), so it's replaced with a copyable endpoint reference
- cURL code examples and all endpoint documentation remain unchanged

## Test plan
- [ ] Verify "Try it" button no longer appears on API Reference pages
- [ ] Confirm endpoint URL/method still displays as a copyable block
- [ ] Confirm cURL examples render normally