### PR TITLE
fix(security): prevent path traversal via env_file resolution

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -31,7 +31,7 @@ import { SSOService } from './services/SSOService';
 import { SchedulerService } from './services/SchedulerService';
 import { RegistryService } from './services/RegistryService';
 import { CronExpressionParser } from 'cron-parser';
-import { isValidStackName, isValidRemoteUrl } from './utils/validation';
+import { isValidStackName, isValidRemoteUrl, isPathWithinBase } from './utils/validation';
 import YAML from 'yaml';
 import fs, { promises as fsPromises } from 'fs';
 
@@ -2512,6 +2512,7 @@ async function resolveAllEnvFilePaths(nodeId: number, stackName: string): Promis
 
       const addEnvPath = (rawPath: string) => {
         const resolved = path.resolve(stackDir, rawPath);
+        if (!isPathWithinBase(resolved, stackDir)) return;
         envFiles.add(resolved);
       };
 


### PR DESCRIPTION
## Summary
- Adds boundary validation to `resolveAllEnvFilePaths()` so that `env_file` paths in compose files cannot escape the stack directory
- Uses the existing `isPathWithinBase` utility — paths that resolve outside the stack dir are silently excluded from the allowed list
- Covers all three env endpoints (GET `/envs`, GET `/env`, PUT `/env`) since they all rely on `resolveAllEnvFilePaths()` as their allowlist

## Test plan
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [x] All 93 backend tests pass (`npm test`)
- [ ] Manual: create a stack with `env_file: ../../../etc/passwd` and confirm the GET `/env` endpoint does not return its contents