### PR TITLE
fix(fleet): resolve remote node capability detection failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **licensing:** Admiral licenses (including lifetime) are now correctly identified; previously, Lemon Squeezy variant names containing "Admiral" were not matched, causing the tier to display as "Skipper" and Admiral features to remain locked
 * **licensing:** "Manage Subscription" button is now hidden for lifetime licenses, which have no billing portal by design
 * **licensing:** license card now shows "Duration: Lifetime" for lifetime licenses instead of an empty renewal date
+* **fleet:** remote node capability detection now works reliably; `/api/meta` and `/api/health` are exempt from the global rate limiter so they are never blocked by proxied traffic, and a backend-side cache with stale-while-revalidate prevents transient failures from disabling capability-gated features (Auto-Update, Schedules, Audit, Console) on remote nodes
+* **fleet:** failed capability fetches now retry after 30 seconds instead of being cached for the full 5-minute TTL
 
 ### Changed
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -25,7 +25,7 @@ import { ImageUpdateService } from './services/ImageUpdateService';
 import { templateService } from './services/TemplateService';
 import { ErrorParser } from './utils/ErrorParser';
 import { NodeRegistry } from './services/NodeRegistry';
-import { LicenseService, type LicenseTier, type LicenseVariant, isLicenseTier, isLicenseVariant, PROXY_TIER_HEADER, PROXY_VARIANT_HEADER } from './services/LicenseService';
+import { LicenseService, type LicenseTier, type LicenseVariant, isLicenseTier, isLicenseVariant, normalizeTier, normalizeVariant, PROXY_TIER_HEADER, PROXY_VARIANT_HEADER } from './services/LicenseService';
 import { WebhookService } from './services/WebhookService';
 import { SSOService } from './services/SSOService';
 import { SchedulerService } from './services/SchedulerService';
@@ -310,10 +310,10 @@ const authMiddleware = async (req: Request, res: Response, next: NextFunction): 
       const tierHeader = req.headers[PROXY_TIER_HEADER] as string | undefined;
       const variantHeader = req.headers[PROXY_VARIANT_HEADER] as string | undefined;
       if (isLicenseTier(tierHeader)) {
-        req.proxyTier = tierHeader;
+        req.proxyTier = normalizeTier(tierHeader);
       }
       if (isLicenseVariant(variantHeader)) {
-        req.proxyVariant = variantHeader;
+        req.proxyVariant = normalizeVariant(variantHeader);
       } else if (variantHeader === '') {
         req.proxyVariant = null;
       }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -30,7 +30,7 @@ import { WebhookService } from './services/WebhookService';
 import { SSOService } from './services/SSOService';
 import { SchedulerService } from './services/SchedulerService';
 import { RegistryService } from './services/RegistryService';
-import { CAPABILITIES, getSenchoVersion, fetchRemoteMeta, getActiveCapabilities } from './services/CapabilityRegistry';
+import { CAPABILITIES, getSenchoVersion, fetchRemoteMeta, getActiveCapabilities, type RemoteMeta } from './services/CapabilityRegistry';
 import SelfUpdateService from './services/SelfUpdateService';
 import semver from 'semver';
 import { CronExpressionParser } from 'cron-parser';
@@ -149,6 +149,7 @@ const globalApiLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: 'Too many requests. Please try again shortly.' },
+  skip: (req: Request) => req.path === '/meta' || req.path === '/health',
 });
 
 app.use('/api/', globalApiLimiter);
@@ -5451,6 +5452,7 @@ app.delete('/api/nodes/:id', async (req: Request, res: Response) => {
     const id = parseInt(nodeIdParam);
     DatabaseService.getInstance().deleteNode(id);
     NodeRegistry.getInstance().evictConnection(id);
+    remoteMetaCache.delete(id);
     res.json({ success: true });
   } catch (error: any) {
     console.error('Failed to delete node:', error);
@@ -5471,8 +5473,11 @@ app.post('/api/nodes/:id/test', async (req: Request, res: Response) => {
 
 // Fetch capability metadata for a specific node. For local nodes, returns this
 // instance's capabilities directly. For remote nodes, relays GET /api/meta from
-// the remote Sencho instance. Returns { version: null, capabilities: [] } on
-// failure (old node without /api/meta, or node offline) — never an error status.
+// the remote Sencho instance. Backend-side cache shields against rate limit
+// contention on the remote; stale data is served on transient failures.
+const remoteMetaCache = new Map<number, { data: RemoteMeta; fetchedAt: number }>();
+const REMOTE_META_CACHE_TTL = 3 * 60 * 1000;
+
 app.get('/api/nodes/:id/meta', authMiddleware, async (req: Request, res: Response) => {
   try {
     const id = parseInt(req.params.id as string);
@@ -5487,7 +5492,12 @@ app.get('/api/nodes/:id/meta', authMiddleware, async (req: Request, res: Respons
       return;
     }
 
-    // Remote node — relay GET /api/meta
+    const cached = remoteMetaCache.get(id);
+    if (cached && Date.now() - cached.fetchedAt < REMOTE_META_CACHE_TTL) {
+      res.json(cached.data);
+      return;
+    }
+
     const baseUrl = node.api_url?.replace(/\/$/, '');
     if (!baseUrl || !node.api_token) {
       res.json({ version: null, capabilities: [] });
@@ -5495,10 +5505,22 @@ app.get('/api/nodes/:id/meta', authMiddleware, async (req: Request, res: Respons
     }
 
     const meta = await fetchRemoteMeta(baseUrl, node.api_token);
+
+    // A successful fetch always includes a version; null version means the remote
+    // was unreachable. Only cache successful responses so transient failures retry.
+    if (meta.version !== null) {
+      remoteMetaCache.set(id, { data: meta, fetchedAt: Date.now() });
+    } else if (cached) {
+      cached.fetchedAt = Date.now();
+      res.json(cached.data);
+      return;
+    }
+
     res.json(meta);
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('Failed to fetch node meta:', error);
-    res.status(500).json({ error: error.message || 'Failed to fetch node metadata' });
+    const message = error instanceof Error ? error.message : 'Failed to fetch node metadata';
+    res.status(500).json({ error: message });
   }
 });
 

--- a/backend/src/services/CapabilityRegistry.ts
+++ b/backend/src/services/CapabilityRegistry.ts
@@ -66,7 +66,8 @@ export async function fetchRemoteMeta(baseUrl: string, apiToken: string): Promis
       version: res.data.version ?? null,
       capabilities: Array.isArray(res.data.capabilities) ? res.data.capabilities : [],
     };
-  } catch {
+  } catch (err) {
+    console.warn(`[CapabilityRegistry] Failed to fetch meta from ${baseUrl}:`, (err as Error).message);
     return { version: null, capabilities: [] };
   }
 }

--- a/backend/src/services/LicenseService.ts
+++ b/backend/src/services/LicenseService.ts
@@ -10,12 +10,28 @@ export type LicenseVariant = 'skipper' | 'admiral' | null;
 const VALID_TIERS: readonly string[] = ['community', 'paid'] satisfies readonly LicenseTier[];
 const VALID_VARIANTS: readonly string[] = ['skipper', 'admiral'] satisfies readonly LicenseVariant[];
 
-export function isLicenseTier(value: unknown): value is LicenseTier {
-    return typeof value === 'string' && (VALID_TIERS as readonly string[]).includes(value);
+// Legacy names from pre-0.38.1 versions. Accepted on input and normalized to current names.
+const LEGACY_TIER_MAP: Record<string, LicenseTier> = { pro: 'paid' };
+const LEGACY_VARIANT_MAP: Record<string, Exclude<LicenseVariant, null>> = { personal: 'skipper', team: 'admiral' };
+
+/** Check if value is a recognized tier (current or legacy name). */
+export function isLicenseTier(value: unknown): value is string {
+    return typeof value === 'string' && ((VALID_TIERS as readonly string[]).includes(value) || value in LEGACY_TIER_MAP);
 }
 
-export function isLicenseVariant(value: unknown): value is Exclude<LicenseVariant, null> {
-    return typeof value === 'string' && (VALID_VARIANTS as readonly string[]).includes(value);
+/** Check if value is a recognized variant (current or legacy name). */
+export function isLicenseVariant(value: unknown): value is string {
+    return typeof value === 'string' && ((VALID_VARIANTS as readonly string[]).includes(value) || value in LEGACY_VARIANT_MAP);
+}
+
+/** Normalize a tier value, mapping legacy names to current equivalents. Must be called after isLicenseTier validation. */
+export function normalizeTier(value: string): LicenseTier {
+    return LEGACY_TIER_MAP[value] ?? (value as LicenseTier);
+}
+
+/** Normalize a variant value, mapping legacy names to current equivalents. Must be called after isLicenseVariant validation. */
+export function normalizeVariant(value: string): Exclude<LicenseVariant, null> {
+    return LEGACY_VARIANT_MAP[value] ?? (value as Exclude<LicenseVariant, null>);
 }
 
 /** Header names used for Distributed License Enforcement between nodes. */
@@ -220,26 +236,34 @@ export class LicenseService {
     /**
      * Get the license variant (skipper or admiral) from stored metadata.
      * Trial licenses default to "skipper"; Admiral features require an Admiral license.
-     * Reads the pre-resolved `license_variant_type` from DB. Falls back to name-based
-     * resolution for pre-existing installs, then persists the result so the fallback
-     * only runs once.
+     *
+     * Self-healing: on every call, cross-checks the stored variant_type against what
+     * resolveVariantType() produces from the current product/variant names. If they
+     * disagree (e.g. stale cache from a previous buggy version), re-resolves and
+     * persists the corrected value.
      */
     public getVariant(): LicenseVariant {
         const db = DatabaseService.getInstance();
         const status = db.getSystemState('license_status');
         if (status === 'trial') return 'skipper';
 
-        // Primary path: read the pre-resolved type stored at activation/validation
-        const storedType = db.getSystemState('license_variant_type');
-        if (isLicenseVariant(storedType)) return storedType;
-
-        // Backward compat: resolve from variant/product name for pre-existing installs
         const variantName = db.getSystemState('license_variant_name');
-        if (!variantName) return null;
         const productName = db.getSystemState('license_product_name') || undefined;
-        const resolved = this.resolveVariantType(variantName, productName);
-        db.setSystemState('license_variant_type', resolved);
-        return resolved;
+        const storedType = db.getSystemState('license_variant_type');
+
+        // Self-heal: if we have source metadata, always cross-check the stored type
+        if (variantName) {
+            const resolved = this.resolveVariantType(variantName, productName);
+            if (resolved !== storedType) {
+                db.setSystemState('license_variant_type', resolved);
+            }
+            return resolved;
+        }
+
+        // No variant name available; trust stored type if valid
+        if (isLicenseVariant(storedType)) return normalizeVariant(storedType);
+
+        return null;
     }
 
     /**

--- a/frontend/src/components/FleetView.tsx
+++ b/frontend/src/components/FleetView.tsx
@@ -707,9 +707,10 @@ export function FleetView({ onNavigateToNode }: FleetViewProps) {
     // Paid tier: auto-refresh every 30s
     useEffect(() => {
         if (!isPaid) return;
-        const interval = setInterval(() => fetchOverview(), 30000);
-        return () => clearInterval(interval);
-    }, [isPaid, fetchOverview]);
+        const overviewInterval = setInterval(fetchOverview, 30000);
+        const updateInterval = setInterval(fetchUpdateStatus, 120000);
+        return () => { clearInterval(overviewInterval); clearInterval(updateInterval); };
+    }, [isPaid, fetchOverview, fetchUpdateStatus]);
 
     // Fast poll (5s) when any node is actively updating — uses ref to avoid interval thrashing
     const hasUpdatingRef = useRef(false);

--- a/frontend/src/components/ResourcesView.tsx
+++ b/frontend/src/components/ResourcesView.tsx
@@ -387,13 +387,17 @@ export default function ResourcesView() {
                 apiFetch('/system/orphans'),
             ]);
 
-            setUsage(await usageRes.json());
-            const resources = await resourcesRes.json();
-            setImages(resources.images ?? []);
-            setVolumes(resources.volumes ?? []);
-            setNetworks(resources.networks ?? []);
-            setOrphans(await orphansRes.json());
-            setSelectedOrphans([]);
+            if (usageRes.ok) setUsage(await usageRes.json());
+            if (resourcesRes.ok) {
+                const resources = await resourcesRes.json();
+                setImages(resources.images ?? []);
+                setVolumes(resources.volumes ?? []);
+                setNetworks(resources.networks ?? []);
+            }
+            if (orphansRes.ok) {
+                setOrphans(await orphansRes.json());
+                setSelectedOrphans([]);
+            }
         } catch (err) {
             console.error('Failed to fetch data', err);
             toast.error('Failed to load resources data');

--- a/frontend/src/context/NodeContext.tsx
+++ b/frontend/src/context/NodeContext.tsx
@@ -32,7 +32,8 @@ interface NodeContextType {
   refreshNodeMeta: (nodeId: number) => Promise<void>;
 }
 
-const META_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+const META_CACHE_TTL = 5 * 60 * 1000;
+const META_FAILURE_TTL = 30 * 1000;
 
 const NodeContext = createContext<NodeContextType | undefined>(undefined);
 
@@ -50,7 +51,11 @@ export function NodeProvider({ children }: { children: React.ReactNode }) {
 
   const fetchNodeMeta = useCallback(async (nodeId: number) => {
     const cached = nodeMetaRef.current.get(nodeId);
-    if (cached && Date.now() - cached.fetchedAt < META_CACHE_TTL) return;
+    if (cached) {
+      // Use shorter TTL for failed fetches so we retry quickly after transient errors
+      const ttl = cached.capabilities.length > 0 ? META_CACHE_TTL : META_FAILURE_TTL;
+      if (Date.now() - cached.fetchedAt < ttl) return;
+    }
 
     try {
       const res = await apiFetch(`/nodes/${nodeId}/meta`, { localOnly: true });


### PR DESCRIPTION
## Summary
- Exempt `/api/meta` and `/api/health` from the global rate limiter so capability fetches are never blocked by proxied traffic from the same gateway IP
- Add backend-side caching (3-min TTL) with stale-while-revalidate for remote node meta, preventing transient failures from disabling capability-gated features (Auto-Update, Schedules, Audit, Console)
- Shorten frontend failure cache from 5 minutes to 30 seconds for faster recovery after transient errors
- Evict meta cache entries when nodes are deleted

## Root cause
All proxied requests from the local gateway to a remote node share the same source IP. The global rate limiter (100 req/min) on the remote counts `/api/meta` fetches against this shared budget. When the rate limit is exhausted, capability fetches silently fail and the empty result is cached for 5 minutes, locking all capability-gated features behind the "does not support this capability" overlay.

## Test plan
- [ ] Deploy to production, switch to Opsix remote node
- [ ] Verify Auto-Update, Schedules, Audit, and Console pages load without the capability gate overlay
- [ ] Verify capability recovery after transient network interruption (should recover within 30s)
- [ ] Verify deleting a remote node cleans up its meta cache