### PR TITLE
fix(fleet): resolve getSenchoVersion crash in Docker containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **licensing:** license card now shows "Duration: Lifetime" for lifetime licenses instead of an empty renewal date
 * **fleet:** remote node capability detection now works reliably; `/api/meta` and `/api/health` are exempt from the global rate limiter so they are never blocked by proxied traffic, and a backend-side cache with stale-while-revalidate prevents transient failures from disabling capability-gated features (Auto-Update, Schedules, Audit, Console) on remote nodes
 * **fleet:** failed capability fetches now retry after 30 seconds instead of being cached for the full 5-minute TTL
+* **fleet:** `getSenchoVersion()` now resolves `package.json` via `__dirname` walk instead of a hardcoded relative path; the previous `require('../../../package.json')` resolved correctly in dev but crashed with a 500 in Docker (compiled path `dist/services/` has a different depth than source `src/services/`), causing `/api/meta` to always fail on containerized instances and all capability-gated features to appear unsupported on remote nodes
 
 ### Changed
 

--- a/backend/src/services/CapabilityRegistry.ts
+++ b/backend/src/services/CapabilityRegistry.ts
@@ -1,4 +1,6 @@
 import axios from 'axios';
+import path from 'path';
+import fs from 'fs';
 
 /**
  * Static registry of capabilities supported by THIS Sencho instance.
@@ -33,8 +35,21 @@ export const CAPABILITIES = [
 export type Capability = (typeof CAPABILITIES)[number];
 
 export function getSenchoVersion(): string {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  return require('../../../package.json').version;
+  // Walk up from __dirname to find the root package.json (name === 'sencho').
+  // In dev this is 3 levels up (src/services/ -> root), in Docker it's 2
+  // (dist/services/ -> /app/). Skips intermediate package.json files like
+  // backend/package.json which has a different name and version.
+  let dir = __dirname;
+  for (let i = 0; i < 5; i++) {
+    const candidate = path.join(dir, 'package.json');
+    if (fs.existsSync(candidate)) {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const pkg = require(candidate);
+      if (pkg.name === 'sencho') return pkg.version;
+    }
+    dir = path.dirname(dir);
+  }
+  return 'unknown';
 }
 
 export interface RemoteMeta {


### PR DESCRIPTION
## Summary
- `getSenchoVersion()` used `require('../../../package.json')` which worked in dev but crashed with a 500 in Docker containers
- In dev, the source path `src/services/` is 3 levels below the root `package.json`
- In Docker, the compiled path `dist/services/` is only 2 levels below `/app/package.json`, so `../../../package.json` resolves to `/package.json` which doesn't exist
- This caused `/api/meta` to always return 500 on Docker instances, making `fetchRemoteMeta` return empty capabilities, which made all capability-gated features (Auto-Update, Schedules, Audit, Console) show "does not support this capability" on remote nodes
- Replaced with a `__dirname`-based walk that finds the root `package.json` (matched by `name === 'sencho'`) regardless of directory depth

## Root cause
This bug has existed since the capability system was introduced (v0.32.0) but was only visible when viewing a remote Docker-hosted node through a gateway instance. The `/api/meta` endpoint crashed silently, and `fetchRemoteMeta` swallowed the error.

## Verification
- Confirmed `/api/meta` returns 500 on Opsix (Docker v0.38.5) via `curl`
- Confirmed the fix returns correct version and capabilities in dev via `curl http://localhost:3000/api/meta`
- Docker verification requires deploying the new image to Opsix

## Test plan
- [ ] Deploy new Docker image to Opsix
- [ ] Verify `curl http://151.145.55.226:3000/api/meta` returns version and capabilities (not 500)
- [ ] Switch to Opsix in the UI and verify Auto-Update, Schedules, Audit, Console load without capability gate