### PR TITLE
fix(fleet): filter invalid version strings from UI display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+* **fleet:** node switcher and fleet overview no longer display "vunknown" for remote nodes running older images; invalid version strings are filtered from the UI
+
 ## [0.39.1](https://github.com/AnsoCode/Sencho/compare/v0.39.0...v0.39.1) (2026-04-06)
 
 

--- a/frontend/src/components/CapabilityGate.tsx
+++ b/frontend/src/components/CapabilityGate.tsx
@@ -15,7 +15,8 @@ export function CapabilityGate({ capability, featureName = 'This feature', child
   if (hasCapability(capability)) return <>{children}</>;
 
   const nodeName = activeNode?.name ?? 'this node';
-  const versionHint = activeNodeMeta?.version
+  const hasValidVersion = activeNodeMeta?.version && activeNodeMeta.version !== 'unknown' && activeNodeMeta.version !== '0.0.0-dev';
+  const versionHint = hasValidVersion
     ? `${nodeName} is running v${activeNodeMeta.version}`
     : `${nodeName} does not support this capability`;
 

--- a/frontend/src/components/EditorLayout.tsx
+++ b/frontend/src/components/EditorLayout.tsx
@@ -1350,7 +1350,7 @@ export default function EditorLayout() {
                           node.status === 'offline' ? 'bg-red-500' : 'bg-gray-400'
                           }`} />
                         <span>{node.name}</span>
-                        {meta?.version && (
+                        {meta?.version && meta.version !== 'unknown' && meta.version !== '0.0.0-dev' && (
                           <span className="font-mono text-[10px] tabular-nums text-muted-foreground/60 ml-auto">
                             v{meta.version}
                           </span>

--- a/frontend/src/components/FleetView.tsx
+++ b/frontend/src/components/FleetView.tsx
@@ -1218,7 +1218,7 @@ export function FleetView({ onNavigateToNode }: FleetViewProps) {
 
                                             {/* Current version */}
                                             <span className="text-xs font-mono tabular-nums text-muted-foreground">
-                                                {s.version ? `v${s.version}` : <span className="text-muted-foreground/50 italic text-[10px]">unknown</span>}
+                                                {s.version && s.version !== 'unknown' && s.version !== '0.0.0-dev' ? `v${s.version}` : <span className="text-muted-foreground/50 italic text-[10px]">unknown</span>}
                                             </span>
 
                                             {/* Latest version */}


### PR DESCRIPTION
## Summary

- Node switcher, fleet overview, and capability gate now treat `"unknown"` and `"0.0.0-dev"` as absent versions
- Remote nodes running older Docker images (pre-v0.39.1) that return these fallback values show a clean label instead of "vunknown"

## Context

Follow-up to #396 (build-time version injection). While that fix ensures new images report the correct version, remote nodes still running older images return `"unknown"` from `/api/meta`. The frontend was displaying this as `vunknown` in the node switcher and `Opsix is running vunknown` in the capability gate.

## Test plan

- [x] Frontend typecheck passes
- [x] Validated via Playwright: node switcher shows "Opsix" without version badge when version is "unknown"
- [ ] Fleet overview shows styled "unknown" label instead of "vunknown"
- [ ] Capability gate shows "does not support this capability" instead of "running vunknown"