### PR TITLE
fix(nav): remove toggle behavior on navigation tabs

### DIFF
--- a/frontend/src/components/EditorLayout.tsx
+++ b/frontend/src/components/EditorLayout.tsx
@@ -249,12 +249,9 @@ export default function EditorLayout() {
     setIsEditing(false);
   };
 
-  // Navigation handler with toggle support
   const handleNavigate = (value: string) => {
-    if (value === activeView) {
-      // Toggle off: return to editor if a file is open, else dashboard
-      setActiveView(selectedFile ? 'editor' : 'dashboard');
-    } else if (value === 'dashboard') {
+    if (value === activeView) return;
+    if (value === 'dashboard') {
       resetEditorState();
       setActiveView('dashboard');
     } else {


### PR DESCRIPTION
## Summary

- Remove the toggle-off behavior when clicking an already-active navigation tab
- Previously, clicking e.g. Fleet while already on Fleet would send you back to the dashboard/editor. This was a leftover from the old UI design where the button layout was different
- Now clicking the active tab is a no-op, which matches user expectations under the current navigation design

## Test Plan

- [ ] Click Fleet tab, verify it navigates to Fleet
- [ ] Click Fleet tab again while on Fleet, verify nothing happens (stays on Fleet)
- [ ] Repeat for all navigation tabs (Resources, App Store, Logs, etc.)
- [ ] Verify clicking a different tab still navigates correctly
- [ ] Verify clicking Home still resets editor state and returns to dashboard