### PR TITLE
feat(nav): add pulsing animation to local node status dot

### DIFF
--- a/frontend/src/components/EditorLayout.tsx
+++ b/frontend/src/components/EditorLayout.tsx
@@ -1733,7 +1733,10 @@ export default function EditorLayout() {
               </div>
             ) : (
               <div className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-muted/50 border border-border text-muted-foreground text-sm">
-                <span className="w-2 h-2 rounded-full bg-success shrink-0" />
+                <span className="relative flex h-2 w-2 shrink-0">
+                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-success opacity-75" />
+                  <span className="relative inline-flex rounded-full h-2 w-2 bg-success" />
+                </span>
                 {activeNode?.name ?? 'Local'}
               </div>
             )}

--- a/frontend/src/components/EditorLayout.tsx
+++ b/frontend/src/components/EditorLayout.tsx
@@ -1733,10 +1733,7 @@ export default function EditorLayout() {
               </div>
             ) : (
               <div className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-muted/50 border border-border text-muted-foreground text-sm">
-                <span className="relative flex h-2 w-2 shrink-0">
-                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-success opacity-75" />
-                  <span className="relative inline-flex rounded-full h-2 w-2 bg-success" />
-                </span>
+                <span className="w-2 h-2 rounded-full bg-success animate-pulse shrink-0" />
                 {activeNode?.name ?? 'Local'}
               </div>
             )}


### PR DESCRIPTION
## Summary

- Add the `animate-ping` pulsing effect to the green status dot in the local node context pill (top header bar)
- Uses the same pattern as the notification bell unread badge: an expanding ring behind a solid dot
- Gives a stronger visual signal that the node connection is live

## Test Plan

- [ ] Verify the green dot in the "Local" pill pulses with a ping animation
- [ ] Verify the remote node pill (blue) still uses `animate-pulse` as before
- [ ] Verify the notification bell dot still pulses independently
- [ ] Check both light and dark themes for visibility