### PR TITLE
fix(schedules): filter auto-update policies from Scheduled Operations view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * **auto-update:** resolve failure when executing auto-update policies on remote Distributed API nodes. Previously, the scheduler tried to access the remote Docker daemon directly, which is not supported. Now the update execution is proxied to the remote Sencho instance via HTTP, matching the existing Distributed API architecture.
+* **schedules:** auto-update policies no longer appear in the Scheduled Operations list. Each view now fetches only its relevant task type via server-side action filtering.
 
 ## [0.39.6](https://github.com/AnsoCode/Sencho/compare/v0.39.5...v0.39.6) (2026-04-07)
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4518,6 +4518,15 @@ app.get('/api/scheduled-tasks', (req: Request, res: Response): void => {
     if (ls.getVariant() !== 'admiral') {
       tasks = tasks.filter(t => t.action === 'update');
     }
+    // Optional action filter: ?action=update returns only that action,
+    // ?exclude_action=update excludes it. Useful for separating views.
+    const actionFilter = req.query.action as string | undefined;
+    const excludeAction = req.query.exclude_action as string | undefined;
+    if (actionFilter) {
+      tasks = tasks.filter(t => t.action === actionFilter);
+    } else if (excludeAction) {
+      tasks = tasks.filter(t => t.action !== excludeAction);
+    }
     res.json(tasks);
   } catch (error) {
     console.error('[ScheduledTasks] List error:', error);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4518,10 +4518,9 @@ app.get('/api/scheduled-tasks', (req: Request, res: Response): void => {
     if (ls.getVariant() !== 'admiral') {
       tasks = tasks.filter(t => t.action === 'update');
     }
-    // Optional action filter: ?action=update returns only that action,
-    // ?exclude_action=update excludes it. Useful for separating views.
-    const actionFilter = req.query.action as string | undefined;
-    const excludeAction = req.query.exclude_action as string | undefined;
+    // Separate Auto-Update and Scheduled Operations into distinct views
+    const actionFilter = typeof req.query.action === 'string' ? req.query.action : undefined;
+    const excludeAction = typeof req.query.exclude_action === 'string' ? req.query.exclude_action : undefined;
     if (actionFilter) {
       tasks = tasks.filter(t => t.action === actionFilter);
     } else if (excludeAction) {

--- a/frontend/src/components/AutoUpdatePoliciesView.tsx
+++ b/frontend/src/components/AutoUpdatePoliciesView.tsx
@@ -115,10 +115,9 @@ function AutoUpdatePoliciesContent({ filterNodeId, onClearFilter }: AutoUpdatePo
   const fetchPolicies = useCallback(async () => {
     setLoading(true);
     try {
-      const res = await apiFetch('/scheduled-tasks', { localOnly: true });
+      const res = await apiFetch('/scheduled-tasks?action=update', { localOnly: true });
       if (res.ok) {
-        const all: ScheduledTask[] = await res.json();
-        setPolicies(all.filter(t => t.action === 'update'));
+        setPolicies(await res.json());
       }
     } catch {
       // Non-critical

--- a/frontend/src/components/ScheduledOperationsView.tsx
+++ b/frontend/src/components/ScheduledOperationsView.tsx
@@ -118,7 +118,7 @@ export default function ScheduledOperationsView({ filterNodeId, onClearFilter }:
   const fetchTasks = useCallback(async () => {
     setLoading(true);
     try {
-      const res = await apiFetch('/scheduled-tasks', { localOnly: true });
+      const res = await apiFetch('/scheduled-tasks?exclude_action=update', { localOnly: true });
       if (res.ok) {
         setTasks(await res.json());
       }


### PR DESCRIPTION
## Summary
- Auto-update policies (action=update) were appearing in both the Auto-Update tab and the Scheduled Operations tab
- Added `action` and `exclude_action` query params to `GET /api/scheduled-tasks` for server-side filtering
- `ScheduledOperationsView` now requests `?exclude_action=update` to hide auto-update policies
- `AutoUpdatePoliciesView` now requests `?action=update` server-side instead of client-side filtering

## Test plan
- [ ] Navigate to the Schedules tab and verify auto-update policies no longer appear
- [ ] Navigate to the Auto-Update tab and verify policies still display correctly
- [ ] Create a new scheduled operation (restart/snapshot/prune) and verify it appears only in Schedules
- [ ] Create a new auto-update policy and verify it appears only in Auto-Update