### PR TITLE
fix(console): send proxy tier headers for remote node console-token requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* **console:** fix remote node Host Console failing with "Connection error" / 502. The gateway's console-token request to the remote node was missing license tier headers, causing the remote's Admiral license gate to reject the request. Both the HTTP fetch and the WS upgrade handler now correctly propagate proxy tier headers for console_session tokens.
 * **auto-update:** resolve failure when executing auto-update policies on remote Distributed API nodes. Previously, the scheduler tried to access the remote Docker daemon directly, which is not supported. Now the update execution is proxied to the remote Sencho instance via HTTP, matching the existing Distributed API architecture.
 * **schedules:** auto-update policies no longer appear in the Scheduled Operations list. Each view now fetches only its relevant task type via server-side action filtering.
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2690,9 +2690,14 @@ server.on('upgrade', async (req, socket, head) => {
       let bearerTokenForProxy = node.api_token;
       if (isInteractiveConsolePath) {
         try {
+          const ls = LicenseService.getInstance();
           const tokenRes = await fetch(`${node.api_url.replace(/\/$/, '')}/api/system/console-token`, {
             method: 'POST',
-            headers: { 'Authorization': `Bearer ${node.api_token}` },
+            headers: {
+              'Authorization': `Bearer ${node.api_token}`,
+              [PROXY_TIER_HEADER]: ls.getTier(),
+              [PROXY_VARIANT_HEADER]: ls.getVariant() || '',
+            },
           });
           if (tokenRes.ok) {
             const data = await tokenRes.json() as { token?: string };
@@ -2759,9 +2764,20 @@ server.on('upgrade', async (req, socket, head) => {
         socket.destroy();
         return;
       }
-      // Admiral license gate: host console requires Admiral (paid + team variant)
+      // Admiral license gate: host console requires Admiral (paid + team variant).
+      // For proxied connections (console_session tokens), trust the tier headers sent by the gateway;
+      // for direct connections, check the local LicenseService.
+      const isConsoleSession = decoded.scope === 'console_session';
+      const consoleTierHeader = req.headers[PROXY_TIER_HEADER] as string | undefined;
+      const consoleVariantHeader = req.headers[PROXY_VARIANT_HEADER] as string | undefined;
       const ls = LicenseService.getInstance();
-      if (ls.getTier() !== 'paid' || ls.getVariant() !== 'admiral') {
+      const consoleTier = (isConsoleSession && isLicenseTier(consoleTierHeader))
+        ? normalizeTier(consoleTierHeader)
+        : ls.getTier();
+      const consoleVariant = (isConsoleSession && consoleVariantHeader !== undefined && isLicenseVariant(consoleVariantHeader))
+        ? normalizeVariant(consoleVariantHeader)
+        : ls.getVariant();
+      if (consoleTier !== 'paid' || consoleVariant !== 'admiral') {
         socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
         socket.destroy();
         return;


### PR DESCRIPTION
## Summary
- Fixed remote node Host Console failing with "Connection error" / 502 by adding missing `x-sencho-tier` and `x-sencho-variant` headers to the gateway's `POST /api/system/console-token` request
- Fixed the remote's WS upgrade handler for host-console to respect proxy tier headers on `console_session` tokens, instead of only checking the local LicenseService

## Root cause
The gateway exchanges the long-lived `node_proxy` token for a short-lived `console_session` token via the remote's `/api/system/console-token` endpoint. That endpoint is gated by `requireAdmiral`, which checks `req.proxyTier` (populated from headers) before falling back to the local license. Without the tier headers, the remote's local license (Community) was used, causing a 403 rejection that surfaced as a 502 to the browser.

## Test plan
- [ ] Deploy updated backend to gateway instance
- [ ] Switch to Opsix (remote node) in the node selector
- [ ] Navigate to Console tab
- [ ] Verify terminal connects successfully (green "Connected" badge, shell prompt appears)
- [ ] Verify local node Console still works as before
- [ ] Verify container exec terminal still works on both local and remote nodes