### PR TITLE
feat(contact): add official contact emails throughout app and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * **resources:** loading toast notification during prune, delete, and purge operations in the Resources Hub. A spinning indicator with an indeterminate progress bar now appears while the operation runs, replacing the previous dead moment between confirmation and result.
+* **contact:** add official contact emails throughout the app, website, and documentation. Six dedicated channels (support, contact, licensing, security, privacy, conduct) are now surfaced in contextually appropriate locations including upgrade prompts, legal pages, security policy, and a new Contact & Support docs page.
+* **security:** add `.well-known/security.txt` to both the app and marketing website per RFC 9116.
 
 ### Fixed
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,18 +4,19 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.2.x   | Yes                |
+| 0.2.x+  | Yes                |
 | < 0.2   | No                 |
 
 ## Reporting a Vulnerability
 
 **Please do not open a public issue for security vulnerabilities.**
 
-Instead, use GitHub's private vulnerability reporting:
+You can report security issues in two ways:
 
-1. Go to the [Security tab](https://github.com/AnsoCode/Sencho/security) of this repository
-2. Click **"Report a vulnerability"**
-3. Provide details including: steps to reproduce, impact assessment, and any suggested fixes
+1. **Email:** Send details to **security@sencho.io**
+2. **GitHub:** Use [private vulnerability reporting](https://github.com/AnsoCode/Sencho/security/advisories/new) in the Security tab
+
+In your report, include: steps to reproduce, impact assessment, and any suggested fixes.
 
 You can expect an initial response within 72 hours. We will work with you to understand and address the issue before any public disclosure.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -125,6 +125,7 @@
             "pages": [
               "features/node-compatibility",
               "reference/settings",
+              "reference/contact",
               "reference/security-advisories"
             ]
           },

--- a/docs/reference/contact.mdx
+++ b/docs/reference/contact.mdx
@@ -1,0 +1,68 @@
+---
+title: Contact & Support
+description: Official contact channels for support, licensing, security, privacy, and general inquiries.
+---
+
+Sencho provides dedicated email channels for different types of inquiries. Use the channel that best matches your need so your message reaches the right team.
+
+## Support
+
+<Card title="support@sencho.io" icon="life-ring" href="mailto:support@sencho.io">
+  Technical support, how-to questions, and troubleshooting help. Available to Skipper and Admiral license holders via **Settings > Help & Support** in the app.
+</Card>
+
+Community users can get help through the [Documentation](https://docs.sencho.io) and [GitHub Issues](https://github.com/AnsoCode/Sencho/issues).
+
+## General inquiries
+
+<Card title="contact@sencho.io" icon="envelope" href="mailto:contact@sencho.io">
+  General inquiries, partnership proposals, and media requests. Found in the website footer under **Community > Contact**.
+</Card>
+
+## Licensing
+
+<Card title="licensing@sencho.io" icon="key" href="mailto:licensing@sencho.io">
+  License activation issues, upgrade questions, enterprise pricing, refund requests, and alternative licensing arrangements.
+</Card>
+
+This address appears in:
+- The [LICENSE](https://github.com/AnsoCode/Sencho/blob/main/LICENSE) file for alternative licensing inquiries
+- Upgrade prompts inside the app (paywall screens)
+- The [Refund Policy](https://sencho.io/refund) and pricing section on the website
+
+## Security
+
+<Card title="security@sencho.io" icon="shield" href="mailto:security@sencho.io">
+  Vulnerability reports, security incidents, and bug bounty submissions. **Do not open a public issue for security vulnerabilities.**
+</Card>
+
+You can also use [GitHub private vulnerability reporting](https://github.com/AnsoCode/Sencho/security/advisories/new). Both the app and the website publish a `/.well-known/security.txt` file that points to this address.
+
+See the full [Security Policy](https://github.com/AnsoCode/Sencho/blob/main/SECURITY.md) for response times and disclosure guidelines.
+
+## Privacy
+
+<Card title="privacy@sencho.io" icon="lock" href="mailto:privacy@sencho.io">
+  GDPR data requests, CCPA inquiries, Terms of Service questions, and DMCA claims.
+</Card>
+
+This address is listed in the [Privacy Policy](https://sencho.io/privacy) and [Terms of Service](https://sencho.io/terms) on the website.
+
+## Community conduct
+
+<Card title="conduct@sencho.io" icon="users" href="mailto:conduct@sencho.io">
+  Reports of Code of Conduct violations in any Sencho community space.
+</Card>
+
+All reports are reviewed promptly and handled with confidentiality. See the [Code of Conduct](https://github.com/AnsoCode/Sencho/blob/main/CODE_OF_CONDUCT.md) for details.
+
+## Summary
+
+| Email | When to use |
+|-------|-------------|
+| `support@sencho.io` | Technical help (paid tiers) |
+| `contact@sencho.io` | General inquiries, partnerships, media |
+| `licensing@sencho.io` | Upgrades, enterprise deals, refunds, license issues |
+| `security@sencho.io` | Vulnerability reports, security incidents |
+| `privacy@sencho.io` | GDPR/CCPA requests, legal, DMCA |
+| `conduct@sencho.io` | Code of Conduct violations |

--- a/frontend/public/.well-known/security.txt
+++ b/frontend/public/.well-known/security.txt
@@ -1,0 +1,6 @@
+Contact: mailto:security@sencho.io
+Contact: https://github.com/AnsoCode/Sencho/security/advisories/new
+Expires: 2027-12-31T23:59:00.000Z
+Preferred-Languages: en
+Canonical: https://sencho.io/.well-known/security.txt
+Policy: https://github.com/AnsoCode/Sencho/blob/main/SECURITY.md

--- a/frontend/src/components/AdmiralGate.tsx
+++ b/frontend/src/components/AdmiralGate.tsx
@@ -47,6 +47,8 @@ export function AdmiralGate({ children, featureName = 'This feature' }: AdmiralG
                 <h3 className="text-lg font-semibold mb-2">{featureName} requires Sencho Admiral</h3>
                 <p className="text-sm text-muted-foreground">
                     Unlock team features like SSO authentication, audit logging, API tokens, and unlimited user accounts with a Sencho Admiral license.
+                    For enterprise pricing or questions, contact{' '}
+                    <a href="mailto:licensing@sencho.io" className="text-brand hover:underline">licensing@sencho.io</a>.
                 </p>
             </div>
             <div className="flex gap-3">

--- a/frontend/src/components/PaidGate.tsx
+++ b/frontend/src/components/PaidGate.tsx
@@ -47,6 +47,8 @@ export function PaidGate({ children, featureName = 'This feature' }: PaidGatePro
                 <h3 className="text-lg font-semibold mb-2">{featureName} requires a paid license</h3>
                 <p className="text-sm text-muted-foreground">
                     Unlock features like fleet management, viewer accounts, and more with a Skipper or Admiral license.
+                    For enterprise pricing or questions, contact{' '}
+                    <a href="mailto:licensing@sencho.io" className="text-brand hover:underline">licensing@sencho.io</a>.
                 </p>
             </div>
             <div className="flex gap-3">


### PR DESCRIPTION
## Summary
- Added six official contact email channels across the app, documentation, and website
- Created `.well-known/security.txt` (RFC 9116) for the app and website
- Added `security@sencho.io` as an alternative reporting method in `SECURITY.md`
- Added `licensing@sencho.io` to upgrade prompts (PaidGate, AdmiralGate)
- Created new **Contact & Support** docs page listing all channels with usage guidance
- Website changes (separate repo): `privacy@sencho.io` in Privacy/Terms, `licensing@sencho.io` in Refund/Pricing, `contact@sencho.io` in footer

## Email channel placement

| Email | Locations |
|-------|-----------|
| `support@sencho.io` | Settings > Help & Support (existing, Admiral tier) |
| `contact@sencho.io` | Website footer (new) |
| `licensing@sencho.io` | LICENSE (existing), PaidGate/AdmiralGate prompts (new), Refund page (new), Pricing section (new) |
| `security@sencho.io` | SECURITY.md (new), `.well-known/security.txt` (new) |
| `privacy@sencho.io` | Privacy Policy (new), Terms of Service (new) |
| `conduct@sencho.io` | CODE_OF_CONDUCT.md (existing) |

## Test plan
- [ ] Verify `/.well-known/security.txt` is served by the app at the expected path
- [ ] Navigate to a paid-gated feature as Community tier; verify `licensing@sencho.io` appears in the upgrade prompt
- [ ] Check the new Contact & Support docs page renders correctly at docs.sencho.io
- [ ] Verify website Privacy, Terms, and Refund pages show updated email addresses
- [ ] Verify website footer includes the Contact link
- [ ] Verify website pricing section shows the licensing contact line