### PR TITLE
fix(fleet): strip trailing slash in fetchRemoteMeta URL construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+* **fleet:** fix false "Update available" on remote nodes whose `api_url` has a trailing slash, causing `fetchRemoteMeta` to construct a double-slash URL that fails silently
+
 ## [0.41.1](https://github.com/AnsoCode/Sencho/compare/v0.41.0...v0.41.1) (2026-04-08)
 
 

--- a/backend/src/services/CapabilityRegistry.ts
+++ b/backend/src/services/CapabilityRegistry.ts
@@ -93,7 +93,7 @@ export function getActiveCapabilities(): readonly string[] {
 /** Fetch /api/meta from a remote Sencho instance. Returns empty data on failure. */
 export async function fetchRemoteMeta(baseUrl: string, apiToken: string): Promise<RemoteMeta> {
   try {
-    const res = await axios.get(`${baseUrl}/api/meta`, {
+    const res = await axios.get(`${baseUrl.replace(/\/$/, '')}/api/meta`, {
       headers: { Authorization: `Bearer ${apiToken}` },
       timeout: 5000,
     });


### PR DESCRIPTION
## Summary

- Fix false "Update available" badge on remote nodes whose `api_url` has a trailing slash (e.g. `http://host:3000/`)
- `fetchRemoteMeta` constructed a double-slash URL (`http://host:3000//api/meta`) that failed silently, returning `version: null`, which the update-status logic interpreted as "outdated"
- Every other URL construction in the codebase already strips the trailing slash; this was the one call site missed

## Test plan

- [ ] Navigate to Fleet Overview on a gateway where both local and remote nodes run the same version
- [ ] Verify remote node no longer shows "Update available" badge or "Update to vX.Y.Z" button
- [ ] Open Node Updates modal and confirm remote shows "Up to date"