### PR TITLE
fix(fleet): prevent modal flash when clicking Recheck button

### DIFF
--- a/frontend/src/components/FleetView.tsx
+++ b/frontend/src/components/FleetView.tsx
@@ -640,6 +640,7 @@ export function FleetView({ onNavigateToNode }: FleetViewProps) {
     const [localUpdateConfirm, setLocalUpdateConfirm] = useState<number | null>(null);
     const [showUpdateModal, setShowUpdateModal] = useState(false);
     const [checkingUpdates, setCheckingUpdates] = useState(false);
+    const [recheckingUpdates, setRecheckingUpdates] = useState(false);
     const [modalSearch, setModalSearch] = useState('');
     const updateStatusesRef = useRef(updateStatuses);
     updateStatusesRef.current = updateStatuses;
@@ -1352,15 +1353,15 @@ export function FleetView({ onNavigateToNode }: FleetViewProps) {
                                         variant="ghost"
                                         size="sm"
                                         className="h-7 text-xs text-muted-foreground"
-                                        disabled={checkingUpdates}
+                                        disabled={recheckingUpdates}
                                         onClick={async () => {
-                                            setCheckingUpdates(true);
+                                            setRecheckingUpdates(true);
                                             await apiFetch('/fleet/update-status?recheck=true', { method: 'DELETE', localOnly: true });
                                             await fetchUpdateStatus();
-                                            setCheckingUpdates(false);
+                                            setRecheckingUpdates(false);
                                         }}
                                     >
-                                        <RefreshCw className={`w-3 h-3 mr-1.5 ${checkingUpdates ? 'animate-spin' : ''}`} strokeWidth={1.5} />
+                                        <RefreshCw className={`w-3 h-3 mr-1.5 ${recheckingUpdates ? 'animate-spin' : ''}`} strokeWidth={1.5} />
                                         Recheck
                                     </Button>
                                     {updatableRemoteCount > 0 && (


### PR DESCRIPTION
## Summary

- The Recheck button in the Node Updates modal was replacing the entire modal body with a loading spinner, causing a jarring flash
- Added a separate `recheckingUpdates` state so the modal content stays visible during recheck; only the RefreshCw icon spins
- The full-screen loading spinner is now only used for the initial "Check Updates" open from the header, where it makes sense since there's no content to show yet

## Test plan

- [x] Click "Check Updates" from header: full loading spinner shown, then modal content appears (unchanged)
- [x] Click "Recheck" in modal footer: modal content stays visible, RefreshCw icon spins, no flash
- [x] No console errors during recheck