### PR TITLE
ci: optimize workflows to cut redundant runs

### DIFF
--- a/.github/actions/start-app/action.yml
+++ b/.github/actions/start-app/action.yml
@@ -22,6 +22,11 @@ runs:
       uses: actions/setup-node@v6
       with:
         node-version: '20'
+        cache: 'npm'
+        cache-dependency-path: |
+          package-lock.json
+          backend/package-lock.json
+          frontend/package-lock.json
 
     - name: Install root dependencies (Playwright)
       shell: bash

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 10
+    groups:
+      all-npm-root:
+        patterns: ["*"]
 
   - package-ecosystem: "npm"
     directory: "/backend"
@@ -15,6 +18,9 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 10
+    groups:
+      all-npm-backend:
+        patterns: ["*"]
 
   - package-ecosystem: "npm"
     directory: "/frontend"
@@ -23,6 +29,9 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 10
+    groups:
+      all-npm-frontend:
+        patterns: ["*"]
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -30,3 +39,6 @@ updates:
       interval: "weekly"
     labels:
       - "ci"
+    groups:
+      all-actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,16 @@ concurrency:
   cancel-in-progress: true
 
 # ---------------------------------------------------------------------------
-# Build & Validation (runs on PRs and push to main)
+# Build & Validation (PRs only, skipped for release-please PRs)
 # ---------------------------------------------------------------------------
 jobs:
   backend:
     name: Backend (Build, Test, Lint)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: >-
+      github.event_name == 'pull_request'
+      && github.head_ref != 'release-please--branches--main--components--sencho'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -58,6 +62,10 @@ jobs:
   frontend:
     name: Frontend (Build, Lint)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: >-
+      github.event_name == 'pull_request'
+      && github.head_ref != 'release-please--branches--main--components--sencho'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -88,6 +96,10 @@ jobs:
   docker-validate:
     name: Docker Build & Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: >-
+      github.event_name == 'pull_request'
+      && github.head_ref != 'release-please--branches--main--components--sencho'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -117,12 +129,16 @@ jobs:
         continue-on-error: true
 
   # ---------------------------------------------------------------------------
-  # E2E Tests (runs on PRs and push to main)
+  # E2E Tests (PRs only, skipped for release-please PRs)
   # ---------------------------------------------------------------------------
   e2e:
     name: E2E Tests (Playwright)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [backend, frontend]
+    if: >-
+      github.event_name == 'pull_request'
+      && github.head_ref != 'release-please--branches--main--components--sencho'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -154,11 +170,11 @@ jobs:
   update-screenshots:
     name: Refresh Doc Screenshots
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: >-
       github.event_name == 'push'
       && github.ref == 'refs/heads/main'
       && startsWith(github.event.head_commit.message, 'chore(main): release')
-    needs: [backend, frontend]
     permissions:
       contents: write
       pull-requests: write
@@ -201,6 +217,7 @@ jobs:
   sync-docs:
     name: Sync Docs to sencho-docs
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout Sencho repo

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,10 +6,15 @@ on:
       - 'v*'
   workflow_dispatch:
 
+concurrency:
+  group: docker-publish
+  cancel-in-progress: true
+
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Check out the repo
         uses: actions/checkout@v6

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules/
 
 # Build Outputs
 dist/
+*.tsbuildinfo
 
 # Sencho User Data & Mocks
 data/


### PR DESCRIPTION
## Summary
- **Skip validation jobs on push-to-main**: backend, frontend, docker-validate, and E2E only run on PRs now (code was already validated before merge)
- **Skip CI for release-please PRs**: version bump PRs no longer trigger full build/test/Docker/E2E
- **Add timeout-minutes to all jobs**: prevents hung runners from burning the 360-min GitHub default (the 0.42.5 post-merge run was stuck on "Setup Node.js" indefinitely)
- **Add npm caching to start-app action**: caches all 3 lock files for E2E and screenshot jobs
- **Add concurrency to docker-publish**: prevents wasted parallel builds on rapid tag pushes
- **Group Dependabot updates**: batches updates per ecosystem into single PRs instead of one per package

## Savings estimate
| Run | Before | After |
|-----|--------|-------|
| Feature PR CI | ~4 min | ~4 min (necessary) |
| Feature merge push CI | ~4 min | ~0.5 min (sync-docs only) |
| Release-please PR CI | ~4 min | skipped |
| Release merge push CI | ~4 min | ~2 min (screenshots + sync) |
| **Total per release** | **~19 min** | **~9.5 min** |

~50% reduction in CI minutes per release cycle, ~30-40 min/day saved.

## Test plan
- [ ] Verify this PR triggers full CI (backend, frontend, docker-validate, e2e)
- [ ] After merge, verify only sync-docs runs on push-to-main
- [ ] On next release-please PR, verify validation jobs are skipped
- [ ] On next release merge, verify update-screenshots runs independently