### PR TITLE
ci: harden supply chain (SHA pin actions, least-privilege permissions)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,26 @@
 **/dist
 .git
 .gitignore
+.DS_Store
+
+# Docs and non-runtime content. Not needed in the image, bloats build context.
 plans/
 Product Requirements Document
 *.md
-.DS_Store
+docs/
+website/
+
+# Tests and reports. Never shipped in the image.
+e2e/
+tests/
+test-results/
+playwright-report/
+
+# CI config runs on GitHub Actions, not inside the image.
+.github/
+
+# Secrets and key material. Defense in depth against accidental context leaks.
+.env
+.env.*
+*.key
+*.pem

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default for every job. Individual jobs may override (e.g.
+# update-screenshots needs contents: write + pull-requests: write to open a PR).
+permissions:
+  contents: read
+
 # ---------------------------------------------------------------------------
 # Build & Validation (PRs only, skipped for release-please PRs)
 # ---------------------------------------------------------------------------
@@ -118,7 +123,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Scan image for vulnerabilities (Trivy)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: sencho:pr-test
           exit-code: '1'
@@ -195,7 +200,7 @@ jobs:
 
       - name: Open / update screenshots PR
         id: create-pr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.DOCS_REPO_TOKEN }}
           branch: chore/refresh-screenshots

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,6 +15,8 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - name: Check out the repo
         uses: actions/checkout@v6

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         with:
           # GITHUB_TOKEN cannot trigger other workflows (GitHub security restriction).
           # Using DOCS_REPO_TOKEN (PAT) ensures the tag push from release-please


### PR DESCRIPTION
## Summary

PR 1 of the CI/CD hardening plan. This PR is pure supply-chain hygiene, no behavior changes.

- **SHA-pin third-party actions** so dependabot can update them in place without exposing the pipeline to upstream tag tampering:
  - `aquasecurity/trivy-action` (was `@master`) → `57a97c7...` (v0.35.0)
  - `peter-evans/create-pull-request` (was `@v8`) → `5f6978f...` (v8.1.1)
  - `googleapis/release-please-action` (was `@v4`) → `16a9c90...` (v4.4.0)
- **Workflow-level least-privilege `permissions: contents: read`** default in `ci.yml`, with `update-screenshots` keeping its explicit `contents: write` + `pull-requests: write` override. Same default added to `docker-publish.yml` (single-job workflow).
- **Expand `.dockerignore`** to explicitly exclude `.env*`, `*.key`, `*.pem`, `.github/`, `docs/`, `website/`, `e2e/`, `tests/`, `test-results/`, and `playwright-report/`. None of these paths are read by any `COPY` step in the Dockerfile.

## Test plan

- [x] All three workflow YAML files parse cleanly (validated via backend `yaml` package)
- [x] SHA pins verified against `gh api .../git/refs/tags/vX.Y.Z`
- [x] Dockerfile `COPY` sources walked; no path matches the new `.dockerignore` excludes
- [x] `/simplify` three-agent code review (reuse, quality, efficiency) completed
- [ ] CI pipeline runs green on this PR
- [ ] Docker build succeeds in `docker-validate` job with the expanded `.dockerignore`
- [ ] Next dependabot cycle picks up SHA-pinned actions correctly

Part of the CI/CD pipeline hardening plan (9 grouped PRs total).