### PR TITLE
ci: capture backend and frontend logs for E2E failures

### DIFF
--- a/.github/actions/start-app/action.yml
+++ b/.github/actions/start-app/action.yml
@@ -47,13 +47,20 @@ runs:
       run: npm ci
       working-directory: ./frontend
 
-    - name: Create compose directory
+    - name: Create compose directory and log dir
       shell: bash
-      run: mkdir -p ${{ inputs.compose-dir }}
+      run: |
+        mkdir -p ${{ inputs.compose-dir }}
+        mkdir -p "${{ github.workspace }}/ci-logs"
 
+    # Log files live under $GITHUB_WORKSPACE so actions/upload-artifact@v4+ can
+    # include them alongside repo-relative paths like e2e/report/. Mixing those
+    # with /tmp paths makes '/' the common root and v4+ strips the absolute
+    # entries from the artifact. `stdbuf -oL -eL` forces line-buffered output
+    # so a crash doesn't lose the final few hundred lines to block buffering.
     - name: Start backend
       shell: bash
-      run: node dist/index.js &
+      run: stdbuf -oL -eL node dist/index.js > "${{ github.workspace }}/ci-logs/backend.log" 2>&1 &
       working-directory: ./backend
       env:
         JWT_SECRET: ${{ inputs.jwt-secret }}
@@ -63,7 +70,7 @@ runs:
 
     - name: Start frontend dev server
       shell: bash
-      run: npm run dev &
+      run: stdbuf -oL -eL npm run dev > "${{ github.workspace }}/ci-logs/frontend.log" 2>&1 &
       working-directory: ./frontend
 
     - name: Wait for services to be ready

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,11 +153,8 @@ jobs:
 
       - name: Run E2E tests
         run: npx playwright test
-        env:
-          E2E_USERNAME: admin
-          E2E_PASSWORD: password123
 
-      - name: Upload E2E report
+      - name: Upload E2E report and service logs
         if: failure()
         uses: actions/upload-artifact@v7
         with:
@@ -165,6 +162,7 @@ jobs:
           path: |
             e2e/report/
             test-results/
+            ci-logs/
           retention-days: 7
 
   # ---------------------------------------------------------------------------
@@ -194,9 +192,6 @@ jobs:
 
       - name: Capture screenshots
         run: npx playwright test e2e/screenshots.spec.ts --project=chromium
-        env:
-          E2E_USERNAME: admin
-          E2E_PASSWORD: password123
 
       - name: Open / update screenshots PR
         id: create-pr


### PR DESCRIPTION
## Summary

When an E2E test flakes in CI, the backend and frontend stdout disappears the moment the step exits. You get the Playwright report but nothing from the services underneath it, which makes a failed run hard to triage. This PR:

- Redirects backend and frontend dev servers to `ci-logs/backend.log` and `ci-logs/frontend.log` under the workspace.
- Uploads `ci-logs/` as part of the existing failure-only artifact alongside the Playwright report, so logs and reports travel together.
- Removes the duplicated `E2E_USERNAME: admin` / `E2E_PASSWORD: password123` env blocks from the `e2e` and `update-screenshots` jobs. Those were already the fallback defaults in `e2e/helpers.ts` (`process.env.E2E_USERNAME ?? 'admin'`), so the blocks were no-ops on the default path and created two sources of truth. `helpers.ts` is now the sole canonical source.

## Implementation notes

- **Workspace-relative log paths:** `actions/upload-artifact@v4+` computes a common parent directory across all path entries. Mixing repo-relative paths (`e2e/report/`) with `/tmp/*.log` makes `/` the common root and v4+ silently strips the absolute entries from the artifact. Putting the logs under `${{ github.workspace }}/ci-logs` keeps the common root inside the workspace so everything uploads cleanly.
- **`stdbuf -oL -eL` on both services:** Node stdout is block-buffered when redirected to a regular file. A crash or abort can lose the final few hundred lines, which is exactly the output you need when debugging a CI failure. `stdbuf -oL -eL` forces line-buffered output so the file reflects the live state.
- **Override path preserved:** Callers that want non-default creds can still set `E2E_USERNAME` / `E2E_PASSWORD` as job-level env vars and `e2e/helpers.ts` picks them up via `process.env.E2E_USERNAME ?? ...`.

## Stacked on

This PR is stacked on #475 (supply-chain hardening), which adds the workflow-level ` permissions: contents: read ` default that this diff lives under. Merge order: #475 -> this PR. Base will retarget to main automatically once #475 merges.

## Test plan

- [ ] CI green on this branch
- [ ] Intentionally fail an E2E test in a draft PR; verify the uploaded ` playwright-report ` artifact now contains ` ci-logs/backend.log ` and ` ci-logs/frontend.log ` alongside the Playwright report
- [ ] Confirm the ` update-screenshots ` job (on the next release merge) still runs successfully after removing its hardcoded env block