### PR TITLE
ci: hard-fail PR and release scans on unacknowledged HIGH/CRITICAL CVEs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,26 @@
 **/dist
 .git
 .gitignore
+.DS_Store
+
+# Docs and non-runtime content. Not needed in the image, bloats build context.
 plans/
 Product Requirements Document
 *.md
-.DS_Store
+docs/
+website/
+
+# Tests and reports. Never shipped in the image.
+e2e/
+tests/
+test-results/
+playwright-report/
+
+# CI config runs on GitHub Actions, not inside the image.
+.github/
+
+# Secrets and key material. Defense in depth against accidental context leaks.
+.env
+.env.*
+*.key
+*.pem

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,15 +123,15 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Scan image for vulnerabilities (Trivy)
+        # Hard-fails the PR on any HIGH or CRITICAL finding that is not listed
+        # in .trivyignore at the repo root. To accept a CVE, add it to that
+        # file with a human-readable justification comment, not here.
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: sencho:pr-test
           exit-code: '1'
           severity: 'CRITICAL,HIGH'
           format: 'table'
-        # Findings surface as a visible warning on the job without blocking the PR.
-        # Base-image CVEs are often outside our control - review manually before ignoring.
-        continue-on-error: true
 
   # ---------------------------------------------------------------------------
   # E2E Tests (PRs only, skipped for release-please PRs)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default for every job. Individual jobs may override (e.g.
+# update-screenshots needs contents: write + pull-requests: write to open a PR).
+permissions:
+  contents: read
+
 # ---------------------------------------------------------------------------
 # Build & Validation (PRs only, skipped for release-please PRs)
 # ---------------------------------------------------------------------------
@@ -118,7 +123,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Scan image for vulnerabilities (Trivy)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: sencho:pr-test
           exit-code: '1'
@@ -195,7 +200,7 @@ jobs:
 
       - name: Open / update screenshots PR
         id: create-pr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.DOCS_REPO_TOKEN }}
           branch: chore/refresh-screenshots

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,6 +15,13 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # DOCKERHUB_USERNAME and DOCKERHUB_TOKEN live in the `production` environment,
+    # not repo-wide secrets. Any future workflow that tries to push to Docker Hub
+    # without declaring this environment will fail to resolve the credentials,
+    # which is exactly the blast-radius reduction we want. Adding a required
+    # reviewer to the environment in repo settings also turns every release into
+    # a manual-approval gate without any workflow change.
+    environment: production
     permissions:
       contents: read
       # Required for cosign keyless signing via GitHub OIDC.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,6 +17,8 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      # Required for cosign keyless signing via GitHub OIDC.
+      id-token: write
     steps:
       - name: Check out the repo
         uses: actions/checkout@v6
@@ -35,16 +37,27 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v6
         with:
           images: saelix/sencho
+          # On a v-tag push we publish:
+          #   latest           always points at the newest release
+          #   X.Y.Z            the immutable semver tag
+          #   X.Y              moving minor tag for users who want latest patch
+          # The pre-1.0 constraint hides the {{major}}-only tag until we ship 1.0,
+          # since on 0.x every minor is potentially breaking.
           tags: |
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -54,3 +67,32 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=saelix/sencho:buildcache
           cache-to: type=registry,ref=saelix/sencho:buildcache,mode=max
+          # SBOM + provenance attestations are embedded as OCI referrers on the
+          # published image. Inspect with: docker buildx imagetools inspect <img>
+          sbom: true
+          provenance: mode=max
+
+      - name: Sign published image with cosign (keyless)
+        # Signs every tag produced by metadata-action using the ambient GitHub
+        # OIDC token. No private keys, no secrets. Users verify with:
+        #   cosign verify saelix/sencho:<tag> \
+        #     --certificate-identity-regexp "https://github.com/AnsoCode/Sencho/.*" \
+        #     --certificate-oidc-issuer https://token.actions.githubusercontent.com
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          # Build a single cosign invocation with every tag pinned to the digest.
+          # All tags resolve to the same manifest, so one call signs them all and
+          # saves N-1 Rekor/Fulcio round trips. On workflow_dispatch $TAGS is empty
+          # and the refs array stays empty, so we no-op cleanly.
+          refs=()
+          while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            refs+=("${tag}@${DIGEST}")
+          done <<< "$TAGS"
+          if [ ${#refs[@]} -gt 0 ]; then
+            cosign sign --yes "${refs[@]}"
+          else
+            echo "No tags to sign (likely a workflow_dispatch run on a non-tag ref)."
+          fi

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,6 +15,8 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - name: Check out the repo
         uses: actions/checkout@v6

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -63,6 +63,39 @@ jobs:
             type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
+      # Build an amd64-only variant into the local daemon first so Trivy can
+      # scan the exact release artifact before it is tagged and pushed. This
+      # keeps vulnerable releases out of the `latest` and semver tags that
+      # users actually pull. The scan-build inherits layers from the shared
+      # buildcache so the amd64 leg of the subsequent push-build is mostly a
+      # cache hit; we intentionally do NOT write `cache-to` here because the
+      # push-build below writes a strictly better (multi-arch, mode=max)
+      # cache entry moments later. The tag lives in the `localhost/` namespace
+      # so a future `push: false` -> `push: true` mistake cannot publish it.
+      # Scanning only amd64 is a defensible proxy for the multi-arch release:
+      # distro package CVEs are arch-agnostic at the manifest level, and
+      # arch-specific container-relevant CVEs are extraordinarily rare.
+      - name: Build release image for pre-publish scan (amd64, loaded)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: false
+          load: true
+          platforms: linux/amd64
+          tags: localhost/sencho:release-scan
+          cache-from: type=registry,ref=saelix/sencho:buildcache
+
+      - name: Re-scan release image for vulnerabilities (Trivy)
+        # Gates the release on the same HIGH/CRITICAL policy as the PR scan.
+        # Entries in .trivyignore at the repo root are honored so the acknowledged
+        # CVE list is the single source of truth across PR CI and release CI.
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          image-ref: localhost/sencho:release-scan
+          exit-code: '1'
+          severity: 'CRITICAL,HIGH'
+          format: 'table'
+
       - name: Build and push Docker image
         id: build
         uses: docker/build-push-action@v7

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         with:
           # GITHUB_TOKEN cannot trigger other workflows (GitHub security restriction).
           # Using DOCS_REPO_TOKEN (PAT) ensures the tag push from release-please

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,20 @@
+# Trivy ignore list
+#
+# Every entry in this file is a known HIGH or CRITICAL CVE that we have
+# consciously accepted risk on and decided not to block CI over. Format:
+#
+#   CVE-YYYY-NNNNN
+#   # Justification: why we're accepting this risk, and a link or note about
+#   # when to revisit (e.g. "blocked on upstream base image update, revisit
+#   # when alpine/node:22 ships a fix").
+#
+# Rules:
+#   - Every CVE MUST have a justification comment directly above it.
+#   - If there is no justification, the CVE is not ignored - add it here only
+#     after a human review and a decision to accept the risk.
+#   - Review this file on every release; remove entries whose upstream fix has
+#     landed.
+#
+# Picked up automatically by aquasecurity/trivy-action from the repo root
+# working directory. Both the pre-push PR scan (.github/workflows/ci.yml) and
+# the release-time re-scan (.github/workflows/docker-publish.yml) honor it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Large payloads like `/api/templates` shrink roughly 5x on the wire, with
   Server-Sent Event streams explicitly excluded so real-time log tails and system
   metrics are not buffered.
+* **release:** sign every published Docker image with Sigstore cosign keyless
+  signing, and embed an SBOM plus SLSA provenance attestation as OCI referrers on
+  the image. Users can now independently verify that a pulled image came from the
+  official GitHub Actions build pipeline (see the new "Verifying Docker Images"
+  reference page in the docs). The release pipeline also publishes a new moving
+  minor tag `saelix/sencho:X.Y` alongside the existing `latest` and immutable
+  `X.Y.Z` tags, so operators who want the latest patch on a given minor line can
+  pin without chasing every release.
 
 ### Fixed
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -125,6 +125,7 @@
             "pages": [
               "features/node-compatibility",
               "reference/settings",
+              "reference/verifying-images",
               "reference/contact",
               "reference/security-advisories"
             ]

--- a/docs/reference/verifying-images.mdx
+++ b/docs/reference/verifying-images.mdx
@@ -1,0 +1,81 @@
+---
+title: Verifying Docker Images
+description: Verify that the Sencho image you pulled was built and signed by the official GitHub Actions pipeline.
+---
+
+Every published Sencho Docker image is signed by the official GitHub Actions pipeline using [Sigstore cosign](https://docs.sigstore.dev/) keyless signing. The signature is backed by a short-lived certificate issued by Sigstore's public Fulcio certificate authority, tied to the GitHub Actions workflow run that produced the image. You can verify this signature yourself before pulling the image into production.
+
+Every image also ships with an embedded SBOM (Software Bill of Materials) and [SLSA](https://slsa.dev) (Supply-chain Levels for Software Artifacts) provenance attestation, so you can inspect exactly what went into the image and which workflow run built it.
+
+<Note>
+  Image signing is available starting with Sencho **v0.43.0**. Earlier releases do not ship a cosign signature; running `cosign verify` against them will fail, which is expected and does not indicate tampering. If you are on an older version, the first step is to upgrade.
+</Note>
+
+## Why verify
+
+Verification guarantees:
+
+1. The image was built from the [AnsoCode/Sencho](https://github.com/AnsoCode/Sencho) repository on GitHub.
+2. The build ran inside a GitHub Actions workflow, not on someone's laptop.
+3. The image has not been tampered with between publish and pull.
+
+<Note>
+  Verification is optional. If you skip it, Sencho still works exactly the same; you are just trusting Docker Hub to deliver the right bytes. Verification adds a second independent check.
+</Note>
+
+## Install cosign
+
+[cosign](https://docs.sigstore.dev/system_config/installation/) is a single static binary. Install it once on any machine you use to pull Sencho.
+
+<CodeGroup>
+
+```bash macOS (Homebrew)
+brew install cosign
+```
+
+```bash Linux (binary)
+curl -Lo cosign https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64
+chmod +x cosign
+sudo mv cosign /usr/local/bin/
+```
+
+```bash Windows (Scoop)
+scoop install cosign
+```
+
+</CodeGroup>
+
+## Verify a released image
+
+Replace `<tag>` with the version you intend to pull, for example `0.42.7`, `0.42`, or `latest`.
+
+```bash
+cosign verify saelix/sencho:<tag> \
+  --certificate-identity-regexp "https://github.com/AnsoCode/Sencho/.*" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+A successful verification prints the signature, the Rekor transparency log entry, and the certificate that signed it. If the image is not signed by the official Sencho pipeline, the command exits with a non-zero status and you should not run that image.
+
+## Inspect the SBOM and provenance
+
+Both the SBOM and SLSA provenance are attached to the published image as [OCI referrers](https://docs.docker.com/build/attestations/attestation-storage/). You can inspect them with `docker buildx imagetools`:
+
+```bash
+docker buildx imagetools inspect saelix/sencho:<tag> --format "{{json .SBOM}}"
+docker buildx imagetools inspect saelix/sencho:<tag> --format "{{json .Provenance}}"
+```
+
+The SBOM lists every package baked into the image with versions and licenses. The provenance records the exact GitHub Actions workflow run, commit SHA, and builder that produced it.
+
+## Available tags
+
+Each release publishes two moving tags plus one immutable tag, so you can choose how aggressively you want to track updates:
+
+| Tag | Example | Updates on |
+|---|---|---|
+| `latest` | `saelix/sencho:latest` | Every release |
+| `X.Y` | `saelix/sencho:0.42` | Every patch release in the `0.42.x` line |
+| `X.Y.Z` | `saelix/sencho:0.42.7` | Never (immutable) |
+
+For production, pin to `X.Y.Z` or `X.Y` and verify the signature on every pull. For staging or development, `latest` is fine.


### PR DESCRIPTION
## Summary

Makes Trivy a real release gate instead of an advisory signal:

- **PR CI**: removes `continue-on-error: true` from the `docker-validate` Trivy step. Any HIGH/CRITICAL finding not in `.trivyignore` now fails the PR.
- **Release CI**: builds an amd64-only scan image into the local daemon before the multi-arch push-build, re-runs Trivy against that exact artifact, and only proceeds to the push if the scan passes. Closes the gap where a CVE can land between PR merge and release-time rebuild.
- Adds `.trivyignore` at repo root as the single source of truth for acknowledged CVEs. Both workflows auto-pick it up.

## Why amd64-only for the scan build

Distro package CVEs are arch-agnostic at the manifest level, and arch-specific container-relevant CVEs are extraordinarily rare. Scanning one arch is a defensible proxy for the multi-arch release and keeps the scan fast. The scan-build shares the `buildcache` layer cache with the subsequent push-build, so the amd64 leg of the push is mostly a cache hit.

The scan-build tag lives in the `localhost/` namespace so a future `push: false` to `push: true` mistake cannot accidentally publish the unscanned artifact to Docker Hub.

## `.trivyignore` bootstrapping

The file ships **empty** on purpose. The first CI run after merge will intentionally fail and surface the full HIGH/CRITICAL list from the current base image. We then populate `.trivyignore` with CVE IDs + justification comments in a follow-up commit on main, so the acknowledgement list is grounded in real findings rather than guessed up front.

## Stacking

This PR stacks on #477 (production environment gating). Rebase onto main after #477 merges.

## Test plan

- [ ] CI surfaces a clean list of unacknowledged HIGH/CRITICAL CVEs from the current base image on first run (expected failure).
- [ ] Follow-up commit populates `.trivyignore` with justifications; CI then passes.
- [ ] On a subsequent release run, the new pre-publish scan step executes before the build-push and honors `.trivyignore`.
- [ ] A synthetic CVE (temporarily adding a known-vulnerable package) fails both the PR job and the release job.