### PR TITLE
ci: capture backend and frontend logs for E2E failures

### DIFF
--- a/.github/actions/start-app/action.yml
+++ b/.github/actions/start-app/action.yml
@@ -47,13 +47,20 @@ runs:
       run: npm ci
       working-directory: ./frontend
 
-    - name: Create compose directory
+    - name: Create compose directory and log dir
       shell: bash
-      run: mkdir -p ${{ inputs.compose-dir }}
+      run: |
+        mkdir -p ${{ inputs.compose-dir }}
+        mkdir -p "${{ github.workspace }}/ci-logs"
 
+    # Log files live under $GITHUB_WORKSPACE so actions/upload-artifact@v4+ can
+    # include them alongside repo-relative paths like e2e/report/. Mixing those
+    # with /tmp paths makes '/' the common root and v4+ strips the absolute
+    # entries from the artifact. `stdbuf -oL -eL` forces line-buffered output
+    # so a crash doesn't lose the final few hundred lines to block buffering.
     - name: Start backend
       shell: bash
-      run: node dist/index.js &
+      run: stdbuf -oL -eL node dist/index.js > "${{ github.workspace }}/ci-logs/backend.log" 2>&1 &
       working-directory: ./backend
       env:
         JWT_SECRET: ${{ inputs.jwt-secret }}
@@ -63,7 +70,7 @@ runs:
 
     - name: Start frontend dev server
       shell: bash
-      run: npm run dev &
+      run: stdbuf -oL -eL npm run dev > "${{ github.workspace }}/ci-logs/frontend.log" 2>&1 &
       working-directory: ./frontend
 
     - name: Wait for services to be ready

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,11 +153,8 @@ jobs:
 
       - name: Run E2E tests
         run: npx playwright test
-        env:
-          E2E_USERNAME: admin
-          E2E_PASSWORD: password123
 
-      - name: Upload E2E report
+      - name: Upload E2E report and service logs
         if: failure()
         uses: actions/upload-artifact@v7
         with:
@@ -165,6 +162,7 @@ jobs:
           path: |
             e2e/report/
             test-results/
+            ci-logs/
           retention-days: 7
 
   # ---------------------------------------------------------------------------
@@ -194,9 +192,6 @@ jobs:
 
       - name: Capture screenshots
         run: npx playwright test e2e/screenshots.spec.ts --project=chromium
-        env:
-          E2E_USERNAME: admin
-          E2E_PASSWORD: password123
 
       - name: Open / update screenshots PR
         id: create-pr


### PR DESCRIPTION
## Summary

Closes and supersedes #478 (auto-closed during PR 1 merge).

When an E2E run flakes, the Playwright report tells you *what* failed but not *why*. This PR plumbs backend and frontend logs into the failure artifact so the next regression is investigable without re-running locally:

- Composite `start-app` action now redirects backend and frontend stdout+stderr to `\${{ github.workspace }}/ci-logs/backend.log` and `.../frontend.log`.
- Both services launch under `stdbuf -oL -eL` so a crash can't lose the final few hundred lines to block buffering.
- Log files live under `\$GITHUB_WORKSPACE` (not `/tmp`) so `actions/upload-artifact@v4+` keeps them in the artifact tree alongside `e2e/report/`. Mixing absolute and workspace-relative paths would make `/` the common root and silently strip the absolute entries.
- E2E job uploads `ci-logs/**` on failure alongside the Playwright report.
- Removes the redundant hardcoded `E2E_USERNAME` / `E2E_PASSWORD` env blocks. `e2e/helpers.ts:12-13` already has `process.env.E2E_USERNAME ?? 'admin'` fallbacks, so a single source of truth is cleaner.

## Test plan

- [ ] Break an E2E test in a draft PR; confirm the failure artifact contains both `backend.log` and `frontend.log`.
- [ ] Confirm log files capture the final lines before crash (stdbuf working).
- [ ] Confirm E2E tests still pass with the removed env blocks.