### PR TITLE
ci: gate docker-publish on `production` environment

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,6 +15,13 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # DOCKERHUB_USERNAME and DOCKERHUB_TOKEN live in the `production` environment,
+    # not repo-wide secrets. Any future workflow that tries to push to Docker Hub
+    # without declaring this environment will fail to resolve the credentials,
+    # which is exactly the blast-radius reduction we want. Adding a required
+    # reviewer to the environment in repo settings also turns every release into
+    # a manual-approval gate without any workflow change.
+    environment: production
     permissions:
       contents: read
       # Required for cosign keyless signing via GitHub OIDC.


### PR DESCRIPTION
## Summary

Closes and supersedes #477 (auto-closed when the stacked base branch merged).

Scopes `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` behind a GitHub Environment named `production`, and declares `environment: production` on the `push_to_registry` job in `docker-publish.yml`.

## Why

- **Blast-radius reduction**: any future workflow that tries to push to Docker Hub without declaring this environment will silently fail to resolve credentials. That's the exact property we want - new workflows cannot accidentally inherit release secrets.
- **Optional manual-approval gate**: adding a required reviewer to the environment in repo settings turns every release into a click-to-approve gate with zero workflow changes.

The secrets have already been moved into the `production` environment in repo settings. This PR is just the workflow declaration.

## Test plan

- [ ] Next release PR merge triggers docker-publish with the environment badge in the Actions UI.
- [ ] Credentials resolve correctly and the push succeeds.
- [ ] (Optional follow-up) Add a required reviewer to the environment and confirm the next release pauses for approval.