### PR TITLE
ci: smoke-test the release image before publishing

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -100,6 +100,34 @@ jobs:
           severity: 'CRITICAL,HIGH'
           format: 'table'
 
+      # Start the scanned image headless on the runner and poll /api/health
+      # until it returns 200. Catches entrypoint regressions, native module
+      # ABI breakage, and first-boot crashes on the exact artifact that the
+      # multi-arch push below will republish moments later. Intentionally
+      # placed BEFORE the publish step so a smoke failure does not move
+      # `latest` or the semver tags on Docker Hub. The health endpoint is
+      # public and returns before any DB or Docker-socket work, so the
+      # container only needs a free port, no env vars, and no volume mounts.
+      - name: Smoke test release image (pre-publish)
+        run: |
+          set -euo pipefail
+          # Not using --rm so that a crashed container sticks around long
+          # enough for `docker logs` in the trap to surface the stack trace.
+          # The trap force-removes it explicitly whether it is still running
+          # or already exited.
+          docker run -d --name sencho-smoke -p 3000:3000 localhost/sencho:release-scan
+          trap 'docker logs sencho-smoke 2>&1 || true; docker rm -f sencho-smoke >/dev/null 2>&1 || true' EXIT
+          for i in $(seq 1 30); do
+            if curl -fsS http://localhost:3000/api/health >/dev/null 2>&1; then
+              echo "Container healthy after ${i}s"
+              curl -s http://localhost:3000/api/health
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "FAILED: /api/health did not become ready within 30s"
+          exit 1
+
       - name: Build and push Docker image
         id: build
         uses: docker/build-push-action@v7


### PR DESCRIPTION
## Summary

Add a pre-publish smoke test to \`docker-publish.yml\` that starts the scanned release image headless on the runner and polls \`/api/health\` for up to 30 seconds. Catches entrypoint regressions, native module ABI breakage, and first-boot crashes on the exact artifact that the multi-arch push step will republish moments later.

## Design choices

**Placed before push-build, not after.** A post-publish smoke test would only tell us *after* \`latest\` and the semver tags had already moved on Docker Hub. Reusing the already-loaded \`localhost/sencho:release-scan\` image (the same artifact Trivy just scanned) validates *exactly* what is about to be pushed, and blocks the push entirely if it fails. No tags move, no cosign signature is produced, the release is held until a fix lands.

**No \`--rm\` on \`docker run\`.** With \`--rm\`, a crashed container is auto-removed the instant it exits, which makes \`docker logs\` in the cleanup trap return nothing for exactly the failure mode we care about. Dropped \`--rm\` and used an explicit \`docker rm -f\` in the EXIT trap after \`docker logs\`, so a crash boot still produces a full stack trace in the CI log.

**No env vars, no volume mounts.** \`/api/health\` is a public endpoint declared at \`backend/src/index.ts:499\` that returns before any DB query, JWT verification, or Docker socket call. A bare \`docker run -p 3000:3000\` is sufficient to prove the process booted and the HTTP server is accepting connections, which is all a smoke test needs to prove.

**Reuses the scanned image, not a fresh Docker Hub pull.** The plan originally called for pulling \`saelix/sencho:{{version}}\` from Docker Hub after push. Reusing the local scan image is strictly better: it is the same amd64 bytes (built in the same buildkit daemon), there is no pull round-trip, and critically it runs *before* publication so a failure cannot poison the release tags.

## Validation

\`docker-publish.yml\` only runs on tag push or \`workflow_dispatch\`, so PR CI does not exercise the new step. YAML parses cleanly (validated via \`yaml.parse\`). The script logic is a 20-line bash loop and is reviewable in full. The first real exercise happens on the next release tag.

## Test plan

- [ ] Merge this PR and wait for the next release-please Release PR.
- [ ] Merge the Release PR; watch \`docker-publish.yml\` and confirm the \"Smoke test release image (pre-publish)\" step runs, returns 200 from \`/api/health\`, and the subsequent push + sign + Trivy re-scan all complete successfully.
- [ ] (Negative case, deferred) In a future PR that intentionally breaks the entrypoint, confirm the smoke step fails and that \`docker logs\` output is visible in the failed CI log.