### PR TITLE
ci: reuse backend dist in E2E via upload/download-artifact

### DIFF
--- a/.github/actions/start-app/action.yml
+++ b/.github/actions/start-app/action.yml
@@ -14,6 +14,15 @@ inputs:
   port:
     required: false
     default: '3000'
+  skip-backend-build:
+    description: >
+      When 'true', skip running `npm run build` in backend/ and assume the
+      caller has already materialized backend/dist (e.g. via download-artifact
+      from an upstream job that already built and verified it). Leave 'false'
+      for standalone invocations like the update-screenshots job that do not
+      run in a job graph with a prior build step.
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -38,6 +47,7 @@ runs:
       working-directory: ./backend
 
     - name: Build backend
+      if: inputs.skip-backend-build != 'true'
       shell: bash
       run: npm run build
       working-directory: ./backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,17 @@ jobs:
         working-directory: ./backend
         run: npm audit --audit-level=high
 
+      # Hand the freshly-verified dist/ to the E2E job so it does not have to
+      # re-run `tsc` on the same source. retention-days is the minimum; this
+      # artifact is only needed for the downstream e2e job in the same run.
+      - name: Upload backend dist
+        uses: actions/upload-artifact@v7
+        with:
+          name: backend-dist
+          path: backend/dist
+          retention-days: 1
+          if-no-files-found: error
+
   frontend:
     name: Frontend (Build, Lint)
     runs-on: ubuntu-latest
@@ -158,8 +169,20 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
 
+      # Reuse the dist/ that the `backend` job produced and verified, instead
+      # of running `tsc` a second time against the same source tree. The
+      # composite action's `skip-backend-build` input short-circuits its build
+      # step when this artifact is already in place.
+      - name: Download backend dist
+        uses: actions/download-artifact@v7
+        with:
+          name: backend-dist
+          path: backend/dist
+
       - name: Start app & install Playwright
         uses: ./.github/actions/start-app
+        with:
+          skip-backend-build: 'true'
 
       - name: Run E2E tests
         run: npx playwright test


### PR DESCRIPTION
## Summary

The \`backend\` job compiles \`backend/src\` with \`tsc\` and only goes green after build, unit tests, lint, and audit all pass. The \`e2e\` job then checked out the same source and ran \`tsc\` a second time against it inside the \`start-app\` composite, producing an identical \`backend/dist/\`.

Stop double-building: upload \`backend/dist/\` from the backend job and download it in e2e before the composite runs.

## Changes

- \`ci.yml\` backend job: new \`Upload backend dist\` step after \`npm audit\` using \`actions/upload-artifact@v7\`, 1-day retention, \`if-no-files-found: error\` so a silent empty upload breaks the job loudly.
- \`start-app/action.yml\`: new \`skip-backend-build\` input (default \`false\`). When \`true\`, the \"Build backend\" step is gated off via \`if: inputs.skip-backend-build != 'true'\`.
- \`ci.yml\` e2e job: new \`Download backend dist\` step before \`start-app\`, then passes \`skip-backend-build: 'true'\` to the composite.
- \`update-screenshots\` job is unchanged. It uses the composite without setting the new input, so the default \`'false'\` applies and it continues to build backend from source (it runs on post-release pushes with no upstream backend job to inherit an artifact from).

## Expected impact

Wall-time savings are modest (~10-15s per E2E run on top of what \`setup-node\`'s \`~/.npm\` cache already buys). The bigger win is the contract: the exact bytes the backend job verified are now what E2E exercises, eliminating a class of \"works in backend job, drifts in e2e\" bugs.

## Test plan

- [ ] PR CI goes green end-to-end. The e2e job should show a \"Download backend dist\" step between checkout and start-app, and the composite's \"Build backend\" step should be skipped (rendered as a grey dot in the step list).
- [ ] Timing: confirm the e2e job is ~10-15s faster than recent runs.
- [ ] Next release cycle: confirm \`update-screenshots\` still builds backend from source (its composite invocation does not set the new input).