### PR TITLE
ci: cache Playwright browsers on ~/.cache/ms-playwright

### DIFF
--- a/.github/actions/start-app/action.yml
+++ b/.github/actions/start-app/action.yml
@@ -87,6 +87,33 @@ runs:
       shell: bash
       run: npx wait-on http://localhost:${{ inputs.port }}/api/health http://localhost:5173 --timeout 30000
 
-    - name: Install Playwright browsers
+    # Playwright bundles Chrome for Testing (~170MB) and FFmpeg. Downloading
+    # them on every E2E run is the single largest cost in this composite:
+    # observed ~4m15s cold vs ~10s warm when the path is cached. Cache the
+    # download under a key pinned to the @playwright/test version so a
+    # future bump invalidates automatically.
+    - name: Read Playwright version
+      id: playwright-version
       shell: bash
-      run: npx playwright install --with-deps chromium
+      run: |
+        version=$(node -p "require('./package.json').devDependencies['@playwright/test'].replace(/^[\^~]/, '')")
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
+    - name: Cache Playwright browsers
+      id: playwright-cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+    # OS deps are apt packages under /var, which actions/cache does not
+    # preserve, so they have to be reinstalled every run regardless of the
+    # browser cache state. It is fast (~10s).
+    - name: Install Playwright OS dependencies
+      shell: bash
+      run: npx playwright install-deps chromium
+
+    - name: Install Playwright browsers
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: npx playwright install chromium


### PR DESCRIPTION
## Summary

Cache the Playwright browser download (Chrome for Testing + Chrome Headless Shell + FFmpeg, ~170MB) under \`~/.cache/ms-playwright\` keyed on the \`@playwright/test\` version from \`package.json\`.

Empirical data from the E2E run on #488: the browser install step alone took **4m15s** when the cache was cold (timestamps 18:32:54 → 18:36:59). On warm runs it takes ~10s. That makes browser download the single largest cost in the \`start-app\` composite, and on cold runs it dominates the whole E2E job wall time.

## Implementation

Split the existing \`playwright install --with-deps chromium\` into two:

1. **\`playwright install-deps chromium\`** runs unconditionally. Apt packages under \`/var\` are not preserved by \`actions/cache\`, and the step is fast (~10s).
2. **\`playwright install chromium\`** runs only when the cache missed, gated on \`steps.playwright-cache.outputs.cache-hit != 'true'\`.

Cache key: \`playwright-\${{ runner.os }}-\${{ steps.playwright-version.outputs.version }}\`. A future \`@playwright/test\` bump invalidates automatically, so stale browsers can never be resurrected.

## Sharding (evaluated and rejected)

The original plan paired this PR with 2-way Playwright sharding. Running the numbers against observed timings:

| Scenario | Warm cache | Cold cache |
|---|---|---|
| Current (non-sharded) | ~2m20s wall, 2m20s minutes | ~6m30s wall, 6m30s minutes |
| 2-way sharded | ~2m15s wall, **~4m30s** minutes | ~6m10s wall, **~12m20s** minutes |

Sharding roughly doubles action minutes while saving only ~5s of warm wall time, because ~80s of per-shard setup dwarfs the ~30s of test time each shard would get. It only pays off when test time significantly exceeds setup time. Sencho has 12 tests in ~60s total, so sharding is a net loss today. Revisit if the suite grows past ~5 minutes of pure test time.

## Test plan

- [ ] First PR run will miss the cache (cold) and run both \`install-deps\` and \`install\`. Log should show a cache MISS line from \`actions/cache\`.
- [ ] Second run (force a no-op push or re-run this workflow after merge) will hit the cache and show a cache HIT. The \`Install Playwright browsers\` step should be grey/skipped. E2E wall time should drop by ~3 to 4 minutes compared to the cold run.
- [ ] Confirm the job still produces the Playwright report artifact on failure (no changes to that step).