### PR TITLE
ci: migrate DOCS_REPO_TOKEN to GitHub App installation tokens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,10 +225,24 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      # Mint a short-lived installation token for the `sencho-token-app`
+      # GitHub App. Reused by the checkout, PR creation, and auto-merge
+      # steps below so we make exactly one /app/installations token call.
+      - name: Generate GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: Sencho
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Checkout Code
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.DOCS_REPO_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Start app & install Playwright
         uses: ./.github/actions/start-app
@@ -240,7 +254,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.DOCS_REPO_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           branch: chore/refresh-screenshots
           commit-message: "docs: refresh screenshots"
           title: "docs: refresh screenshots"
@@ -251,7 +265,7 @@ jobs:
       - name: Auto-merge screenshots PR
         if: steps.create-pr.outputs.pull-request-number != ''
         env:
-          GH_TOKEN: ${{ secrets.DOCS_REPO_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} \
             --squash \
@@ -263,6 +277,21 @@ jobs:
     timeout-minutes: 5
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
+      # This job mirrors docs/ into the sibling sencho-docs repo. The token
+      # must therefore be scoped to `sencho-docs`, not the current repo, so
+      # we mint an installation token explicitly targeting that repo.
+      # Minted unconditionally so the step graph stays simple; the token
+      # auto-revokes on post-step even when the gate below is false.
+      - name: Generate GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: sencho-docs
+          permission-contents: write
+
       - name: Checkout Sencho repo
         uses: actions/checkout@v6
         with:
@@ -289,7 +318,7 @@ jobs:
       - name: Clone or init sencho-docs
         if: steps.detect.outputs.changed == 'true'
         env:
-          DOCS_TOKEN: ${{ secrets.DOCS_REPO_TOKEN }}
+          DOCS_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           rm -rf sencho-docs
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,11 +13,26 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # Mint a short-lived installation token for the `sencho-token-app`
+      # GitHub App instead of using a long-lived user PAT. The token:
+      #   - is scoped to this one repository (least privilege)
+      #   - requests only the permissions release-please actually needs
+      #   - is auto-revoked by the action's post step at job end
+      #   - unlike GITHUB_TOKEN, CAN trigger downstream workflow runs, so the
+      #     tag push from release-please still cascades to docker-publish.yml
+      - name: Generate GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: Sencho
+          permission-contents: write
+          permission-pull-requests: write
+
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         with:
-          # GITHUB_TOKEN cannot trigger other workflows (GitHub security restriction).
-          # Using DOCS_REPO_TOKEN (PAT) ensures the tag push from release-please
-          # cascades to docker-publish.yml and publishes to Docker Hub.
-          token: ${{ secrets.DOCS_REPO_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

Retire the long-lived \`DOCS_REPO_TOKEN\` PAT and replace it with short-lived installation tokens minted per-job from the \`sencho-token-app\` GitHub App (App ID \`3339708\`, owned by @AnsoCode, installed on both \`AnsoCode/Sencho\` and \`AnsoCode/sencho-docs\`).

## Why this is worth doing

The existing \`DOCS_REPO_TOKEN\` is a classic user-tied PAT. It works, but it is:

- **Scoped by accident**, not by design. A PAT carries every scope the minter gave it, not just the scope each job actually needs.
- **Long-lived.** A leak in a log line or artifact stays exploitable until someone notices and manually rotates it.
- **Tied to one human.** If the user who minted it leaves, rotates keys, or loses MFA, the entire release pipeline dies silently.

Installation tokens fix all three:

- **Scoped per-job to only the repos the job touches.** \`update-screenshots\` and \`release-please\` mint against \`Sencho\` only. \`sync-docs\` mints against \`sencho-docs\` only. No step has access to a repo it does not use.
- **Scoped per-job to only the permissions it needs.** Each mint requests \`permission-contents: write\` and (where relevant) \`permission-pull-requests: write\`. Nothing else.
- **Auto-revoked at job end.** The \`actions/create-github-app-token\` action's post-run step calls \`DELETE /installation/token\` so a leaked value is useful for at most the remainder of the current job.
- **Not tied to a human.** Lives as long as the App does.

Importantly, installation tokens (unlike \`GITHUB_TOKEN\`) **do** trigger downstream workflow runs. So the release-please tag push still cascades into \`docker-publish.yml\` exactly as before. This was the original reason \`DOCS_REPO_TOKEN\` existed in the first place, and the migration preserves that behavior.

## Changes

**\`release-please.yml\`** — one mint, passed to \`release-please-action\`:

\`\`\`yaml
- name: Generate GitHub App installation token
  id: app-token
  uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
  with:
    app-id: \${{ secrets.APP_ID }}
    private-key: \${{ secrets.APP_PRIVATE_KEY }}
    owner: \${{ github.repository_owner }}
    repositories: Sencho
    permission-contents: write
    permission-pull-requests: write
\`\`\`

**\`ci.yml update-screenshots\`** — one mint reused by checkout, \`peter-evans/create-pull-request\`, and the final \`gh pr merge\` step. Same permissions as release-please.

**\`ci.yml sync-docs\`** — one mint, but targeting \`sencho-docs\` instead of \`Sencho\`, with only \`permission-contents: write\`. The token is fed into the git clone URL as \`x-access-token\`, replacing the PAT in \`https://x-access-token:\${DOCS_TOKEN}@github.com/AnsoCode/sencho-docs.git\`.

\`actions/create-github-app-token\` is pinned to v3.0.0 at SHA \`f8d387b68d61c58ab83c6c016672934102569859\`, consistent with the SHA-pinning convention established in the supply-chain hardening PR.

## Test plan

- [ ] PR CI stays green. (Does not exercise the new token path since these jobs only run on \`push\` to main.)
- [ ] First merge to main after this PR lands: watch the \`sync-docs\` job log. On a push that touches \`docs/\`, it should print \"Cloned existing sencho-docs\" and push successfully. On a push that does not, it should skip the clone step entirely (gated by the existing \`detect\` step from #486).
- [ ] Next release cycle: watch \`release-please.yml\` open the Release PR under the App identity (commit author should be \`sencho-token-app[bot]\`), then merge the Release PR and confirm the tag push fires \`docker-publish.yml\`.
- [ ] Same release cycle: watch \`update-screenshots\` open the \`chore/refresh-screenshots\` PR under the App identity and auto-merge it.
- [ ] After the full release + docs-sync cycle validates, delete \`DOCS_REPO_TOKEN\` from repo secrets (in a follow-up) and confirm nothing breaks on the subsequent push.