### PR TITLE
docs(dockerfile): fix stale entrypoint comment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -186,7 +186,8 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
   CMD node -e "const h=require('http');h.get('http://localhost:3000/api/health',r=>{process.exit(r.statusCode===200?0:1)}).on('error',()=>process.exit(1))"
 
-# Entrypoint fixes volume ownership as root then drops to sencho via su-exec.
+# Entrypoint ensures /app/data is writable and execs the CMD as root by default,
+# or drops to $SENCHO_USER via su-exec when that env var is set (see comment above).
 # CMD provides the default arguments passed through to the entrypoint.
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## Summary

Follow-up to #501 (root-default refactor). A final audit found one stale comment next to the `ENTRYPOINT` directive in the `Dockerfile` that still described the old default behavior ("fixes volume ownership as root then drops to sencho via su-exec"), contradicting the updated explanatory block a few lines up.

Rewords the two-line comment to match the new default: exec the CMD as root, drop to `$SENCHO_USER` via `su-exec` only when that env var is set.

## Scope

- One file: `Dockerfile`
- Comment-only change; zero behavioral impact
- Image layer cache is not busted (only the comment inside the `ENTRYPOINT` block changes)

## Audit summary

Swept the whole repo for leftover non-root assumptions from the #501 refactor. This was the only gap found. Everything else is consistent with "root by default, `SENCHO_USER=sencho` is an opt-out":

- `docker-entrypoint.sh`: every `su-exec` / `sencho` / `drop privileges` mention is correctly inside the opt-out branch.
- `SelfUpdateService.ts:173`: `--user root` on the helper container spawn is intentional and correct under both modes.
- `FileSystemService.ts` + tests: no dangling references to the deleted `forceDeleteViaDocker`, no `sencho` user assumptions, no UID-checking code anywhere in the backend.
- All 40 `.mdx` pages under `docs/`: every "non-root" / "drop privileges" reference is correctly scoped to the `SENCHO_USER` opt-out.
- `README.md`, `docker-compose.yml`, `website/public/install.sh`, CI workflows: no user directives, no stale assumptions.

## Test plan

- [x] Grep sanity: `rg "drops to sencho"` returns zero hits after the edit.
- [x] Visual inspection: `Dockerfile:161-174` (root-default explanation) and `Dockerfile:189-191` (ENTRYPOINT comment) are now consistent.
- [ ] No rebuild or tests required; behavior is identical.