### PR TITLE
fix(app-store): handle orphaned stack directories on template deploy

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5687,10 +5687,17 @@ app.post('/api/templates/deploy', authMiddleware, async (req: Request, res: Resp
 
     try {
       await fsPromises.access(stackPath);
-      return res.status(409).json({
-        error: `A stack directory named '${stackName}' already exists. Please choose a different Stack Name.`,
-        rolledBack: false
-      });
+
+      if (await fsService.hasComposeFile(stackPath)) {
+        return res.status(409).json({
+          error: `A stack directory named '${stackName}' already exists. Please choose a different Stack Name.`,
+          rolledBack: false
+        });
+      }
+
+      // Orphaned directory left by external deletion (e.g. Docker Desktop).
+      console.log(`[Templates] Cleaned up orphaned stack directory: ${stackName}`);
+      await fsService.deleteStack(stackName);
     } catch {
       // Directory does not exist; proceed with deploy
     }

--- a/backend/src/services/FileSystemService.ts
+++ b/backend/src/services/FileSystemService.ts
@@ -34,7 +34,7 @@ export class FileSystemService {
     return new FileSystemService(nodeId);
   }
 
-  private async hasComposeFile(dir: string): Promise<boolean> {
+  async hasComposeFile(dir: string): Promise<boolean> {
     const composeFiles = ['compose.yaml', 'compose.yml', 'docker-compose.yaml', 'docker-compose.yml'];
     for (const file of composeFiles) {
       try {

--- a/docs/features/app-store.mdx
+++ b/docs/features/app-store.mdx
@@ -74,6 +74,8 @@ Below the template variables, an **Add Custom Variable** section lets you define
 
 A toast notification confirms success or shows the error message. Large images may take a few minutes to pull.
 
+If a previous stack with the same name was removed outside of Sencho (for example, through the Docker CLI or Docker Desktop), the leftover directory is cleaned up automatically and the deploy proceeds as normal.
+
 <Note>
   Deploying a template requires the `stack:create` permission. Users without this permission will see the Deploy button disabled.
 </Note>


### PR DESCRIPTION
## Summary

- When a stack is deployed via the App Store then deleted externally (e.g. Docker Desktop, CLI), the stack directory remains on disk without a compose file. The deploy endpoint previously rejected re-deploys with a 409 because the directory existed, even if empty.
- The endpoint now checks for a compose file before rejecting. Orphaned directories (no compose file) are cleaned up automatically and the deploy proceeds.
- Makes `FileSystemService.hasComposeFile` public to reuse the existing compose-file check instead of duplicating it.

## Test plan

- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] All 392 backend tests pass (`npm test`)
- [x] Verified orphaned directory is cleaned up and deploy succeeds (curl test with empty dir)
- [x] Verified real duplicate stack (with compose file) still returns 409
- [x] Code review (`/simplify`) completed, findings addressed