### PR TITLE
chore(deps): bump protobufjs transitive to patch GHSA-xq3m-2v4x-88gg

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -5965,9 +5965,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {


### PR DESCRIPTION
## Summary

`npm audit` now flags `protobufjs < 7.5.5` (transitive via `dockerode` → `@grpc/grpc-js` / `@grpc/proto-loader`) as a critical severity: [GHSA-xq3m-2v4x-88gg](https://github.com/advisories/GHSA-xq3m-2v4x-88gg), arbitrary code execution in `protobufjs`. This blocks the backend CI Audit Dependencies step on every open PR.

Fix is a transitive lockfile bump to `protobufjs@7.5.5`. No direct dependency changes, no API surface changes.

## Test plan

- [x] `npm audit --audit-level=high` reports 0 vulnerabilities
- [x] Backend unit tests still pass locally

## Notes

Scoped to a dedicated branch so it can land independently of in-flight feature/fix PRs that are blocked by the same audit gate.