### PR TITLE
chore(security): add diagnostic log to scan compare handler

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -8008,6 +8008,21 @@ app.get('/api/security/compare', authMiddleware, (req: Request, res: Response): 
   const added = applySuppressions(addedRaw, b.image_ref, suppressions);
   const removed = applySuppressions(removedRaw, a.image_ref, suppressions);
   const unchanged = applySuppressions(unchangedRaw, b.image_ref, suppressions);
+  if (isDebugEnabled()) {
+    console.log('[Compare:diag]', {
+      scanId1,
+      scanId2,
+      reqNodeId: req.nodeId,
+      tier: req.proxyTier ?? LicenseService.getInstance().getTier(),
+      aVulns: aVulns.length,
+      bVulns: bVulns.length,
+      added: added.length,
+      removed: removed.length,
+      unchanged: unchanged.length,
+      suppressions: suppressions.length,
+      truncated,
+    });
+  }
   res.json({
     scanA: {
       id: a.id,


### PR DESCRIPTION
## Summary

- Add an `isDebugEnabled()`-gated `[Compare:diag]` entry in the `/api/security/compare` handler. Logs scan ids, request-scoped node id, effective tier (honoring the proxy header), input vuln counts, added/removed/unchanged sizes, suppression count, and the truncation flag.
- Reuses the existing Developer Mode debug switch and the `proxyTier` already resolved by auth middleware; no new env vars, no hot-path work.

## Test plan

- [x] Backend `npm test` (12 scan-compare tests green, full typecheck clean).
- [x] Log is only emitted when `developer_mode=true`. No secrets or row-level data in the payload.

## Notes

Addresses finding M-2 from the scan-comparison audit.