### PR TITLE
docs(security): troubleshooting entries for scan comparison

### DIFF
--- a/docs/features/vulnerability-scanning.mdx
+++ b/docs/features/vulnerability-scanning.mdx
@@ -260,7 +260,9 @@ The comparison sheet shows:
 - Filter pills to switch between **Added** (new findings since the baseline), **Removed** (resolved findings), and **Unchanged** (findings present in both).
 - A sorted table of CVEs with severity, affected package, and direct links to Trivy's primary URL when available.
 
-Cross-image comparisons (picking scans from two different image references) are allowed but flagged with a warning, since package-level changes may reflect image differences rather than CVE drift.
+Comparisons are scoped to a single node; scans taken on different nodes cannot be compared against each other.
+
+Cross-image comparisons (picking scans from two different image references) are allowed but flagged with a warning, since package-level changes may reflect image differences rather than CVE drift. In that mode, the **Unchanged** pill is relabeled to **Shared** to reflect that same CVE + package matches across different images are not necessarily the same finding.
 
 Up to 1000 findings per scan are loaded for comparison. When a scan exceeds this limit, the sheet shows a banner indicating the comparison may be incomplete.
 
@@ -308,7 +310,18 @@ When a post-deploy scan fails for a specific image (for example because Trivy co
 
 ### Compare button is disabled
 
-Two completed scans are required to run a comparison. If you have only one scan for an image, trigger a second scan from the Resources Hub (or wait for a scheduled scan), then return to the Scan history page and tick both.
+Scan comparison is a Skipper feature; on Community, the Compare button stays disabled with a tooltip explaining the upgrade path. If your license is Skipper or Admiral, make sure you have ticked exactly two completed scans: selecting zero, one, or three scans leaves the button disabled. If you have only one scan for an image, trigger a second scan from the Resources Hub (or wait for a scheduled scan), then return to the Scan history page and tick both.
+
+### Comparison shows unexpected results
+
+Two common causes:
+
+- **Cross-image comparison.** If the Baseline and Current rows at the top of the sheet point at different image references, the warning banner is shown and the "Unchanged" pill is labeled "Shared". Items in that bucket match on CVE + package name but may not be the same finding across two distinct images. Stick to scans of the same image reference for apples-to-apples drift analysis.
+- **Truncated scans.** When either scan has more than 1000 stored findings, the sheet shows a truncation banner. In that case, items past the 1000-row cap do not contribute to the Added / Removed / Unchanged buckets and the totals may be misleading. Re-run the scan with a tighter image (or scope the investigation to the most severe findings) to avoid truncation.
+
+### An older scan is missing from Scan history
+
+The Scan history page uses server-driven pagination. If you know the scan exists but cannot see it, use the search box to filter by image reference, or page forward with the arrows in the card header. Scans older than 90 days are pruned automatically to keep the database compact.
 
 ### Scan policies are missing on one of my nodes
 


### PR DESCRIPTION
## Summary

- Document that scan comparisons are scoped to a single node.
- Note the cross-image \"Unchanged\" -> \"Shared\" relabeling and its rationale.
- Add three troubleshooting entries: Compare button disabled (tier + selection count), Comparison shows unexpected results (cross-image and truncation), Older scan missing from Scan history (server-driven pagination + 90-day pruning).

## Test plan

- [x] Reviewed rendered prose; no em dashes, no legacy-version phrasing.

## Notes

Addresses finding M-3 from the scan-comparison audit.