### PR TITLE
chore(security): a11y polish on scan comparison and history

### DIFF
--- a/frontend/src/components/ResourcesView.tsx
+++ b/frontend/src/components/ResourcesView.tsx
@@ -721,6 +721,7 @@ export default function ResourcesView() {
                             }));
                         }}
                         title="View completed vulnerability scans and compare them"
+                        aria-label="Open scan history"
                     >
                         <History className="w-4 h-4 mr-2" strokeWidth={1.5} />
                         Scan history

--- a/frontend/src/components/ScanComparisonSheet.tsx
+++ b/frontend/src/components/ScanComparisonSheet.tsx
@@ -246,17 +246,21 @@ export function ScanComparisonSheet({
                 Unchanged ({data.unchanged.length})
               </Button>
               {needsPagination && (
-                <div className="flex items-center gap-1 ml-auto">
+                <div className="flex items-center gap-1 ml-auto" aria-live="polite">
                   <Button
                     variant="ghost"
                     size="icon"
                     className="h-6 w-6"
                     onClick={() => setPage(Math.max(0, safePage - 1))}
                     disabled={safePage === 0}
+                    aria-label="Previous page"
                   >
                     <ChevronLeft className="w-4 h-4" strokeWidth={1.5} />
                   </Button>
-                  <span className="text-xs font-mono tabular-nums text-stat-subtitle min-w-[3rem] text-center">
+                  <span
+                    className="text-xs font-mono tabular-nums text-stat-subtitle min-w-[3rem] text-center"
+                    aria-label={`Page ${safePage + 1} of ${totalPages}`}
+                  >
                     {safePage + 1} / {totalPages}
                   </span>
                   <Button
@@ -265,6 +269,7 @@ export function ScanComparisonSheet({
                     className="h-6 w-6"
                     onClick={() => setPage(Math.min(totalPages - 1, safePage + 1))}
                     disabled={safePage >= totalPages - 1}
+                    aria-label="Next page"
                   >
                     <ChevronRight className="w-4 h-4" strokeWidth={1.5} />
                   </Button>

--- a/frontend/src/components/SecurityHistoryView.tsx
+++ b/frontend/src/components/SecurityHistoryView.tsx
@@ -192,17 +192,21 @@ export function SecurityHistoryView() {
               />
             </div>
             {needsPagination && (
-              <div className="flex items-center gap-1 ml-auto">
+              <div className="flex items-center gap-1 ml-auto" aria-live="polite">
                 <Button
                   variant="ghost"
                   size="icon"
                   className="h-6 w-6"
                   onClick={() => setPage(Math.max(0, safePage - 1))}
                   disabled={safePage === 0}
+                  aria-label="Previous page"
                 >
                   <ChevronLeft className="w-4 h-4" strokeWidth={1.5} />
                 </Button>
-                <span className="text-xs font-mono tabular-nums text-stat-subtitle min-w-[3rem] text-center">
+                <span
+                  className="text-xs font-mono tabular-nums text-stat-subtitle min-w-[3rem] text-center"
+                  aria-label={`Page ${safePage + 1} of ${totalPages}`}
+                >
                   {safePage + 1} / {totalPages}
                 </span>
                 <Button
@@ -211,6 +215,7 @@ export function SecurityHistoryView() {
                   className="h-6 w-6"
                   onClick={() => setPage(Math.min(totalPages - 1, safePage + 1))}
                   disabled={safePage >= totalPages - 1}
+                  aria-label="Next page"
                 >
                   <ChevronRight className="w-4 h-4" strokeWidth={1.5} />
                 </Button>


### PR DESCRIPTION
## Summary

- Add `aria-label=\"Open scan history\"` to the Scan history entry button in the Resources Hub.
- Add `aria-label` to the pagination chevrons (\"Previous page\" / \"Next page\") on both the ScanComparisonSheet and SecurityHistoryView pagers.
- Add `aria-label=\"Page X of Y\"` on the page indicator span and `aria-live=\"polite\"` on its container so screen readers announce context when paging.

## Test plan

- [x] `npm test` (frontend) green.
- [x] `npx tsc -b --noEmit` clean.

## Notes

Addresses finding L-2 from the scan-comparison audit. No visual change.