### PR TITLE
chore: add .worktrees to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ plans/
 CLAUDE.md
 MANUAL_STEPS.md
 docs/superpowers/
+.worktrees/
 
 # Playwright MCP
 .playwright-mcp/


### PR DESCRIPTION
## Summary
- Adds `.worktrees/` to `.gitignore` so git worktrees created for feature branches are not tracked

## Test plan
- [ ] Verify `.worktrees/` directory is not shown in `git status` after creating a worktree