### PR TITLE
feat(design-system): adopt cyan as data color and add Instrument Serif

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,7 +8,7 @@
   <title>Sencho</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&family=Instrument+Serif:ital,wght@0,400;1,400&display=swap" rel="stylesheet" />
   <script src="/theme-init.js"></script>
 </head>
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -50,12 +50,16 @@
   --info-muted: oklch(0.62 0.14 250 / 0.12);
   --destructive-muted: oklch(0.63 0.19 23 / 0.12);
 
-  /* Charts */
-  --chart-1: oklch(0.8100 0.1700 75.3500);
-  --chart-2: oklch(0.5500 0.2200 264.5300);
-  --chart-3: oklch(0.7200 0 0);
-  --chart-4: oklch(0.9200 0 0);
-  --chart-5: oklch(0.5600 0 0);
+  /* Charts — cyan leads as the primary data color, amber for peaks, rose for errors */
+  --chart-1: var(--brand);
+  --chart-2: var(--warning);
+  --chart-3: var(--destructive);
+  --chart-4: oklch(0.70 0 0);
+  --chart-5: oklch(0.45 0 0);
+
+  /* Sparkline / data-line styling (centralized) */
+  --data-line-width: 1.25px;
+  --data-peak: var(--warning);
 
   /* Sidebar */
   --sidebar: oklch(0.98 0 0 / 0.80);
@@ -78,7 +82,7 @@
   --card-border-top: oklch(0 0 0 / 0.12);
   --card-border-hover: oklch(0 0 0 / 0.15);
 
-  /* Label palette */
+  /* Label palette — ten raw hues preserved for existing assignments */
   --label-teal: oklch(0.55 0.12 192);
   --label-teal-bg: oklch(0.55 0.12 192 / 0.12);
   --label-blue: oklch(0.55 0.14 250);
@@ -100,13 +104,26 @@
   --label-slate: oklch(0.50 0.01 250);
   --label-slate-bg: oklch(0.50 0.01 250 / 0.12);
 
+  /* Semantic label roles — new labels should consume these */
+  --label-env: var(--label-teal);
+  --label-env-bg: var(--label-teal-bg);
+  --label-role: var(--label-blue);
+  --label-role-bg: var(--label-blue-bg);
+  --label-owner: var(--label-green);
+  --label-owner-bg: var(--label-green-bg);
+  --label-risk: var(--label-rose);
+  --label-risk-bg: var(--label-rose-bg);
+  --label-custom: var(--label-amber);
+  --label-custom-bg: var(--label-amber-bg);
+
   /* Chart grid & axis */
   --chart-grid: oklch(0 0 0 / 0.06);
   --chart-tick: oklch(0 0 0 / 0.45);
 
   /* Typography */
   --font-sans: 'Geist', sans-serif;
-  --font-serif: Georgia, serif;
+  --font-serif: 'Instrument Serif', Georgia, serif;
+  --font-display: 'Instrument Serif', Georgia, serif;
   --font-mono: 'Geist Mono', monospace;
 
   /* Shape */
@@ -197,12 +214,16 @@
   --info-muted: oklch(0.70 0.14 250 / 0.15);
   --destructive-muted: oklch(0.69 0.20 24 / 0.15);
 
-  /* Charts — monochrome blue/teal */
-  --chart-1: oklch(0.72 0.08 220);
-  --chart-2: oklch(0.65 0.08 220);
-  --chart-3: oklch(0.56 0 0);
-  --chart-4: oklch(0.44 0 0);
-  --chart-5: oklch(0.92 0 0);
+  /* Charts — cyan leads as the primary data color, amber for peaks, rose for errors */
+  --chart-1: var(--brand);
+  --chart-2: var(--warning);
+  --chart-3: var(--destructive);
+  --chart-4: oklch(0.55 0 0);
+  --chart-5: oklch(0.80 0 0);
+
+  /* Sparkline / data-line styling (centralized) */
+  --data-line-width: 1.25px;
+  --data-peak: var(--warning);
 
   /* Sidebar */
   --sidebar: oklch(0.08 0 0 / 0.80);
@@ -225,7 +246,7 @@
   --card-border-top: oklch(1 0 0 / 0.14);
   --card-border-hover: oklch(1 0 0 / 0.14);
 
-  /* Label palette */
+  /* Label palette — ten raw hues preserved for existing assignments */
   --label-teal: oklch(0.75 0.10 192);
   --label-teal-bg: oklch(0.75 0.10 192 / 0.15);
   --label-blue: oklch(0.72 0.12 250);
@@ -247,13 +268,26 @@
   --label-slate: oklch(0.65 0.01 250);
   --label-slate-bg: oklch(0.65 0.01 250 / 0.15);
 
+  /* Semantic label roles — new labels should consume these */
+  --label-env: var(--label-teal);
+  --label-env-bg: var(--label-teal-bg);
+  --label-role: var(--label-blue);
+  --label-role-bg: var(--label-blue-bg);
+  --label-owner: var(--label-green);
+  --label-owner-bg: var(--label-green-bg);
+  --label-risk: var(--label-rose);
+  --label-risk-bg: var(--label-rose-bg);
+  --label-custom: var(--label-amber);
+  --label-custom-bg: var(--label-amber-bg);
+
   /* Chart grid & axis */
   --chart-grid: oklch(1 0 0 / 0.05);
   --chart-tick: oklch(1 0 0 / 0.40);
 
   /* Typography */
   --font-sans: 'Geist', sans-serif;
-  --font-serif: Georgia, serif;
+  --font-serif: 'Instrument Serif', Georgia, serif;
+  --font-display: 'Instrument Serif', Georgia, serif;
   --font-mono: 'Geist Mono', monospace;
 
   /* Shape */
@@ -354,6 +388,7 @@
   --font-sans: var(--font-sans);
   --font-mono: var(--font-mono);
   --font-serif: var(--font-serif);
+  --font-display: var(--font-display);
 
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);


### PR DESCRIPTION
## Summary

First step of a multi-PR design refresh. This PR is deliberately contained to CSS tokens and the font import so later view-level PRs can cascade through without re-deriving every value.

- Repoint `--chart-1..3` to `--brand` / `--warning` / `--destructive` so cyan becomes the primary data color, amber the peak color, and rose the error color. `--chart-4/5` become neutral greyscale.
- Add `--data-line-width` (1.25px) and `--data-peak` so sparklines across the app share one sparkline spec instead of each component re-deriving stroke / peak styling.
- Introduce five semantic label role aliases (`--label-env`, `--label-role`, `--label-owner`, `--label-risk`, `--label-custom`) mapped onto existing hues. The raw ten-hue tokens stay in place for back-compat; new label assignments should consume roles.
- Replace Georgia serif with Instrument Serif and add `--font-display` alias in both `:root` and `.dark`. Expose `font-display` through the Tailwind `@theme inline` block so utility classes can use it. Load the family from Google Fonts alongside Geist and Geist Mono.

No component files are rewritten here — downstream views in follow-up PRs pick up the new tokens automatically.

## Test plan

- [ ] Dashboard renders without regressions (existing chart consumers now show cyan for CPU and amber for RAM via the token cascade — intentional).
- [ ] `getComputedStyle(document.documentElement)` returns the expected values for `--chart-1..5`, `--data-line-width`, `--data-peak`, `--font-display`, and the five label-role tokens in both light and dark themes.
- [ ] Instrument Serif italic loads from Google Fonts and `document.fonts.check('italic 48px "Instrument Serif"')` returns true after the first use on the page.
- [ ] `npx tsc -b --noEmit` in `frontend/` passes.

## Notes

- Subsequent PRs will refine `HistoricalCharts`, introduce the dashboard masthead, and consume the new display token and sparkline spec directly.