### PR TITLE
fix(dashboard): remove peak indicator dot from CPU sparkline

### DIFF
--- a/frontend/src/components/dashboard/ResourceGauges.tsx
+++ b/frontend/src/components/dashboard/ResourceGauges.tsx
@@ -88,8 +88,7 @@ export function ResourceGauges({ systemStats, cpuHistory, netHistory, historyEnd
             points={cpuHistory}
             stroke="var(--chart-1)"
             fill="var(--chart-1)"
-            peakColor="var(--chart-2)"
-            peakIndex={cpuPeakIndex >= 0 ? cpuPeakIndex : undefined}
+            showPeak={false}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Disable the peak indicator dot on the CPU sparkline in the dashboard `ResourceGauges` tile.
- The textual peak label above the chart (`avg X% last 10m · peak Y% @ HH:MM`) is preserved, so the peak value is still surfaced; only the visual dot on the line is removed.

## Test plan
- [x] Open the dashboard and confirm the CPU tile sparkline renders with no peak dot.
- [x] Confirm the textual `peak Y% @ HH:MM` label still appears under the CPU value.
- [x] Confirm the network sparkline (which already had no peak dot) is unchanged.

## Notes
- Implemented by replacing `peakColor` + `peakIndex` props on the CPU `Sparkline` with `showPeak={false}`. The `Sparkline` component already supports this and the network sparkline uses the same idiom.
- `cpuPeak`, `cpuPeakIndex`, and `cpuPeakLabel` are still computed because they feed the textual peak label.