### PR TITLE
fix(sidebar): distinct fuchsia notification dot for update indicator

### DIFF
--- a/docs/features/multi-node.mdx
+++ b/docs/features/multi-node.mdx
@@ -77,7 +77,7 @@ The Nodes table surfaces scheduling and update status at a glance for each node:
 | Column | What it shows |
 |--------|---------------|
 | **Schedules** | Number of active scheduled tasks targeting this node, plus a relative countdown to the next run (e.g. "next 2h") |
-| **Updates** | Whether auto-update policies are enabled ("Auto" badge), and how many stacks have pending image updates (pulsing blue dot with count) |
+| **Updates** | Whether auto-update policies are enabled ("Auto" badge), and how many stacks have pending image updates (fuchsia notification dot with expanding halo and a count) |
 
 Click the **calendar icon** on any node row to jump directly to the Schedules view filtered to that node. From there you can create, edit, or manage scheduled tasks scoped to the selected node. The filter bar shows which node you are viewing, with a **Clear filter** button to return to the full list.
 

--- a/frontend/src/components/NodeManager.tsx
+++ b/frontend/src/components/NodeManager.tsx
@@ -602,8 +602,11 @@ export function NodeManager() {
                         )}
                         {(summary?.stacks_with_updates ?? 0) > 0 && (
                           <span className="flex items-center gap-1">
-                            <span className="w-2 h-2 rounded-full bg-info animate-pulse" />
-                            <span className="font-mono text-xs tabular-nums tracking-tight text-info">
+                            <span className="relative inline-flex w-2 h-2 shrink-0">
+                              <span className="absolute inset-0 rounded-full bg-update opacity-75 animate-ping" />
+                              <span className="relative w-2 h-2 rounded-full bg-update" />
+                            </span>
+                            <span className="font-mono text-xs tabular-nums tracking-tight text-update">
                               {summary!.stacks_with_updates}
                             </span>
                           </span>

--- a/frontend/src/components/sidebar/StackRow.tsx
+++ b/frontend/src/components/sidebar/StackRow.tsx
@@ -72,7 +72,12 @@ export function StackRow(props: StackRowProps) {
       )}
       {hasUpdate && (
         <RowTooltip
-          trigger={<span className="w-2 h-2 rounded-full bg-info animate-pulse" />}
+          trigger={(
+            <span className="relative inline-flex w-2 h-2 shrink-0">
+              <span className="absolute inset-0 rounded-full bg-update opacity-75 animate-ping" />
+              <span className="relative w-2 h-2 rounded-full bg-update" />
+            </span>
+          )}
           label="Update available"
         />
       )}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -48,6 +48,9 @@
   --info: oklch(0.62 0.14 250);
   --info-foreground: oklch(1 0 0);
   --info-muted: oklch(0.62 0.14 250 / 0.12);
+  --update: oklch(0.62 0.22 320);
+  --update-foreground: oklch(1 0 0);
+  --update-muted: oklch(0.62 0.22 320 / 0.12);
   --destructive-muted: oklch(0.63 0.19 23 / 0.12);
 
   /* Charts — cyan leads as the primary data color, amber for peaks, rose for errors */
@@ -221,6 +224,9 @@
   --info: oklch(0.70 0.14 250);
   --info-foreground: oklch(0.10 0 0);
   --info-muted: oklch(0.70 0.14 250 / 0.15);
+  --update: oklch(0.72 0.20 320);
+  --update-foreground: oklch(0.10 0 0);
+  --update-muted: oklch(0.72 0.20 320 / 0.15);
   --destructive-muted: oklch(0.69 0.20 24 / 0.15);
 
   /* Charts — cyan leads as the primary data color, amber for peaks, rose for errors */
@@ -393,6 +399,9 @@
   --color-info: var(--info);
   --color-info-foreground: var(--info-foreground);
   --color-info-muted: var(--info-muted);
+  --color-update: var(--update);
+  --color-update-foreground: var(--update-foreground);
+  --color-update-muted: var(--update-muted);
   --color-destructive-muted: var(--destructive-muted);
 
   --font-sans: var(--font-sans);


### PR DESCRIPTION
## Summary

- The sidebar's "update available" pulsing dot used the `--info` token (blue hue 250), which is the exact same hue as the `--label-blue` label color. When a stack carried a blue label, the two read as one continuous color cluster and the update signal disappeared into the labels.
- Introduces a dedicated `--update` design token (vibrant fuchsia, hue 320) that sits in the gap between `--label-purple` (300) and `--label-pink` (340) and is also distinct from every other status token (`--info`, `--success`, `--warning`, `--destructive`).
- Switches the indicator to a notification-dot pattern: a solid stationary core with an `animate-ping` halo expanding outward. The halo is decorative; the core dot stays static, which aligns with the existing design rule that pulsing motion belongs to live streams while static state means "last known."
- Same change applied to the fleet `NodeManager` row indicator (the count of stacks with available updates) so the visual language is consistent across surfaces.
- Tooltip copy ("Update available") and surrounding layout footprint are preserved; only the dot's styling changes.

## Files

- `frontend/src/index.css` - new `--update` / `--update-foreground` / `--update-muted` tokens for light + dark, plus `--color-update*` Tailwind v4 wiring
- `frontend/src/components/sidebar/StackRow.tsx` - sidebar dot
- `frontend/src/components/NodeManager.tsx` - fleet row dot + count text
- `docs/features/multi-node.mdx` - copy update for the Updates column

## Test plan

- [x] `tsc -b --noEmit` passes for frontend
- [x] Verified `bg-update` Tailwind utility resolves to `oklch(0.72 0.20 320)` in dark theme and `oklch(0.62 0.22 320)` in light theme
- [x] Confirmed in browser that the new dot is visually distinct when adjacent to blue, purple, and pink label dots on the same row
- [x] Confirmed the `animate-ping` halo expands outward (scale 1->2, opacity 0.75->0 at 1Hz) while the solid core stays in place
- [x] Layout footprint preserved (8px box, no shift in kebab/git-pending icon positions)
- [x] Hover tooltip "Update available" still appears on the sidebar dot