### PR TITLE
fix(ui): raise toast z-index above dialog overlays

### DIFF
--- a/frontend/src/components/ui/toast.tsx
+++ b/frontend/src/components/ui/toast.tsx
@@ -204,7 +204,7 @@ export function ToastContainer() {
   const visible = toasts.slice(-MAX_VISIBLE);
 
   return createPortal(
-    <div className="pointer-events-none fixed bottom-4 right-4 z-50 flex w-full max-w-sm flex-col gap-2 p-4">
+    <div className="pointer-events-none fixed bottom-4 right-4 z-[200] flex w-full max-w-sm flex-col gap-2 p-4">
       <AnimatePresence mode="popLayout">
         {visible.map((t) => (
           <ToastItem key={t.id} {...t} />


### PR DESCRIPTION
## Summary

- Toast notifications were rendering behind modal dialogs (Settings Hub, and any Radix Dialog) because both used `z-50` (z-index: 50). The dialog portal is appended to `<body>` after the toast portal, so it painted on top at the same z-level.
- Bumped the `ToastContainer` wrapper from `z-50` to `z-[200]` so toasts always appear above all Radix overlays regardless of DOM order.

## Test plan

- [x] Open Settings Hub, trigger an error toast (e.g. submit empty password form) — toast appears on top of the dialog and backdrop blur
- [x] Close Settings Hub — toasts still render correctly with no visual regression
- [x] `cd frontend && npx tsc -b --noEmit` passes with zero errors