### PR TITLE
feat(notifications): add per-node filter and 60s refetch safety net

### DIFF
--- a/frontend/src/components/EditorLayout.tsx
+++ b/frontend/src/components/EditorLayout.tsx
@@ -817,6 +817,17 @@ export default function EditorLayout() {
     }
   };
 
+  // Safety-net poll: reconciles the list every 60s so events missed during a
+  // WebSocket reconnect backoff still appear without a manual refresh. The ref
+  // indirection keeps the interval pinned to the latest closure even though
+  // fetchNotifications is redefined on every render.
+  const fetchNotificationsRef = useRef(fetchNotifications);
+  fetchNotificationsRef.current = fetchNotifications;
+  useEffect(() => {
+    const id = setInterval(() => { fetchNotificationsRef.current(); }, 60_000);
+    return () => clearInterval(id);
+  }, []);
+
   const fetchImageUpdates = async () => {
     try {
       const res = await apiFetch('/image-updates');

--- a/frontend/src/components/NotificationPanel.tsx
+++ b/frontend/src/components/NotificationPanel.tsx
@@ -12,11 +12,20 @@ import type { LucideIcon } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { SegmentedControl } from '@/components/ui/segmented-control';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
 import { cn } from '@/lib/utils';
 import type { NotificationItem } from './dashboard/types';
 import type { Node } from '@/context/NodeContext';
 
+const NODE_FILTER_ALL = 'all' as const;
 type NotifFilter = 'all' | 'unread' | 'alerts';
+type NodeFilter = typeof NODE_FILTER_ALL | number;
 
 type LevelConfig = {
     icon: LucideIcon;
@@ -77,10 +86,16 @@ function formatRelative(ms: number): string {
     return new Date(ms).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 }
 
-function applyFilter(items: NotificationItem[], filter: NotifFilter): NotificationItem[] {
-    if (filter === 'unread') return items.filter((n) => !n.is_read);
-    if (filter === 'alerts') return items.filter((n) => n.level === 'warning' || n.level === 'error');
-    return items;
+function applyFilter(
+    items: NotificationItem[],
+    filter: NotifFilter,
+    nodeFilter: NodeFilter,
+): NotificationItem[] {
+    let result = items;
+    if (filter === 'unread') result = result.filter((n) => !n.is_read);
+    else if (filter === 'alerts') result = result.filter((n) => n.level === 'warning' || n.level === 'error');
+    if (nodeFilter !== NODE_FILTER_ALL) result = result.filter((n) => n.nodeId === nodeFilter);
+    return result;
 }
 
 interface NotificationPanelProps {
@@ -101,6 +116,7 @@ export function NotificationPanel({
     onNavigate,
 }: NotificationPanelProps) {
     const [filter, setFilter] = useState<NotifFilter>('all');
+    const [nodeFilter, setNodeFilter] = useState<NodeFilter>(NODE_FILTER_ALL);
     const [open, setOpen] = useState(false);
 
     const unreadCount = useMemo(
@@ -114,7 +130,20 @@ export function NotificationPanel({
         return ids;
     }, [nodes]);
 
-    const filtered = useMemo(() => applyFilter(notifications, filter), [notifications, filter]);
+    const showNodeFilter = nodes.length > 1;
+
+    // Derive the effective filter at render time so a removed node falls back
+    // to "all" without needing a state-syncing effect (which the
+    // react-hooks/set-state-in-effect rule forbids).
+    const effectiveNodeFilter: NodeFilter =
+        nodeFilter === NODE_FILTER_ALL || nodes.some((n) => n.id === nodeFilter)
+            ? nodeFilter
+            : NODE_FILTER_ALL;
+
+    const filtered = useMemo(
+        () => applyFilter(notifications, filter, effectiveNodeFilter),
+        [notifications, filter, effectiveNodeFilter],
+    );
     const groups = useMemo(() => groupByDay(filtered), [filtered]);
 
     const filterOptions = useMemo(
@@ -205,7 +234,35 @@ export function NotificationPanel({
                 </div>
 
                 {/* Filter segment */}
-                <div className="flex items-center justify-end border-t border-card-border/60 px-[var(--density-row-x)] py-[var(--density-row-y)]">
+                <div
+                    className={cn(
+                        'flex items-center gap-2 border-t border-card-border/60 px-[var(--density-row-x)] py-[var(--density-row-y)]',
+                        showNodeFilter ? 'justify-between' : 'justify-end',
+                    )}
+                >
+                    {showNodeFilter ? (
+                        <Select
+                            value={effectiveNodeFilter === NODE_FILTER_ALL ? NODE_FILTER_ALL : String(effectiveNodeFilter)}
+                            onValueChange={(v) => setNodeFilter(v === NODE_FILTER_ALL ? NODE_FILTER_ALL : Number(v))}
+                        >
+                            <SelectTrigger
+                                aria-label="Filter by node"
+                                className="h-7 w-[140px] border-card-border bg-card px-2 font-mono text-[10px] uppercase tracking-[0.14em] text-stat-subtitle shadow-none focus:ring-0"
+                            >
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value={NODE_FILTER_ALL} className="font-mono text-[10px] uppercase tracking-[0.14em]">
+                                    All nodes
+                                </SelectItem>
+                                {nodes.map((n) => (
+                                    <SelectItem key={n.id} value={String(n.id)} className="font-mono text-[10px] uppercase tracking-[0.14em]">
+                                        {n.name}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    ) : null}
                     <SegmentedControl
                         value={filter}
                         options={filterOptions}


### PR DESCRIPTION
## Summary

Two small polish improvements to the already-shipped aggregated notifications inbox (the top-bar bell panel that fans in events from every registered node).

- **Per-node filter.** Adds a compact dropdown alongside the existing level / unread segment. Hidden when only one node is registered so single-node installs see no new chrome. Selection is ephemeral per panel open and auto-clears if the selected node is removed from the registry.
- **60-second refetch safety net.** Adds a `setInterval` that calls the existing `fetchNotifications()` so events missed during a WebSocket reconnect backoff are reconciled without a manual refresh. A `useRef` indirection keeps the interval pinned to the latest closure.

No backend changes. No new types, props, or API surface.

## Test plan

- [ ] `cd frontend && npx tsc -b --noEmit` passes cleanly
- [ ] `cd frontend && npm run lint` reports zero errors
- [ ] Register at least one remote node; trigger events on both local and remote (e.g. restart a stack on each)
- [ ] Open the bell panel: node selector is visible; picking a node narrows the list to that origin; picking "All nodes" restores full aggregated stream
- [ ] On a single-node install the selector does not appear and the filter segment sits flush right as before
- [ ] With the panel closed, confirm a `GET /api/notifications` fires every ~60s in the Network tab (plus per-remote mirrors)
- [ ] Close the tab and reopen: no dangling requests from the old tab instance

## Notes

- Browser validation in this session was limited to dev-server boot checks (backend `/api/health` 200, frontend index 200, `/api/notifications` 401 without auth). Recommend manual end-to-end testing of the panel interactions before merge.
- Node ID is serialized as a string at the Radix Select boundary and converted back to `number` in the onChange handler.
- `NODE_FILTER_ALL` uses `as const` so both `applyFilter` and the Select value comparison narrow cleanly against the sentinel.