### PR TITLE
feat(sidebar): keyboard shortcuts for stack menu actions

### DIFF
--- a/docs/features/sidebar.mdx
+++ b/docs/features/sidebar.mdx
@@ -45,6 +45,31 @@ Right-click any stack (or open the kebab that appears on hover) for its context 
   <img src="/images/sidebar/sidebar-context-menu.png" alt="Grouped stack context menu" />
 </Frame>
 
+## Keyboard shortcuts
+
+Every action in the context menu has a keyboard shortcut. Shortcuts fire on the currently selected stack and are blocked when a text input is focused or the command palette is open.
+
+### Lifecycle
+
+| Shortcut | Action | Condition |
+|----------|--------|-----------|
+| <kbd>Ctrl</kbd>+<kbd>Enter</kbd> | Deploy | Stack is stopped |
+| <kbd>Ctrl</kbd>+<kbd>.</kbd> | Stop | Stack is running |
+| <kbd>Ctrl</kbd>+<kbd>R</kbd> | Restart | Stack is running |
+| <kbd>Ctrl</kbd>+<kbd>↑</kbd> | Update images | Stack is running |
+| <kbd>Ctrl</kbd>+<kbd>Backspace</kbd> | Delete | Stack exists |
+
+On macOS, use <kbd>Cmd</kbd> in place of <kbd>Ctrl</kbd>.
+
+### Inspect and organize
+
+| Key | Action |
+|-----|--------|
+| <kbd>A</kbd> | Open alerts sheet |
+| <kbd>H</kbd> | Open auto-heal sheet (Skipper and above) |
+| <kbd>U</kbd> | Check for image updates |
+| <kbd>P</kbd> | Pin or unpin the stack |
+
 ## Activity footer
 
 The footer shows the most recent stack lifecycle event within the last hour. Click it to jump to the global activity log. When nothing has happened recently, the footer reads **IDLE**.

--- a/frontend/src/components/sidebar/StackList.tsx
+++ b/frontend/src/components/sidebar/StackList.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { ArrowUpRight, Loader2 } from 'lucide-react';
+import { useStackKeyboardShortcuts } from '@/hooks/useStackKeyboardShortcuts';
 import { CommandItem, CommandList } from '@/components/ui/command';
 import { Skeleton } from '@/components/ui/skeleton';
 import type { Label } from '@/components/label-types';
@@ -107,6 +108,8 @@ export function StackList(props: StackListProps) {
     () => buildGroups(files, pinnedFiles, stackLabelMap, labels),
     [files, pinnedFiles, stackLabelMap, labels],
   );
+
+  useStackKeyboardShortcuts(selectedFile, buildMenuCtx);
 
   if (isLoading) {
     return (

--- a/frontend/src/hooks/useStackKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useStackKeyboardShortcuts.ts
@@ -1,0 +1,82 @@
+import { useEffect, useRef } from 'react';
+import type { StackMenuCtx } from '@/components/sidebar/sidebar-types';
+
+function isInputFocused(): boolean {
+  const el = document.activeElement as HTMLElement | null;
+  if (!el) return false;
+  const tag = el.tagName;
+  return tag === 'INPUT' || tag === 'TEXTAREA' || el.isContentEditable;
+}
+
+function isPaletteOpen(): boolean {
+  return !!document.querySelector('[role="dialog"] [cmdk-root]');
+}
+
+export function useStackKeyboardShortcuts(
+  selectedFile: string | null,
+  buildMenuCtx: (file: string) => StackMenuCtx,
+) {
+  const selectedFileRef = useRef(selectedFile);
+  const buildMenuCtxRef = useRef(buildMenuCtx);
+
+  useEffect(() => { selectedFileRef.current = selectedFile; }, [selectedFile]);
+  useEffect(() => { buildMenuCtxRef.current = buildMenuCtx; }, [buildMenuCtx]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const file = selectedFileRef.current;
+      if (!file) return;
+      if (isInputFocused()) return;
+      if (isPaletteOpen()) return;
+
+      const cmdOrCtrl = e.metaKey || e.ctrlKey;
+      const key = e.key.toLowerCase();
+
+      const isCmdKey = cmdOrCtrl && ['enter', '.', 'r', 'arrowup', 'backspace'].includes(key);
+      const isSingleKey = !cmdOrCtrl && ['a', 'h', 'u', 'p'].includes(key);
+      if (!isCmdKey && !isSingleKey) return;
+
+      const ctx = buildMenuCtxRef.current(file);
+      const { showDeploy, showStop, showRestart, showUpdate } = ctx.menuVisibility;
+
+      if (cmdOrCtrl) {
+        if (key === 'enter' && showDeploy && !ctx.isBusy) {
+          e.preventDefault();
+          ctx.deploy();
+        } else if (key === '.' && showStop && !ctx.isBusy) {
+          e.preventDefault();
+          ctx.stop();
+        } else if (key === 'r' && showRestart && !ctx.isBusy) {
+          e.preventDefault();
+          ctx.restart();
+        } else if (key === 'arrowup' && showUpdate && !ctx.isBusy) {
+          e.preventDefault();
+          ctx.update();
+        } else if (key === 'backspace' && ctx.canDelete && !ctx.isBusy) {
+          e.preventDefault();
+          ctx.remove();
+        }
+        return;
+      }
+
+      if (key === 'a') {
+        e.preventDefault();
+        ctx.openAlertSheet();
+      } else if (key === 'h' && ctx.isPaid) {
+        e.preventDefault();
+        ctx.openAutoHeal();
+      } else if (key === 'u') {
+        e.preventDefault();
+        ctx.checkUpdates();
+      } else if (key === 'p') {
+        e.preventDefault();
+        if (ctx.isPinned) ctx.unpin();
+        else ctx.pin();
+      }
+    };
+
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}


### PR DESCRIPTION
## Summary

- Implements all keyboard shortcuts shown in the sidebar context menu and kebab menu — they were previously decorative labels with no bindings
- Adds `useStackKeyboardShortcuts` hook registered once on mount, firing actions against the currently selected stack
- Fixes a guard bug where `[cmdk-root]` (always present in the sidebar search) was incorrectly detected as the command palette being open; corrected to `[role="dialog"] [cmdk-root]`
- Documents all shortcuts in `docs/features/sidebar.mdx`

**Shortcuts added:**

| Keys | Action | Condition |
|------|--------|-----------|
| `Ctrl/Cmd+Enter` | Deploy | Stack stopped |
| `Ctrl/Cmd+.` | Stop | Stack running |
| `Ctrl/Cmd+R` | Restart | Stack running |
| `Ctrl/Cmd+↑` | Update images | Stack running |
| `Ctrl/Cmd+Backspace` | Delete | Stack exists |
| `A` | Alerts sheet | — |
| `H` | Auto-Heal sheet | Skipper+ |
| `U` | Check updates | — |
| `P` | Pin / Unpin | — |

All shortcuts respect `menuVisibility` flags, `isBusy`, and `canDelete` from the menu context. Blocked when a text input is focused or the command palette dialog is open.

## Test plan

- Selected a running stack (bookstack), pressed `Ctrl+R` — "Stack restarted successfully" toast confirmed
- Pressed `A` — Stack Alerts sheet opened for the correct stack
- Pressed `P` — stack moved to PINNED group immediately
- Pressed `P` again — stack unpinned
- Focused the sidebar search input, pressed `A` — typed into search field, no sheet opened (input guard working)
- TypeScript: `tsc -b --noEmit` passes with zero errors