### PR TITLE
chore: gitignore docs/internal for engineering documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ backend/src/generated/version.ts
 # Local-only projects (separate repos)
 demo-video/
 website/
+
+# Internal engineering docs (not published)
+docs/internal/


### PR DESCRIPTION
## Summary
- Add `docs/internal/` to `.gitignore`. Reserves the folder for engineering documentation (architecture deep-dives, module responsibilities, shared-state inventory, WebSocket dispatch order, refactor history) that should not ship on docs.sencho.io.
- Mintlify's `docs.json` already does not reference `internal/`, so the folder is also invisible to the published site.

## Test plan
- [x] `git check-ignore docs/internal/test.md` reports the path as ignored.
- [x] `docs/docs.json` navigation has no `internal/` entry.
- [x] `cd backend && npx tsc --noEmit` clean.
- [x] `cd backend && npm test` - 69 files, 1,345 tests passing.
- [x] `cd backend && npm run lint` - 0 errors (201 pre-existing warnings, unchanged).

## Notes
- This completes the `index.ts` modularization refactor. Across six phases (PRs #730 through #745), `index.ts` dropped from **8,941 to 147 lines** (98.4%). All 211 HTTP routes and 6 WebSocket dispatch targets moved into focused modules under `routes/`, `middleware/`, `websocket/`, `proxy/`, `helpers/`, and `bootstrap/`, with handlers preserved byte-for-byte at every step.
- Verified route count: pre-refactor snapshot had 211 `app.method()` route registrations in `index.ts`; post-refactor, 211 across all routers. No routes lost.