### PR TITLE
docs(backend): strip stale phase annotations from canonical-order comment

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -23,18 +23,18 @@ import './types/express';
  *   7.  pollingLimiter (at /api)
  *   8.  conditionalJsonParser
  *   9.  nodeContextMiddleware
- *   10. authGate (at /api)                -- registered in index.ts (before Phase 4 finishes)
+ *   10. authGate (at /api)                -- registered in index.ts
  *   11. auditLog (at /api)                -- registered in index.ts
  *   12. enforceApiTokenScope (at /api)    -- registered in index.ts
  *   13. createRemoteProxyMiddleware       -- proxy/remoteNodeProxy.ts, registered in index.ts
- *   14. routes                            -- registered in index.ts (moves to routes/* in Phase 4)
- *   15. static serving + SPA fallback     -- registered in index.ts (moves here in Phase 5)
+ *   14. routes                            -- registered in index.ts from routes/*
+ *   15. static serving + SPA fallback     -- registered in index.ts
  *   16. errorHandler                      -- registered in index.ts
  *
- * Steps 10-12 and 14 must run after the auth routes are registered so those
- * routes can remain public (login, setup, MFA, SSO). Once all routes live in
- * `routes/*.ts` routers and are mounted here in `createApp()`, every step
- * collapses into this factory.
+ * Steps 10 to 12 and 14 must run after the public auth routers (meta, auth,
+ * mfa, sso) are registered so those routes stay reachable without a session
+ * cookie. index.ts mounts those public routers before step 10 to preserve
+ * that invariant.
  */
 export function createApp(): express.Express {
   const app = express();


### PR DESCRIPTION
## Summary

The canonical middleware-order comment in \`backend/src/app.ts\` carried historical phase annotations from the \`index.ts\` refactor (\"before Phase 4 finishes\", \"moves to routes/* in Phase 4\", \"moves here in Phase 5\"). All three refactor phases shipped, so these notes no longer describe current state. Rewrite as plain descriptions of the final module layout.

The 16-step enumeration and the invariant paragraph (public routers must sit before the auth gate) are preserved.

## Related local-workspace updates (not in this PR)

The \`docs/internal/\` tree is gitignored (commit 86722fe, \"chore: gitignore docs/internal for engineering documentation\"). Alongside this commit I also updated my local workspace copies:
- Created \`architecture/auth-model.md\`, \`modules/middleware.md\`, \`modules/services-inventory.md\` (the three pages indexed from \`README.md\` that were missing).
- Fixed the request-flow numbering in \`architecture/overview.md\` to match the 16-step table.
- Corrected the \`websocket-dispatch.md\` claim that unknown upgrade paths are \`socket.destroy()\`'d (actual default is \`handleGenericWs\`).
- Linked the five \"Known follow-ups\" entries in \`refactor-log.md\` to tracking issues #748 through #752.

Those updates do not ship with the PR because the directory is gitignored by design.

## Tracking issues opened

Five \`tech-debt\` issues cover the deferred follow-ups from the refactor log:

- #748 \`parseIntParam(req, res, name)\` helper
- #749 Hoist severity Sets to \`utils/severity.ts\`
- #750 FleetSync replica guard helper
- #751 Bulk container-op helper for \`/restart\`, \`/stop\`, \`/start\`
- #752 \`stacksRouter.param('stackName', ...)\` validator

## Test plan

- [x] \`cd backend && npx tsc --noEmit\` clean (comment-only change)
- [x] \`cd backend && npm test\` full suite still passes (no code change)
- [x] Comment enumerates all 16 canonical steps; \"public routers before step 10\" invariant preserved