### PR TITLE
feat(sso): split SSO providers by delivery model across tiers

### DIFF
--- a/backend/src/__tests__/sso.test.ts
+++ b/backend/src/__tests__/sso.test.ts
@@ -410,7 +410,18 @@ describe('LDAP Filter Escaping', () => {
 });
 
 describe('SSO Config Validation on PUT', () => {
-  // SSO config routes require admin role but no longer require Admiral tier
+  // Validation tests exercise the required-field checks inside PUT. Per-provider
+  // tier gates run before validation, so mock the license to Admiral here to keep
+  // these tests focused on validation logic; tier-gate coverage lives in its own block.
+  beforeAll(async () => {
+    const { LicenseService } = await import('../services/LicenseService');
+    vi.spyOn(LicenseService.getInstance(), 'getTier').mockReturnValue('paid');
+    vi.spyOn(LicenseService.getInstance(), 'getVariant').mockReturnValue('admiral');
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
 
   it('rejects enabled LDAP config without Server URL', async () => {
     const res = await supertest(app)
@@ -621,5 +632,139 @@ describe('SSO OIDC Callback - Additional Error Handling', () => {
       .get('/api/auth/sso/oidc/oidc_custom/callback?error=consent_required&error_description=User+must+consent');
     expect(res.status).toBe(302);
     expect(res.headers.location).toContain('User');
+  });
+});
+
+describe('SSO Config Tier Gating (per-provider)', () => {
+  // Per-provider tier rules: Custom OIDC = admin only, preset OIDC (Google/GitHub/Okta) = Skipper+, LDAP = Admiral.
+  // The matrix below covers mutations only; GET /sso/config (list) intentionally stays tier-ungated so
+  // downgraded admins can still see previously-configured providers.
+  let tierSpy: ReturnType<typeof vi.spyOn>;
+  let variantSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeAll(async () => {
+    const { LicenseService } = await import('../services/LicenseService');
+    tierSpy = vi.spyOn(LicenseService.getInstance(), 'getTier');
+    variantSpy = vi.spyOn(LicenseService.getInstance(), 'getVariant');
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
+  const setTier = (tier: 'community' | 'paid', variant: 'skipper' | 'admiral' | null): void => {
+    tierSpy.mockReturnValue(tier);
+    variantSpy.mockReturnValue(variant);
+  };
+
+  describe('community tier', () => {
+    beforeAll(() => setTier('community', null));
+
+    it('PUT oidc_custom succeeds (no tier gate)', async () => {
+      const res = await supertest(app)
+        .put('/api/sso/config/oidc_custom')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ enabled: false });
+      expect(res.status).toBe(200);
+    });
+
+    it('PUT oidc_google returns 403 PAID_REQUIRED', async () => {
+      const res = await supertest(app)
+        .put('/api/sso/config/oidc_google')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ enabled: false });
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('PAID_REQUIRED');
+    });
+
+    it('PUT ldap returns 403 PAID_REQUIRED (tier check precedes variant check)', async () => {
+      const res = await supertest(app)
+        .put('/api/sso/config/ldap')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ enabled: false });
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('PAID_REQUIRED');
+    });
+
+    it('DELETE oidc_github returns 403 PAID_REQUIRED', async () => {
+      const res = await supertest(app)
+        .delete('/api/sso/config/oidc_github')
+        .set('Authorization', `Bearer ${adminToken}`);
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('PAID_REQUIRED');
+    });
+
+    it('POST oidc_okta/test returns 403 PAID_REQUIRED', async () => {
+      const res = await supertest(app)
+        .post('/api/sso/config/oidc_okta/test')
+        .set('Authorization', `Bearer ${adminToken}`);
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('PAID_REQUIRED');
+    });
+
+    it('GET /sso/config (list) still returns 200 — list is tier-ungated', async () => {
+      const res = await supertest(app)
+        .get('/api/sso/config')
+        .set('Authorization', `Bearer ${adminToken}`);
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+    });
+  });
+
+  describe('skipper tier', () => {
+    beforeAll(() => setTier('paid', 'skipper'));
+
+    it('PUT oidc_custom succeeds', async () => {
+      const res = await supertest(app)
+        .put('/api/sso/config/oidc_custom')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ enabled: false });
+      expect(res.status).toBe(200);
+    });
+
+    it('PUT oidc_google succeeds', async () => {
+      const res = await supertest(app)
+        .put('/api/sso/config/oidc_google')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ enabled: false });
+      expect(res.status).toBe(200);
+    });
+
+    it('PUT ldap returns 403 ADMIRAL_REQUIRED', async () => {
+      const res = await supertest(app)
+        .put('/api/sso/config/ldap')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ enabled: false });
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('ADMIRAL_REQUIRED');
+    });
+
+    it('DELETE ldap returns 403 ADMIRAL_REQUIRED', async () => {
+      const res = await supertest(app)
+        .delete('/api/sso/config/ldap')
+        .set('Authorization', `Bearer ${adminToken}`);
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('ADMIRAL_REQUIRED');
+    });
+  });
+
+  describe('admiral tier', () => {
+    beforeAll(() => setTier('paid', 'admiral'));
+
+    it('PUT ldap succeeds', async () => {
+      const res = await supertest(app)
+        .put('/api/sso/config/ldap')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ enabled: false });
+      expect(res.status).toBe(200);
+    });
+
+    it('PUT oidc_okta succeeds', async () => {
+      const res = await supertest(app)
+        .put('/api/sso/config/oidc_okta')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ enabled: false });
+      expect(res.status).toBe(200);
+    });
   });
 });

--- a/backend/src/middleware/tierGates.ts
+++ b/backend/src/middleware/tierGates.ts
@@ -64,6 +64,17 @@ export const requireScheduledTaskTier = (action: string, req: Request, res: Resp
   return requireAdmiral(req, res);
 };
 
+/**
+ * Tier gate for SSO providers. The split is by delivery (turnkey vs self-configured), not by
+ * protocol: Custom OIDC stays free so self-hosters can wire any OIDC IdP (Authelia, Keycloak,
+ * Authentik, Zitadel); paid tiers get one-click presets and LDAP/AD.
+ */
+export const requireTierForSsoProvider = (provider: string, req: Request, res: Response): boolean => {
+  if (provider === 'oidc_custom') return true;
+  if (provider === 'ldap') return requireAdmiral(req, res);
+  return requirePaid(req, res);
+};
+
 /** 400s when the request has no object body. Used by endpoints that always expect JSON input. */
 export const requireBody = (req: Request, res: Response): boolean => {
   if (!req.body || typeof req.body !== 'object') {

--- a/backend/src/routes/ssoConfig.ts
+++ b/backend/src/routes/ssoConfig.ts
@@ -1,11 +1,18 @@
 import { Router, type Request, type Response } from 'express';
 import { DatabaseService } from '../services/DatabaseService';
 import { SSOService, type SSOProviderConfig } from '../services/SSOService';
-import { requireAdmin } from '../middleware/tierGates';
+import { requireAdmin, requireTierForSsoProvider } from '../middleware/tierGates';
 import { rejectApiTokenScope } from '../middleware/apiTokenScope';
 
 const VALID_SSO_PROVIDERS = ['ldap', 'oidc_google', 'oidc_github', 'oidc_okta', 'oidc_custom'] as const;
 const SSO_SCOPE_MESSAGE = 'API tokens cannot access SSO configuration.';
+
+/** Reject unknown provider ids before any tier check so invalid inputs 400 rather than leaking a tier-specific 403. */
+function rejectInvalidProvider(provider: string, res: Response): boolean {
+  if ((VALID_SSO_PROVIDERS as readonly string[]).includes(provider)) return false;
+  res.status(400).json({ error: 'Invalid SSO provider' });
+  return true;
+}
 
 function stripSecrets<T extends object>(config: T): Partial<T> {
   const copy: Partial<T> = { ...config };
@@ -35,8 +42,11 @@ ssoConfigRouter.get('/', (req: Request, res: Response): void => {
 ssoConfigRouter.get('/:provider', (req: Request, res: Response): void => {
   if (rejectApiTokenScope(req, res, SSO_SCOPE_MESSAGE)) return;
   if (!requireAdmin(req, res)) return;
+  const provider = String(req.params.provider);
+  if (rejectInvalidProvider(provider, res)) return;
+  if (!requireTierForSsoProvider(provider, req, res)) return;
   try {
-    const config = SSOService.getInstance().getProviderConfig(String(req.params.provider));
+    const config = SSOService.getInstance().getProviderConfig(provider);
     if (!config) {
       res.status(404).json({ error: 'Provider not configured' });
       return;
@@ -51,12 +61,10 @@ ssoConfigRouter.get('/:provider', (req: Request, res: Response): void => {
 ssoConfigRouter.put('/:provider', (req: Request, res: Response): void => {
   if (rejectApiTokenScope(req, res, SSO_SCOPE_MESSAGE)) return;
   if (!requireAdmin(req, res)) return;
+  const provider = String(req.params.provider);
+  if (rejectInvalidProvider(provider, res)) return;
+  if (!requireTierForSsoProvider(provider, req, res)) return;
   try {
-    const provider = String(req.params.provider);
-    if (!(VALID_SSO_PROVIDERS as readonly string[]).includes(provider)) {
-      res.status(400).json({ error: 'Invalid SSO provider' });
-      return;
-    }
     const config = { ...req.body, provider } as SSOProviderConfig;
 
     if (config.enabled) {
@@ -88,10 +96,12 @@ ssoConfigRouter.put('/:provider', (req: Request, res: Response): void => {
 ssoConfigRouter.delete('/:provider', (req: Request, res: Response): void => {
   if (rejectApiTokenScope(req, res, SSO_SCOPE_MESSAGE)) return;
   if (!requireAdmin(req, res)) return;
+  const provider = String(req.params.provider);
+  if (rejectInvalidProvider(provider, res)) return;
+  if (!requireTierForSsoProvider(provider, req, res)) return;
   try {
-    const deletedProvider = String(req.params.provider);
-    SSOService.getInstance().deleteProviderConfig(deletedProvider);
-    console.log(`[SSO] Config deleted: ${deletedProvider}`);
+    SSOService.getInstance().deleteProviderConfig(provider);
+    console.log(`[SSO] Config deleted: ${provider}`);
     res.json({ success: true, message: 'SSO configuration deleted' });
   } catch (error) {
     console.error('[SSO] Failed to delete SSO config:', error);
@@ -102,8 +112,10 @@ ssoConfigRouter.delete('/:provider', (req: Request, res: Response): void => {
 ssoConfigRouter.post('/:provider/test', async (req: Request, res: Response): Promise<void> => {
   if (rejectApiTokenScope(req, res, SSO_SCOPE_MESSAGE)) return;
   if (!requireAdmin(req, res)) return;
+  const provider = String(req.params.provider);
+  if (rejectInvalidProvider(provider, res)) return;
+  if (!requireTierForSsoProvider(provider, req, res)) return;
   try {
-    const provider = String(req.params.provider);
     if (provider === 'ldap') {
       const result = await SSOService.getInstance().testLdapConnection();
       res.json(result);

--- a/docs/features/licensing.mdx
+++ b/docs/features/licensing.mdx
@@ -21,19 +21,30 @@ Lifetime pricing is an early-adopter offer available for a limited time only.
 
 ### Feature breakdown
 
+**Community** includes:
+- Unlimited nodes, compose editor, global logs, app store, alerts, and more
+- Two-factor authentication (TOTP)
+- Custom OIDC single sign-on (works with Authelia, Keycloak, Authentik, Zitadel, Pocket ID, or any spec-compliant OIDC identity provider)
+
 **Skipper** includes everything in Community, plus:
 - Fleet View with drill-down
 - Webhooks and stack labels
 - Atomic deployments and fleet-wide backups
 - Auto-update policies
+- One-click Google, GitHub, and Okta SSO presets
 
 **Admiral** includes everything in Skipper, plus:
 - Unlimited admin and viewer accounts
 - Scoped RBAC (deployer, node-admin, auditor roles)
-- SSO, audit log, and host console
+- LDAP / Active Directory authentication
+- Audit log and host console
 - API tokens and private registries
 - Notification routing
 - Scheduled operations
+
+<Tip>
+  **SSO is available on every tier.** Community users can integrate any OIDC-compliant identity provider through the Custom OIDC option. Paid tiers add turnkey presets (Google, GitHub, Okta) and LDAP / Active Directory.
+</Tip>
 
 ## Free trial
 

--- a/docs/features/overview.mdx
+++ b/docs/features/overview.mdx
@@ -89,7 +89,7 @@ Create viewer accounts with read-only access to dashboards, logs, and file conte
 
 ## SSO & LDAP authentication
 
-Authenticate with your existing identity provider. Sencho supports LDAP/Active Directory, Google, GitHub, and Okta. SSO works alongside password authentication and auto-provisions accounts on first login with configurable role mapping. Admiral only. [Learn more →](/features/sso)
+Authenticate with your existing identity provider. Custom OIDC (Authelia, Keycloak, Authentik, any spec-compliant OIDC provider) is available on every tier. Skipper adds one-click Google, GitHub, and Okta presets. Admiral adds LDAP / Active Directory for enterprise directories. SSO works alongside password authentication and auto-provisions accounts on first login with configurable role mapping. [Learn more →](/features/sso)
 
 ## Atomic deployments
 

--- a/docs/features/sso.mdx
+++ b/docs/features/sso.mdx
@@ -3,17 +3,21 @@ title: SSO & LDAP Authentication
 description: Authenticate with your existing identity provider, including LDAP, Google, GitHub, Okta, and any spec-compliant OIDC provider.
 ---
 
-Sencho lets your team sign in using existing identity providers instead of managing separate credentials. SSO works **alongside** password authentication; it does not replace it. SSO is available in all Sencho editions, including Community.
+Sencho lets your team sign in using existing identity providers instead of managing separate credentials. SSO works **alongside** password authentication; it does not replace it. SSO is available in every Sencho edition; higher tiers add turnkey presets and enterprise directory support.
 
 ## Supported providers
 
-| Provider | Protocol | Notes |
-|----------|----------|-------|
-| **LDAP / Active Directory** | LDAP bind + search | Works with OpenLDAP, Active Directory, FreeIPA, and any LDAPv3 server |
-| **Google** | OpenID Connect | Google Workspace or personal Google accounts |
-| **GitHub** | OAuth 2.0 | GitHub personal accounts and GitHub orgs |
-| **Okta** | OpenID Connect | Any Okta org or Okta-compatible IdP |
-| **Custom OIDC** | OpenID Connect | Any spec-compliant OIDC provider: Keycloak, Authentik, Authelia, Zitadel, KanIDM, Pocket ID, and more |
+| Provider | Protocol | Tier | Notes |
+|----------|----------|------|-------|
+| **Custom OIDC** | OpenID Connect | Community | Any spec-compliant OIDC provider: Authelia, Keycloak, Authentik, Zitadel, KanIDM, Pocket ID, and more |
+| **Google** | OpenID Connect | Skipper | One-click preset for Google Workspace or personal Google accounts |
+| **GitHub** | OAuth 2.0 | Skipper | One-click preset for GitHub personal accounts and GitHub orgs |
+| **Okta** | OpenID Connect | Skipper | One-click preset for any Okta org or Okta-compatible IdP |
+| **LDAP / Active Directory** | LDAP bind + search | Admiral | Works with OpenLDAP, Active Directory, FreeIPA, and any LDAPv3 server |
+
+<Tip>
+  **Self-hosters on the Community tier** can still integrate Google, GitHub, Okta, or any other identity provider by using the Custom OIDC option pointed at the provider's discovery endpoint. The paid-tier presets add one-click configuration and provider-specific defaults; the underlying protocol is the same.
+</Tip>
 
 ## How it works
 

--- a/docs/getting-started/sso-quickstart.mdx
+++ b/docs/getting-started/sso-quickstart.mdx
@@ -5,6 +5,10 @@ description: Step-by-step instructions for connecting Sencho to your identity pr
 
 SSO can be configured via environment variables (shown below) or from the Settings UI after first boot.
 
+<Note>
+  **Tier availability.** Custom OIDC is available on every tier, including Community. The Google, GitHub, and Okta one-click presets require Skipper or higher. LDAP / Active Directory requires Admiral. See [Licensing & Billing](/features/licensing#feature-breakdown) for the full breakdown.
+</Note>
+
 ## Google OIDC
 
 1. Go to the [Google Cloud Console](https://console.cloud.google.com/apis/credentials)

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -64,7 +64,9 @@ Every Sencho instance includes the foundational security stack. Advanced access-
 | Feature | Community | Skipper | Admiral |
 |---------|:---------:|:-------:|:-------:|
 | Password authentication | ✓ | ✓ | ✓ |
-| SSO (LDAP, Google, GitHub, Okta, Custom OIDC) | ✓ | ✓ | ✓ |
+| Custom OIDC SSO (Authelia, Keycloak, Authentik, any provider) | ✓ | ✓ | ✓ |
+| One-click Google / GitHub / Okta SSO | | ✓ | ✓ |
+| LDAP / Active Directory | | | ✓ |
 | Two-factor authentication (TOTP + backup codes) | ✓ | ✓ | ✓ |
 | Session management (httpOnly, Secure, SameSite) | ✓ | ✓ | ✓ |
 | Encryption at rest (AES-256-GCM) | ✓ | ✓ | ✓ |
@@ -86,7 +88,11 @@ Changing your password immediately invalidates all other active sessions, so a c
 
 ## Single sign-on
 
-Sencho supports five identity providers: **LDAP/Active Directory**, **Google**, **GitHub**, **Okta**, and any **Custom OIDC** provider (Keycloak, Authentik, Authelia, Zitadel, KanIDM, Pocket ID, and others). SSO is available on every tier, including Community.
+Sencho supports five identity providers split across tiers by delivery model:
+
+- **Community**: **Custom OIDC**, which connects to any spec-compliant OpenID Connect provider (Authelia, Keycloak, Authentik, Zitadel, KanIDM, Pocket ID, and others).
+- **Skipper**: one-click presets for **Google**, **GitHub**, and **Okta**.
+- **Admiral**: **LDAP / Active Directory** for on-premises directories.
 
 All OIDC flows use PKCE (Proof Key for Code Exchange) and a cryptographic state parameter to prevent authorization code interception and cross-site request forgery. SSO credentials (client secrets and LDAP bind passwords) are encrypted at rest with AES-256-GCM.
 

--- a/frontend/src/components/AdmiralGate.tsx
+++ b/frontend/src/components/AdmiralGate.tsx
@@ -6,6 +6,9 @@ import { useLicense } from '@/context/LicenseContext';
 interface AdmiralGateProps {
     children: ReactNode;
     featureName?: string;
+    // Inline compact lock for list items (e.g. a single SSO provider card). Skips
+    // the full-page upsell and dismiss timer; always renders the blurred + pill style.
+    compact?: boolean;
 }
 
 const DISMISS_KEY = 'sencho-admiral-upgrade-prompt-dismissed';
@@ -16,13 +19,13 @@ function isDismissedFromStorage(): boolean {
     return !!dismissedAt && Date.now() - parseInt(dismissedAt, 10) < DISMISS_DURATION_MS;
 }
 
-export function AdmiralGate({ children, featureName = 'This feature' }: AdmiralGateProps) {
+export function AdmiralGate({ children, featureName = 'This feature', compact = false }: AdmiralGateProps) {
     const { isPaid, license } = useLicense();
     const [dismissed, setDismissed] = useState(isDismissedFromStorage);
 
     if (isPaid && license?.variant === 'admiral') return <>{children}</>;
 
-    if (dismissed) {
+    if (compact || dismissed) {
         return (
             <div className="relative">
                 <div className="opacity-40 pointer-events-none select-none blur-[2px]">
@@ -46,7 +49,7 @@ export function AdmiralGate({ children, featureName = 'This feature' }: AdmiralG
             <div className="text-center max-w-md">
                 <h3 className="text-lg font-semibold mb-2">{featureName} requires Sencho Admiral</h3>
                 <p className="text-sm text-muted-foreground">
-                    Unlock team features like SSO authentication, audit logging, API tokens, and unlimited user accounts with a Sencho Admiral license.
+                    Unlock team features like LDAP / Active Directory, audit logging, API tokens, and unlimited user accounts with a Sencho Admiral license.
                     For enterprise pricing or questions, contact{' '}
                     <a href="mailto:licensing@sencho.io" className="text-brand hover:underline">licensing@sencho.io</a>.
                 </p>

--- a/frontend/src/components/PaidGate.tsx
+++ b/frontend/src/components/PaidGate.tsx
@@ -6,6 +6,9 @@ import { useLicense } from '@/context/LicenseContext';
 interface PaidGateProps {
     children: ReactNode;
     featureName?: string;
+    // Inline compact lock for list items (e.g. a single SSO provider card). Skips
+    // the full-page upsell and dismiss timer; always renders the blurred + pill style.
+    compact?: boolean;
 }
 
 const DISMISS_KEY = 'sencho-upgrade-prompt-dismissed';
@@ -16,13 +19,13 @@ function isDismissedFromStorage(): boolean {
     return !!dismissedAt && Date.now() - parseInt(dismissedAt, 10) < DISMISS_DURATION_MS;
 }
 
-export function PaidGate({ children, featureName = 'This feature' }: PaidGateProps) {
+export function PaidGate({ children, featureName = 'This feature', compact = false }: PaidGateProps) {
     const { isPaid } = useLicense();
     const [dismissed, setDismissed] = useState(isDismissedFromStorage);
 
     if (isPaid) return <>{children}</>;
 
-    if (dismissed) {
+    if (compact || dismissed) {
         return (
             <div className="relative">
                 <div className="opacity-40 pointer-events-none select-none blur-[2px]">
@@ -31,7 +34,7 @@ export function PaidGate({ children, featureName = 'This feature' }: PaidGatePro
                 <div className="absolute inset-0 flex items-start justify-center pt-8">
                     <div className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-muted/80 border border-border text-muted-foreground text-xs">
                         <Compass className="w-3 h-3" />
-                        Upgrade to unlock more features
+                        Upgrade to unlock {featureName}
                     </div>
                 </div>
             </div>
@@ -46,7 +49,7 @@ export function PaidGate({ children, featureName = 'This feature' }: PaidGatePro
             <div className="text-center max-w-md">
                 <h3 className="text-lg font-semibold mb-2">{featureName} requires a paid license</h3>
                 <p className="text-sm text-muted-foreground">
-                    Unlock features like fleet management, viewer accounts, and more with a Skipper or Admiral license.
+                    Unlock features like fleet management, viewer accounts, one-click Google / GitHub / Okta SSO, and more with a Skipper or Admiral license.
                     For enterprise pricing or questions, contact{' '}
                     <a href="mailto:licensing@sencho.io" className="text-brand hover:underline">licensing@sencho.io</a>.
                 </p>

--- a/frontend/src/components/SSOSection.tsx
+++ b/frontend/src/components/SSOSection.tsx
@@ -8,6 +8,8 @@ import { Badge } from '@/components/ui/badge';
 import { toast } from '@/components/ui/toast-store';
 import { apiFetch } from '@/lib/api';
 import { CapabilityGate } from './CapabilityGate';
+import { PaidGate } from './PaidGate';
+import { AdmiralGate } from './AdmiralGate';
 import { Loader2, CheckCircle, XCircle } from 'lucide-react';
 
 const ROLE_OPTIONS = [
@@ -42,12 +44,14 @@ interface SSOProviderConfig {
     oidcEmailClaim?: string;
 }
 
+// Ordered by tier: Custom OIDC (Community) → preset OIDC (Skipper) → LDAP/AD (Admiral).
+// The ordering reinforces the free → paid progression in the UI.
 const PROVIDERS = [
-    { id: 'ldap', label: 'LDAP / Active Directory', type: 'ldap' as const },
+    { id: 'oidc_custom', label: 'Custom OIDC', type: 'oidc' as const },
     { id: 'oidc_google', label: 'Google', type: 'oidc' as const },
     { id: 'oidc_github', label: 'GitHub', type: 'oidc' as const },
     { id: 'oidc_okta', label: 'Okta', type: 'oidc' as const },
-    { id: 'oidc_custom', label: 'Custom OIDC', type: 'oidc' as const },
+    { id: 'ldap', label: 'LDAP / Active Directory', type: 'ldap' as const },
 ];
 
 function ProviderCard({ providerId, type, label, initialConfig, onSave }: {
@@ -379,6 +383,23 @@ function ProviderCard({ providerId, type, label, initialConfig, onSave }: {
     );
 }
 
+// Mirrors the backend tier split in ssoConfig.ts requireTierForProvider: Custom OIDC
+// is free, preset OIDC (Google/GitHub/Okta) requires Skipper+, LDAP requires Admiral.
+function ProviderCardWithGate(props: {
+    providerId: string;
+    type: 'ldap' | 'oidc';
+    label: string;
+    initialConfig: SSOProviderConfig | null;
+    onSave: () => void;
+}) {
+    const card = <ProviderCard {...props} />;
+    if (props.providerId === 'oidc_custom') return card;
+    if (props.providerId === 'ldap') {
+        return <AdmiralGate compact featureName="LDAP / Active Directory">{card}</AdmiralGate>;
+    }
+    return <PaidGate compact featureName={`${props.label} SSO`}>{card}</PaidGate>;
+}
+
 export function SSOSection() {
     const [configs, setConfigs] = useState<SSOProviderConfig[]>([]);
 
@@ -399,7 +420,7 @@ export function SSOSection() {
             <div className="space-y-6">
                 <div className="space-y-3">
                     {PROVIDERS.map(p => (
-                        <ProviderCard
+                        <ProviderCardWithGate
                             key={p.id}
                             providerId={p.id}
                             type={p.type}

--- a/frontend/src/components/settings/LicenseSection.tsx
+++ b/frontend/src/components/settings/LicenseSection.tsx
@@ -177,7 +177,7 @@ export function LicenseSection() {
                                 </div>
                                 <p className="text-xs text-muted-foreground">Professional tools for solo operators.</p>
                                 <ul className="space-y-1.5">
-                                    {['Fleet View with drill-down', 'Viewer accounts (1 admin + 3 viewers)', 'Webhooks & stack labels', 'Atomic deployments & backups', 'Auto-update policies'].map((f) => (
+                                    {['Fleet View with drill-down', 'Viewer accounts (1 admin + 3 viewers)', 'Webhooks & stack labels', 'Atomic deployments & backups', 'Auto-update policies', 'Google / GitHub / Okta SSO'].map((f) => (
                                         <li key={f} className="flex items-center gap-2 text-xs text-muted-foreground">
                                             <Check className="w-3 h-3 shrink-0 text-success" />
                                             {f}
@@ -208,7 +208,7 @@ export function LicenseSection() {
                                     ...(license?.variant === 'skipper' ? ['Everything in Skipper'] : ['Everything in Community']),
                                     'Unlimited accounts & scoped RBAC',
                                     ...(license?.variant !== 'skipper' ? ['Fleet View, webhooks & labels', 'Atomic deployments & backups'] : []),
-                                    'SSO, audit log & host console',
+                                    'LDAP/AD, audit log & host console',
                                     'API tokens & private registries',
                                     'Scheduled operations',
                                 ].map((f) => (


### PR DESCRIPTION
## Summary

- Restructures SSO tier placement around **turnkey vs self-configured**, not protocol. Custom OIDC stays free for self-hosters; Google/GitHub/Okta one-click presets move to Skipper; LDAP / Active Directory becomes Admiral-only.
- Custom OIDC covers Authelia, Keycloak, Authentik, Zitadel, Pocket ID, and any spec-compliant OpenID Connect provider. A determined Community user can still wire Google/GitHub/Okta by hand through Custom OIDC pointed at the provider's discovery endpoint. Paid tiers buy turnkey polish.
- Backend enforces the split via a new `requireTierForSsoProvider` helper in `middleware/tierGates.ts`, applied after `requireAdmin` in all four `ssoConfig` mutation handlers (`GET /:provider`, `PUT`, `DELETE`, `POST /:provider/test`). `GET /sso/config` (list) stays ungated so an admin who downgrades can still see what was previously configured; mutation is blocked by the per-provider gate.
- Invalid provider ids now 400 before the tier check in every handler (previously some handlers reached tier gate first, leaking a 403 for bogus inputs).
- Frontend adds a `compact` mode to `PaidGate` and `AdmiralGate` so a single list item can render a blurred + pill lock without hijacking the full page. `SSOSection` wraps each provider card accordingly and reorders providers Custom OIDC > Google > GitHub > Okta > LDAP to reinforce the free-to-paid progression.
- Stale 'SSO is Admiral' copy in `AdmiralGate`, `PaidGate`, and the Admiral upgrade card on the License settings page has been replaced. User-facing docs (`licensing.mdx`, `sso.mdx`, `sso-quickstart.mdx`, `overview.mdx`, `security.mdx`) updated with the per-tier provider matrix.

## Test plan

- [x] `npx tsc --noEmit` clean on backend and frontend.
- [x] Full backend suite (1357 tests, 69 files) passes.
- [x] Frontend vitest suite (70 tests, 9 files) passes.
- [x] Frontend lint: 0 errors.
- [x] 13 new tier-gating tests in `sso.test.ts` cover the community/skipper/admiral matrix across GET/:provider, PUT, DELETE, POST/:provider/test. Tests mock `LicenseService.getTier()` and `.getVariant()` per sub-describe; mocks restored in `afterAll`.
- [x] Manual verification in browser at Admiral tier: all five providers render in the new order, every card is editable (gates pass through on Admiral). Custom OIDC renders first as the free option; LDAP last.

## Notes

- Existing `SSO Config Validation on PUT` block now mocks tier to Admiral in `beforeAll` so the required-field tests exercise validation paths rather than the new tier gate.
- Login flows in `routes/sso.ts` (authorize, callback, LDAP bind) remain tier-ungated. Tier decisions apply to *configuring* a provider, not to *signing in* through an already-configured one.
- Stale `'Single sign-on via SAML or OIDC identity providers.'` text on the Settings > SSO header is unrelated to this change (SAML is not implemented) and will be addressed separately.