### PR TITLE
fix(security): clear cached policy evaluations when a scan policy is deleted

### DIFF
--- a/backend/src/__tests__/database-policy-delete.test.ts
+++ b/backend/src/__tests__/database-policy-delete.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Pins the cascade behavior of `DatabaseService.deleteScanPolicy`.
+ *
+ * Scans are evaluated against a policy at scan time and the result is cached
+ * inside `vulnerability_scans.policy_evaluation` as a JSON blob. When the
+ * underlying policy is deleted, those blobs must be cleared so the scheduler
+ * and UI stop reporting violations from a policy that no longer exists.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { setupTestDb, cleanupTestDb } from './helpers/setupTestDb';
+
+let tmpDir: string;
+let DatabaseService: typeof import('../services/DatabaseService').DatabaseService;
+
+beforeAll(async () => {
+    tmpDir = await setupTestDb();
+    ({ DatabaseService } = await import('../services/DatabaseService'));
+});
+
+afterAll(() => {
+    cleanupTestDb(tmpDir);
+});
+
+function seedScanWithEvaluation(policyId: number, digest: string): number {
+    const db = DatabaseService.getInstance();
+    const id = db.createVulnerabilityScan({
+        node_id: 1,
+        image_ref: `alpine:${digest.slice(-4)}`,
+        image_digest: digest,
+        scanned_at: Date.now(),
+        total_vulnerabilities: 1,
+        critical_count: 0,
+        high_count: 1,
+        medium_count: 0,
+        low_count: 0,
+        unknown_count: 0,
+        fixable_count: 0,
+        secret_count: 0,
+        misconfig_count: 0,
+        scanners_used: 'vuln',
+        highest_severity: 'HIGH',
+        os_info: 'alpine 3.19',
+        trivy_version: '0.56.0',
+        scan_duration_ms: 1200,
+        triggered_by: 'manual',
+        status: 'completed',
+        error: null,
+        stack_context: null,
+    });
+    db.updateVulnerabilityScan(id, {
+        policy_evaluation: JSON.stringify({
+            policyId,
+            policyName: 'block-high',
+            maxSeverity: 'HIGH',
+            violated: true,
+            evaluatedAt: Date.now(),
+        }),
+    });
+    return id;
+}
+
+describe('deleteScanPolicy', () => {
+    it('removes the policy row and clears policy_evaluation on matching scans', () => {
+        const db = DatabaseService.getInstance();
+        const policy = db.createScanPolicy({
+            name: 'block-high',
+            node_id: null,
+            node_identity: '',
+            stack_pattern: '*',
+            max_severity: 'HIGH',
+            block_on_deploy: 1,
+            enabled: 1,
+            replicated_from_control: 0,
+        });
+        const otherPolicy = db.createScanPolicy({
+            name: 'block-critical',
+            node_id: null,
+            node_identity: '',
+            stack_pattern: '*',
+            max_severity: 'CRITICAL',
+            block_on_deploy: 1,
+            enabled: 1,
+            replicated_from_control: 0,
+        });
+
+        const matchingScanId = seedScanWithEvaluation(policy.id, 'sha256:matching');
+        const unrelatedScanId = seedScanWithEvaluation(otherPolicy.id, 'sha256:unrelated');
+
+        db.deleteScanPolicy(policy.id);
+
+        expect(db.getScanPolicy(policy.id)).toBeNull();
+        expect(db.getVulnerabilityScan(matchingScanId)?.policy_evaluation).toBeNull();
+        expect(db.getVulnerabilityScan(unrelatedScanId)?.policy_evaluation).not.toBeNull();
+        expect(db.getScanPolicy(otherPolicy.id)).not.toBeNull();
+    });
+
+    it('is a no-op for an unknown policy id', () => {
+        const db = DatabaseService.getInstance();
+        expect(() => db.deleteScanPolicy(999_999)).not.toThrow();
+    });
+
+    it('does not touch scans whose policy_evaluation is NULL', () => {
+        const db = DatabaseService.getInstance();
+        const policy = db.createScanPolicy({
+            name: 'block-medium',
+            node_id: null,
+            node_identity: '',
+            stack_pattern: '*',
+            max_severity: 'MEDIUM',
+            block_on_deploy: 1,
+            enabled: 1,
+            replicated_from_control: 0,
+        });
+        const unevaluatedScanId = db.createVulnerabilityScan({
+            node_id: 1,
+            image_ref: 'alpine:none',
+            image_digest: 'sha256:nopol',
+            scanned_at: Date.now(),
+            total_vulnerabilities: 0,
+            critical_count: 0,
+            high_count: 0,
+            medium_count: 0,
+            low_count: 0,
+            unknown_count: 0,
+            fixable_count: 0,
+            secret_count: 0,
+            misconfig_count: 0,
+            scanners_used: 'vuln',
+            highest_severity: null,
+            os_info: 'alpine 3.19',
+            trivy_version: '0.56.0',
+            scan_duration_ms: 100,
+            triggered_by: 'manual',
+            status: 'completed',
+            error: null,
+            stack_context: null,
+        });
+
+        db.deleteScanPolicy(policy.id);
+
+        const row = db.getVulnerabilityScan(unevaluatedScanId);
+        expect(row).not.toBeNull();
+        expect(row?.policy_evaluation).toBeNull();
+    });
+});

--- a/backend/src/services/DatabaseService.ts
+++ b/backend/src/services/DatabaseService.ts
@@ -3015,7 +3015,20 @@ export class DatabaseService {
     }
 
     public deleteScanPolicy(id: number): void {
-        this.db.prepare('DELETE FROM scan_policies WHERE id = ?').run(id);
+        // policy_evaluation is a JSON blob containing the policyId of the policy
+        // that produced it. Clear it on every scan referencing the deleted policy
+        // so cached scans no longer report stale violations after the policy is gone.
+        const clearEval = this.db.prepare(
+            `UPDATE vulnerability_scans
+                SET policy_evaluation = NULL
+              WHERE json_extract(policy_evaluation, '$.policyId') = ?`,
+        );
+        const deletePolicy = this.db.prepare('DELETE FROM scan_policies WHERE id = ?');
+        const txn = this.db.transaction((policyId: number) => {
+            clearEval.run(policyId);
+            deletePolicy.run(policyId);
+        });
+        txn(id);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Deleting a scan policy used to leave the cached `policy_evaluation` JSON intact on every historical `vulnerability_scans` row that had been evaluated against it. The scheduler and UI would then keep flagging those scans as blocked against a policy that no longer existed.
- `deleteScanPolicy` now atomically clears `policy_evaluation` on every scan whose JSON `policyId` matches, then deletes the policy row, inside a single SQLite transaction.
- Uses SQLite's `json_extract` so only the rows tied to the deleted policy id are touched. NULL evaluations and evaluations for other policies are left alone.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] New Vitest suite (`database-policy-delete.test.ts`) covers: matching scan cleared, unrelated scan untouched, NULL evaluation untouched, unknown id is a no-op
- [x] Full backend suite (1374 tests) green
- [ ] End-to-end: create a policy that flags an existing image, run a scan so a violation is recorded, confirm a stack is blocked, delete the policy, refresh, confirm the stack is no longer blocked

## Notes
- Other tables that store a `policy_id` (`auto_heal_history`) reference `auto_heal_policies`, not `scan_policies`, and are already cleaned up by `deleteAutoHealPolicy`. No further cascade is required.
- `PRAGMA foreign_keys = ON` is intentionally not enabled in this PR. `policy_evaluation` is a JSON column, not a foreign key, so cascading would not have helped. Enabling FK enforcement globally is a separate hardening concern.