### PR TITLE
fix(frontend): clear sidebar update dot after toolbar Update

### DIFF
--- a/frontend/src/components/EditorLayout.tsx
+++ b/frontend/src/components/EditorLayout.tsx
@@ -1431,6 +1431,7 @@ export default function EditorLayout() {
         throw new Error(errText || 'Update failed');
       }
       toast.success('Stack updated successfully!');
+      fetchImageUpdates();
       // Refresh containers after update
       if (selectedFile === stackFile) {
         const containersRes = await apiFetch(`/stacks/${stackName}/containers`);


### PR DESCRIPTION
## Summary

- The toolbar **Update** button (`updateStack` in `EditorLayout.tsx`) refreshed containers and stacks but never re-fetched the image-updates list, so the sidebar's blue "update available" dot lingered until the 5-minute polling interval (`EditorLayout.tsx:791`).
- The right-click context-menu path (`executeStackActionByFile` for `action === 'update'`) already calls `fetchImageUpdates()` on success — this mirrors that call so both paths behave identically.
- One-line addition. The backend was already clearing the DB row via `DatabaseService.clearStackUpdateStatus(req.nodeId, stackName)` at `routes/stacks.ts:636`; only the frontend state was stale.

## Test plan

- [x] `tsc -b --noEmit` passes for the frontend.
- [x] Backend and Vite dev servers start cleanly with the change applied; both respond `200`.
- [x] Manual: open a stack with a known available update, click the toolbar **Update**, confirm the sidebar dot disappears immediately on success (within one render after `fetchImageUpdates()` resolves).
- [x] Manual: hard-refresh the page; dot stays gone (DB state was already cleared).
- [x] Regression: right-click context-menu Update still works (unchanged path).

## Notes

The fix is a pure mirror of the call already present at `EditorLayout.tsx` line 1512 (`if (action === 'update') fetchImageUpdates();`); behaviour is now identical between toolbar and context-menu update flows.