### PR TITLE
fix(frontend): stream logs on next paint with ms-precision timestamps

### DIFF
--- a/frontend/src/components/StructuredLogViewer.tsx
+++ b/frontend/src/components/StructuredLogViewer.tsx
@@ -43,7 +43,8 @@ function formatTs(iso: string | null): string {
   const hh = String(d.getHours()).padStart(2, '0');
   const mm = String(d.getMinutes()).padStart(2, '0');
   const ss = String(d.getSeconds()).padStart(2, '0');
-  return `${hh}:${mm}:${ss}`;
+  const ms = String(d.getMilliseconds()).padStart(3, '0');
+  return `${hh}:${mm}:${ss}.${ms}`;
 }
 
 export default function StructuredLogViewer({ stackName }: StructuredLogViewerProps) {
@@ -68,6 +69,22 @@ export default function StructuredLogViewer({ stackName }: StructuredLogViewerPr
     const ws = new WebSocket(wsUrl);
     wsRef.current = ws;
 
+    let rafId = 0;
+    const flushPending = () => {
+      rafId = 0;
+      if (pendingRef.current.length === 0) return;
+      const incoming = pendingRef.current;
+      pendingRef.current = [];
+      setRows((prev) => {
+        const merged = prev.concat(incoming);
+        return merged.length > BUFFER_CAP ? merged.slice(merged.length - BUFFER_CAP) : merged;
+      });
+    };
+    const scheduleFlush = () => {
+      if (rafId !== 0) return;
+      rafId = requestAnimationFrame(flushPending);
+    };
+
     ws.onmessage = (event) => {
       if (closed) return;
       const text = typeof event.data === 'string' ? event.data : '';
@@ -79,24 +96,14 @@ export default function StructuredLogViewer({ stackName }: StructuredLogViewerPr
         rowIdRef.current += 1;
         pendingRef.current.push({ id: rowIdRef.current, ...parsed });
       }
+      scheduleFlush();
     };
 
     ws.onerror = () => { /* surface nothing; reconnection is backend's job */ };
 
-    // Batch incoming lines into state every 250 ms to avoid thrashing React.
-    const flushInterval = window.setInterval(() => {
-      if (pendingRef.current.length === 0) return;
-      const incoming = pendingRef.current;
-      pendingRef.current = [];
-      setRows((prev) => {
-        const merged = prev.concat(incoming);
-        return merged.length > BUFFER_CAP ? merged.slice(merged.length - BUFFER_CAP) : merged;
-      });
-    }, 250);
-
     return () => {
       closed = true;
-      window.clearInterval(flushInterval);
+      if (rafId !== 0) cancelAnimationFrame(rafId);
       try { ws.close(); } catch { /* ignore */ }
       wsRef.current = null;
       pendingRef.current = [];


### PR DESCRIPTION
## Summary

- Replace the 250ms \`setInterval\` flush in \`StructuredLogViewer\` with a \`requestAnimationFrame\` scheduler. Lines now reach the DOM on the next paint (~16ms at 60Hz) while still collapsing a single WebSocket burst into one React commit, so chatty containers no longer feel laggy.
- Render the per-line timestamp as \`HH:mm:ss.SSS\` instead of \`HH:mm:ss\`. \`docker logs -t\` already emits ms-precision ISO timestamps via the backend; the previous formatter was throwing that precision away, which made successive lines within the same second appear to share a timestamp.

## Test plan

- [x] \`tsc -b --noEmit\` passes for the frontend.
- [ ] Manual: open the logs panel for a chatty container (one that emits >10 lines/sec). Lines should appear continuously rather than in 250ms steps.
- [ ] Manual: confirm lines emitted within the same second now show distinct \`HH:mm:ss.SSS\` timestamps.
- [ ] Manual: a very long burst (e.g. \`for i in {1..1000}; do echo \$i; done\`) should not freeze the tab; the rAF coalescing keeps a single React commit per paint.
- [ ] Cleanup: switching stacks or unmounting the viewer cancels the scheduled rAF cleanly.

## Notes

- Backend untouched: \`ComposeService.streamLogs\` already sends each line as soon as the docker child process emits it, and \`LogFormatter.process\` only colorises (no timestamp rewrite).
- No new dependencies; no test infrastructure change.