### PR TITLE
fix(monitor): include node name in janitor alert; stop firing on near-empty hosts

### DIFF
--- a/backend/src/services/MonitorService.ts
+++ b/backend/src/services/MonitorService.ts
@@ -4,6 +4,7 @@ import { promisify } from 'util';
 import semver from 'semver';
 import DockerController from './DockerController';
 import { DatabaseService } from './DatabaseService';
+import { NodeRegistry } from './NodeRegistry';
 import { NotificationService } from './NotificationService';
 import { isValidVersion, getSenchoVersion } from './CapabilityRegistry';
 import { getLatestVersion } from '../utils/version-check';
@@ -182,9 +183,13 @@ export class MonitorService {
                             const match = reclaimStr.match(/^([0-9.]+)([a-zA-Z]+)/);
                             if (match) {
                                 const val = parseFloat(match[1]);
-                                const unit = match[2];
+                                // Docker emits both "kB" (lowercase k) on newer versions and "KB"
+                                // historically. Normalise so neither is silently dropped, and
+                                // include "TB" for hosts with terabytes of reclaimable build cache.
+                                const unit = match[2].toUpperCase();
                                 let bytes = 0;
-                                if (unit === 'GB') bytes = val * 1024 * 1024 * 1024;
+                                if (unit === 'TB') bytes = val * 1024 * 1024 * 1024 * 1024;
+                                else if (unit === 'GB') bytes = val * 1024 * 1024 * 1024;
                                 else if (unit === 'MB') bytes = val * 1024 * 1024;
                                 else if (unit === 'KB') bytes = val * 1024;
                                 else if (unit === 'B') bytes = val;
@@ -199,10 +204,17 @@ export class MonitorService {
 
                 const reclaimGb = totalReclaimableBytes / (1024 * 1024 * 1024);
                 const JANITOR_COOLDOWN_MS = 24 * 60 * 60 * 1000; // 24 hours
+                // Sanity floor: never alert on near-empty hosts even if the user
+                // configured an aggressive threshold like 0.001 GB. 100 MB is the
+                // smallest waste worth interrupting an operator over.
+                const MIN_RECLAIMABLE_GB = 0.1;
 
-                if (reclaimGb >= janitorLimitGb) {
+                if (reclaimGb >= janitorLimitGb && reclaimGb >= MIN_RECLAIMABLE_GB) {
+                    const registry = NodeRegistry.getInstance();
+                    const localNode = registry.getNode(registry.getDefaultNodeId());
+                    const nodeLabel = localNode?.name ?? 'this node';
                     await this.dispatchWithCooldown(HOST_ALERT_KEYS.janitor, JANITOR_COOLDOWN_MS, 'info',
-                        `Your system has accumulated ${reclaimGb.toFixed(1)} GB of unused Docker data. Consider using the Janitor tool.`);
+                        `Node "${nodeLabel}" has accumulated ${reclaimGb.toFixed(1)} GB of unused Docker data. Consider using the Janitor tool.`);
                 }
             }
         } catch (e) {


### PR DESCRIPTION
## Summary

Three small fixes to the Docker janitor watchdog in \`MonitorService.evaluateGlobalSettings\`:

- **Node identification.** The alert message previously said *"Your system has accumulated X GB"* with no node identifier. On a multi-node fleet the operator could not tell which node it referred to. Resolve the local node via \`NodeRegistry.getNode(getDefaultNodeId())\` and prefix the message with \`Node "<name>"\`.
- **No alerts on near-empty hosts.** The threshold gate was a single \`reclaimGb >= janitorLimitGb\` comparison. With a small or accidentally tiny configured threshold, the alert fired on hosts with effectively no waste. Add a \`MIN_RECLAIMABLE_GB = 0.1\` absolute floor so trivial cruft never triggers a notification.
- **Unit parser correctness.** The parser only matched \`GB|MB|KB|B\`. Modern Docker emits \`kB\` with a lowercase \`k\`, which silently contributed zero bytes; \`TB\` was missing entirely. Normalise the unit to uppercase before the comparison and add the \`TB\` case.

## Test plan

- [x] \`tsc --noEmit\` passes for the backend.
- [x] \`vitest run monitor-service\` passes (42 / 42).
- [ ] Manual: set \`docker_janitor_gb\` to a low value on a node already pruned. No alert fires (below the 100 MB floor).
- [ ] Manual: pull a few unused images to push reclaimable above 0.5 GB; wait for the next eval cycle. Alert text includes \`Node "<your-node-name>"\`.
- [ ] Targeted unit tests for the three branches (TB unit, lowercase \`kB\`, sub-floor reclaimable, node-name interpolation) are a recommended follow-up; the change is shipped without them because the existing 42 monitor-service tests still pass and the new branches are simple.

## Notes

The local-node lookup uses the existing \`NodeRegistry.getNode(getDefaultNodeId())\` accessor; no new helper added.