### PR TITLE
fix(env): return empty body for missing .env files; surface non-OK responses cleanly

### DIFF
--- a/backend/src/routes/stacks.ts
+++ b/backend/src/routes/stacks.ts
@@ -185,7 +185,7 @@ stacksRouter.get('/:stackName/env', async (req: Request, res: Response) => {
     const requestedFile = req.query.file as string | undefined;
     const envPaths = await resolveAllEnvFilePaths(req.nodeId, stackName);
 
-    let envPath = envPaths[0];
+    let envPath: string | undefined = envPaths[0];
 
     if (requestedFile) {
       if (envPaths.includes(requestedFile)) {
@@ -193,6 +193,15 @@ stacksRouter.get('/:stackName/env', async (req: Request, res: Response) => {
       } else {
         return res.status(400).json({ error: 'Requested env file not allowed' });
       }
+    }
+
+    // Default path with no env files yet: reply 200 with an empty body and a
+    // header the frontend can read. This avoids surfacing a 404 for the
+    // legitimate "stack has no .env yet" case, which previous flows
+    // sometimes echoed back to the user as a confusing error string.
+    if (!envPath) {
+      res.setHeader('X-Env-Exists', 'false');
+      return res.send('');
     }
 
     const fsService = FileSystemService.getInstance(req.nodeId);
@@ -204,11 +213,31 @@ stacksRouter.get('/:stackName/env', async (req: Request, res: Response) => {
       if (code !== 'ENOENT') {
         console.error('[Sencho] Unexpected error checking env file existence:', (e as Error).message);
       }
-      return res.status(404).json({ error: 'Env file not found' });
+      // No env file at the resolved path. For an explicit ?file= query we
+      // surface a 404 (the caller asked for something specific). Otherwise
+      // treat it as the empty-stack case above.
+      if (requestedFile) {
+        return res.status(404).json({ error: 'Env file not found' });
+      }
+      res.setHeader('X-Env-Exists', 'false');
+      return res.send('');
     }
 
-    const content = await fsService.readFile(envPath, 'utf-8');
-    res.send(content);
+    try {
+      const content = await fsService.readFile(envPath, 'utf-8');
+      res.setHeader('X-Env-Exists', 'true');
+      return res.send(content);
+    } catch (e: unknown) {
+      // TOCTOU: the file existed at access() but vanished before readFile().
+      // Return the same friendly empty-body shape rather than a generic 500
+      // that the frontend would otherwise echo as an opaque error.
+      const code = (e as NodeJS.ErrnoException)?.code;
+      if (code === 'ENOENT' && !requestedFile) {
+        res.setHeader('X-Env-Exists', 'false');
+        return res.send('');
+      }
+      throw e;
+    }
   } catch (error) {
     console.error('Failed to read env file:', error);
     res.status(500).json({ error: 'Failed to read env file' });

--- a/frontend/src/components/EditorLayout.tsx
+++ b/frontend/src/components/EditorLayout.tsx
@@ -1159,11 +1159,20 @@ export default function EditorLayout() {
     setIsFileLoading(true);
     try {
       const res = await apiFetch(`/stacks/${selectedFile}/env?file=${encodeURIComponent(file)}`);
+      if (!res.ok) {
+        // Don't stuff a JSON error body into the editor on a non-OK response.
+        setEnvContent('');
+        setOriginalEnvContent('');
+        toast.error('Could not load env file');
+        return;
+      }
       const text = await res.text();
       setEnvContent(text || '');
       setOriginalEnvContent(text || '');
     } catch (e) {
       console.error('Failed to switch env file', e);
+      setEnvContent('');
+      setOriginalEnvContent('');
     } finally {
       setIsFileLoading(false);
     }


### PR DESCRIPTION
## Summary

When a stack has no \`.env\` files configured, fetching them returned a 404 with a JSON error body. The frontend's secondary loader (\`changeEnvFile\`) called \`res.text()\` without checking \`res.ok\`, so the JSON error body could end up pasted directly into the editor and read back to the user as a "raw error". Two-part fix:

### Backend (\`routes/stacks.ts\`)
- Default \`GET /stacks/:name/env\` (no \`?file=\` query) for a stack with no env files now returns **200** with an empty body and an \`X-Env-Exists: false\` header. The legitimate "no .env yet" case stops looking like a server error.
- Explicit \`?file=\` queries that resolve to a missing file keep the **404** (the caller asked for something specific and it's not there).
- Catch a TOCTOU \`ENOENT\` between \`access()\` and \`readFile()\` and return the same friendly empty-body shape rather than the generic 500.

### Frontend (\`EditorLayout.tsx::changeEnvFile\`)
- Check \`res.ok\` before reading the body. On a non-OK response, clear the editor content and surface a friendly \`toast.error('Could not load env file')\` instead of stuffing the server's error JSON into the file.

## Test plan

- [x] \`tsc --noEmit\` passes for the backend.
- [x] \`tsc -b --noEmit\` passes for the frontend.
- [ ] Manual: open a stack with a \`compose.yaml\` but no \`.env\`. The .env tab loads empty with no toast and no error in the network panel (\`200\` + \`X-Env-Exists: false\`).
- [ ] Manual: save the empty editor — the .env file is created.
- [ ] Manual: with multiple \`env_file:\` entries declared in compose, switch between them. Missing files surface a toast and clear the editor instead of pasting JSON into it.

## Notes

- A Vitest case for the new behaviour requires a supertest app fixture that does not exist yet for the stacks router; recommended as a follow-up alongside other route-level coverage. The change keeps the existing 404 contract for explicit \`?file=\` queries so any external automation that probes specific files still sees the same response shape.