### PR TITLE
fix(logs): drop millisecond suffix from log timestamp display

### DIFF
--- a/frontend/src/components/StructuredLogViewer.tsx
+++ b/frontend/src/components/StructuredLogViewer.tsx
@@ -43,8 +43,7 @@ function formatTs(iso: string | null): string {
   const hh = String(d.getHours()).padStart(2, '0');
   const mm = String(d.getMinutes()).padStart(2, '0');
   const ss = String(d.getSeconds()).padStart(2, '0');
-  const ms = String(d.getMilliseconds()).padStart(3, '0');
-  return `${hh}:${mm}:${ss}.${ms}`;
+  return `${hh}:${mm}:${ss}`;
 }
 
 export default function StructuredLogViewer({ stackName }: StructuredLogViewerProps) {


### PR DESCRIPTION
## Summary

Revert the timestamp formatter back to \`HH:mm:ss\`. The \`.SSS\` suffix made the column busier than the log content needed and was harder to scan at a glance.

The underlying ISO timestamp from \`docker logs -t\` is still preserved on each row, so download / copy still carries the original precision.

The rAF-based flush from the same area stays in place — that's what makes lines feel real-time, not the timestamp width.

## Test plan

- [x] \`tsc -b --noEmit\` passes for the frontend.
- [ ] Manual: open the logs panel, confirm timestamps render \`HH:mm:ss\` only.
- [ ] Manual: a chatty container still feels real-time (rAF batching is unchanged).