### PR TITLE
fix(sidebar): remove 1-hour staleness filter from activity ticker

### DIFF
--- a/frontend/src/components/sidebar/SidebarActivityTicker.tsx
+++ b/frontend/src/components/sidebar/SidebarActivityTicker.tsx
@@ -1,10 +1,9 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useReducer } from 'react';
 import { cn } from '@/lib/utils';
 import { formatTimeAgo } from '@/lib/relativeTime';
 import type { NotificationItem } from '@/components/dashboard/types';
 
-const ONE_HOUR_S = 60 * 60;
-const NOW_TICK_MS = 30_000;
+const NOW_TICK_MS = 10_000;
 
 interface SidebarActivityTickerProps {
   notifications: NotificationItem[];
@@ -13,16 +12,16 @@ interface SidebarActivityTickerProps {
 }
 
 export function SidebarActivityTicker({ notifications, connected, onNavigate }: SidebarActivityTickerProps) {
-  const [nowS, setNowS] = useState(() => Math.floor(Date.now() / 1000));
+  const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
   useEffect(() => {
-    const id = setInterval(() => setNowS(Math.floor(Date.now() / 1000)), NOW_TICK_MS);
+    const id = setInterval(forceUpdate, NOW_TICK_MS);
     return () => clearInterval(id);
   }, []);
   const latest = useMemo(() => {
     return notifications
-      .filter(n => n.stack_name && nowS - n.timestamp <= ONE_HOUR_S)
+      .filter(n => n.stack_name)
       .sort((a, b) => b.timestamp - a.timestamp)[0] ?? null;
-  }, [notifications, nowS]);
+  }, [notifications]);
 
   const idle = latest === null;
   const dotClass = connected


### PR DESCRIPTION
## Summary

- Removed the 1-hour sliding window filter that caused the activity ticker to show \"No recent activity\" after 60 minutes of no Docker events, even when prior events existed in the session
- The ticker now shows the most recent stack event regardless of age, with a live relative timestamp (e.g. \"2h ago\")
- The idle state now only appears when zero events have arrived since the page loaded, which is the honest signal it was meant to convey
- Reduced the update interval from 30s to 10s so relative timestamps stay responsive
- Replaced the unused `nowS` state variable with a `forceUpdate` reducer to keep periodic re-renders without triggering TypeScript's unused-variable check

## Test plan

- [ ] Deploy or restart a stack, note the ticker shows the event
- [ ] Wait more than 1 hour without further Docker events; confirm the ticker still shows the last event with an updated \"Xh ago\" label instead of flipping to idle
- [ ] On a fresh page load with no prior events in the session, confirm the ticker shows the idle state correctly
- [ ] Confirm the relative timestamp updates every ~10 seconds

## Notes

No backend changes. Single frontend component touched.