### PR TITLE
feat(app-store): sort grid by stars and rotate featured weekly

### DIFF
--- a/backend/src/routes/templates.ts
+++ b/backend/src/routes/templates.ts
@@ -25,15 +25,15 @@ templatesRouter.get('/', authMiddleware, async (req: Request, res: Response) => 
     const imageRefs = templates.map(t => t.image).filter((i): i is string => !!i);
     const scanSummary = DatabaseService.getInstance().getLatestScanSummaryByImageRefs(req.nodeId, imageRefs);
 
-    let featuredIndex = -1;
-    let featuredStars = 0;
-    templates.forEach((t, i) => {
-      const s = t.stars ?? 0;
-      if (s > featuredStars) {
-        featuredStars = s;
-        featuredIndex = i;
-      }
-    });
+    const topCandidates = templates
+      .map((t, i) => ({ t, i }))
+      .filter(({ t }) => (t.stars ?? 0) > 0)
+      .sort((a, b) => (b.t.stars ?? 0) - (a.t.stars ?? 0))
+      .slice(0, 5);
+    const weekIndex = Math.floor(Date.now() / (7 * 86_400_000));
+    const featuredIndex = topCandidates.length > 0
+      ? topCandidates[weekIndex % topCandidates.length].i
+      : -1;
 
     const enriched = templates.map((t, i) => {
       const summary = t.image ? scanSummary.get(t.image) : undefined;

--- a/frontend/src/components/AppStoreView.tsx
+++ b/frontend/src/components/AppStoreView.tsx
@@ -247,8 +247,10 @@ export function AppStoreView({ onDeploySuccess }: AppStoreViewProps) {
     }, [filtered, searchQuery]);
 
     const gridTemplates = useMemo(() => {
-        if (!featuredTemplate) return filtered;
-        return filtered.filter(t => t.title !== featuredTemplate.title);
+        const base = featuredTemplate
+            ? filtered.filter(t => t.title !== featuredTemplate.title)
+            : filtered;
+        return [...base].sort((a, b) => (b.stars ?? 0) - (a.stars ?? 0));
     }, [filtered, featuredTemplate]);
 
     return (


### PR DESCRIPTION
## Summary

- App Store grid is now sorted by star count descending, so popular and well-regarded apps surface at the top instead of appearing in registry fetch order
- Featured hero rotates weekly among the top 5 starred apps rather than always pinning the single highest-starred entry; rotation is seeded by week number so all nodes show the same featured app throughout a given week
- Registries with no star data (custom registries that do not expose GitHub star counts) gracefully skip the featured hero and preserve their natural ordering in the grid

## Test plan

- [ ] Open the App Store; confirm the grid is ordered by star count (highest first)
- [ ] Verify the featured hero displays one of the top starred apps
- [ ] Confirm that after advancing the week seed (or patching `Date.now` in a test), a different top-5 app becomes featured
- [ ] Configure a custom registry with no star data; confirm no featured hero is shown and the grid renders in registry order

## Notes

Backend change is in `templates.ts` (featured selection logic, ~6 lines). Frontend change is in `AppStoreView.tsx` (grid sort in a single `useMemo`). No schema or API contract changes.