### PR TITLE
feat(stacks): add optional volume prune to delete confirmation

### DIFF
--- a/backend/src/routes/stacks.ts
+++ b/backend/src/routes/stacks.ts
@@ -526,11 +526,21 @@ stacksRouter.delete('/:stackName', async (req: Request, res: Response) => {
   if (!isValidStackName(stackName)) {
     return res.status(400).json({ error: 'Invalid stack name' });
   }
+  const pruneVolumes = req.query.pruneVolumes === 'true';
   try {
     try {
       await ComposeService.getInstance(req.nodeId).downStack(stackName);
     } catch (downErr) {
       console.warn(`[Teardown] Docker down failed or nothing to clean up for ${stackName}`);
+    }
+
+    if (pruneVolumes) {
+      try {
+        const result = await DockerController.getInstance().pruneManagedOnly('volumes', [stackName]);
+        console.log(`[Stacks] Pruned volumes for ${stackName}: ${result.reclaimedBytes} bytes reclaimed`);
+      } catch (pruneErr) {
+        console.warn(`[Stacks] Volume prune failed for ${stackName}, continuing delete:`, pruneErr);
+      }
     }
 
     let fsErr: unknown = null;

--- a/frontend/src/components/EditorLayout.tsx
+++ b/frontend/src/components/EditorLayout.tsx
@@ -271,6 +271,7 @@ export default function EditorLayout() {
   const [gitDeployNow, setGitDeployNow] = useState(false);
   const [creatingFromGit, setCreatingFromGit] = useState(false);
   const [stackToDelete, setStackToDelete] = useState<string | null>(null);
+  const [pruneVolumesOnDelete, setPruneVolumesOnDelete] = useState(false);
   const [pendingUnsavedLoad, setPendingUnsavedLoad] = useState<string | null>(null);
   const [pendingUnsavedNode, setPendingUnsavedNode] = useState<Node | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -1556,7 +1557,10 @@ export default function EditorLayout() {
     if (isStackBusy(deleteKey)) return;
     setStackAction(deleteKey, 'delete');
     try {
-      const response = await apiFetch(`/stacks/${stackToDelete}`, {
+      const url = pruneVolumesOnDelete
+        ? `/stacks/${stackToDelete}?pruneVolumes=true`
+        : `/stacks/${stackToDelete}`;
+      const response = await apiFetch(url, {
         method: 'DELETE',
       });
       if (!response.ok) {
@@ -1566,6 +1570,7 @@ export default function EditorLayout() {
       toast.success('Stack deleted successfully!');
       setDeleteDialogOpen(false);
       setStackToDelete(null);
+      setPruneVolumesOnDelete(false);
       if (selectedFile === stackToDelete) {
         setSelectedFile(null);
         setContent('');
@@ -1980,7 +1985,7 @@ export default function EditorLayout() {
       stop: () => executeStackActionByFile(file, 'stop', 'stop'),
       restart: () => executeStackActionByFile(file, 'restart', 'restart'),
       update: () => executeStackActionByFile(file, 'update', 'update'),
-      remove: () => { setStackToDelete(stackName); setDeleteDialogOpen(true); },
+      remove: () => { setStackToDelete(stackName); setPruneVolumesOnDelete(false); setDeleteDialogOpen(true); },
       pin: () => pin(file),
       unpin: () => unpin(file),
       setAutoUpdateEnabled: async (enabled: boolean) => {
@@ -2487,6 +2492,7 @@ export default function EditorLayout() {
                                   disabled={loadingAction !== null}
                                   onClick={() => {
                                     setStackToDelete(selectedFile);
+                                    setPruneVolumesOnDelete(false);
                                     setDeleteDialogOpen(true);
                                   }}
                                 >
@@ -2936,6 +2942,16 @@ export default function EditorLayout() {
               Are you sure you want to delete {stackToDelete}? This action cannot be undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
+          <div className="flex items-center gap-2 px-1 py-1">
+            <Checkbox
+              id="prune-volumes"
+              checked={pruneVolumesOnDelete}
+              onCheckedChange={(v) => setPruneVolumesOnDelete(v === true)}
+            />
+            <label htmlFor="prune-volumes" className="text-sm text-muted-foreground cursor-pointer select-none">
+              Also remove associated volumes
+            </label>
+          </div>
           <AlertDialogFooter>
             <AlertDialogCancel onClick={() => setDeleteDialogOpen(false)}>Cancel</AlertDialogCancel>
             <AlertDialogAction className="bg-destructive text-destructive-foreground hover:bg-destructive/90" onClick={deleteStack}>Delete</AlertDialogAction>


### PR DESCRIPTION
## Summary

- The Delete Stack confirmation dialog now includes an opt-in checkbox: \"Also remove associated volumes\"
- The checkbox is unchecked by default and resets to unchecked each time the dialog opens, so the destructive default is always to preserve volumes
- When checked, the backend calls the existing `pruneManagedOnly` method for volumes labeled with the stack's Docker Compose project name; prune failure is non-fatal and logged, so the delete always completes regardless
- No tier gate: this is an explicit one-time user action at delete time, equivalent to `docker compose down --volumes` from the CLI

## Test plan

- [ ] Open the delete confirmation for a stack that has named volumes; verify the checkbox is present and unchecked by default
- [ ] Delete with the checkbox unchecked; confirm the stack is removed but volumes remain (`docker volume ls`)
- [ ] Delete a second stack with the checkbox checked; confirm the stack and its associated volumes are removed
- [ ] Delete a stack with no volumes and the checkbox checked; confirm the delete succeeds without error
- [ ] Cancel the dialog and reopen it; confirm the checkbox resets to unchecked

## Notes

Backend: `DELETE /stacks/:name` now accepts `?pruneVolumes=true`. Frontend: two state variables added to `EditorLayout` (`pruneVolumesOnDelete`, reset on open). No schema changes.