### PR TITLE
fix(deps): bump dompurify to 3.4.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4654,9 +4654,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,7 +57,7 @@
     "yaml": "^2.8.3"
   },
   "overrides": {
-    "dompurify": "^3.3.3"
+    "dompurify": "^3.4.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## Summary
- Bumps the `dompurify` npm override in `frontend/package.json` from `^3.3.3` to `^3.4.0`. Lockfile picks up `3.4.1`.
- Resolves all four open Dependabot advisories on the package, all patched in `3.4.0`:
  - GHSA-39q2-94rc-95cp (ADD_TAGS function form bypasses FORBID_TAGS due to short-circuit eval)
  - GHSA-v9jr-rg53-9pgp / CVE-2026-41238 (prototype pollution to XSS via CUSTOM_ELEMENT_HANDLING fallback)
  - GHSA-h7mw-gpvr-xq4m / CVE-2026-41240 (FORBID_TAGS bypass via function-based ADD_TAGS predicate)
  - GHSA-crv5-9vww-q3g8 / CVE-2026-41239 (SAFE_FOR_TEMPLATES bypass in RETURN_DOM mode)
- Two-line diff in `package.json` plus the lockfile entry update.

## Test plan
- [x] `npx tsc -b --noEmit` clean.
- [x] `npm run build` clean (no new warnings beyond the existing chunk-size advisory).
- [x] `npm install` reports `found 0 vulnerabilities`.
- [x] Dev server smoke: backend on :1852 + frontend on :5173 boot cleanly, app root loads, no console errors.

## Notes
- `dompurify` is a transitive dependency (no direct import in `frontend/src`); the bump flows through the `overrides` entry, which is why no `dependencies` block changes.