### PR TITLE
fix(docker): build compose plugin from ./cmd, not ./cmd/compose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,18 @@ jobs:
           format: 'table'
           trivy-config: trivy.yaml
 
+      # Mirror of the release-time pre-publish smoke gate in docker-publish.yml.
+      # Catches the class of failure where the source-built Docker CLI or
+      # Compose plugin compiles cleanly but does not exec at runtime (e.g. -o
+      # pointed at a non-main Go package, ABI breakage in a base image bump).
+      # The release workflow additionally polls /api/health; PR CI keeps just
+      # the binary check to bound job duration without losing the gate.
+      - name: Smoke test built image (binaries)
+        run: |
+          set -euo pipefail
+          docker run --rm --entrypoint sh sencho:pr-test -c \
+            'docker --version && docker compose version'
+
   # ---------------------------------------------------------------------------
   # E2E Tests (PRs only, skipped for release-please PRs)
   # ---------------------------------------------------------------------------

--- a/.trivyignore
+++ b/.trivyignore
@@ -23,3 +23,14 @@
 # BSD operating systems and Sencho ships linux/amd64 + linux/arm64 only.
 # See security/vex/sencho.openvex.json for the full impact statement.
 CVE-2026-39883
+
+# Justification: covered by VEX statement for CVE-2026-34040 (Moby authz
+# bypass on oversized request body). compose v5.1.2 bundles the legacy
+# github.com/docker/docker@v28.5.2+incompatible as a client-side library
+# for API types and codecs; the daemon-side authz hook code path the CVE
+# affects is unreachable from a CLI client. The advisory's fix in
+# Docker Engine 29.3.1 ships under the new github.com/moby/moby/v2
+# module path which compose v5.1.2 does not yet import, so v28.5.2 is
+# the only Go-module-resolvable version reachable from compose. See
+# security/vex/sencho.openvex.json for the full impact statement.
+CVE-2026-34040

--- a/Dockerfile
+++ b/Dockerfile
@@ -148,6 +148,17 @@ RUN mkdir -p /build
 # v5.1.2's Makefile. The directory ./cmd/compose is package compose (cobra
 # command definitions only, not main). The module path moved from /v2 to /v5
 # in the v5 release, so the Version ldflag must reference /v5/internal.
+#
+# The bundled github.com/docker/docker dependency stays at v28.5.2+incompatible
+# (compose v5.1.2's go.mod). It cannot be upgraded to docker-v29.3.1 (the
+# release that contains the CVE-2026-34040 authz fix) because moby/moby's
+# docker-29.x branch declares its module path as github.com/moby/moby/v2,
+# making it unreachable through the legacy github.com/docker/docker import
+# that compose v5.1.2 still uses. The Go module proxy reflects this and lists
+# v28.5.2+incompatible as the highest resolvable version. The CVE only affects
+# Docker Engine's daemon authz hook code path; compose runs as a CLI client
+# and never executes that path. See security/vex/sencho.openvex.json for the
+# full not_affected justification, which Trivy honours via trivy.yaml.
 RUN --mount=type=cache,id=go-mod,sharing=locked,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
       -trimpath \

--- a/Dockerfile
+++ b/Dockerfile
@@ -144,12 +144,28 @@ WORKDIR /src/docker-compose
 
 RUN mkdir -p /build
 
+# Build target is ./cmd (the package main with plugin.Run), per docker/compose
+# v5.1.2's Makefile. The directory ./cmd/compose is package compose (cobra
+# command definitions only, not main). The module path moved from /v2 to /v5
+# in the v5 release, so the Version ldflag must reference /v5/internal.
 RUN --mount=type=cache,id=go-mod,sharing=locked,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
-      -ldflags "-extldflags=-static \
-        -X github.com/docker/compose/v2/internal.Version=v5.1.2" \
+      -trimpath \
+      -ldflags "-s -w -extldflags=-static \
+        -X github.com/docker/compose/v5/internal.Version=v5.1.2" \
       -o /build/docker-compose \
-      ./cmd/compose
+      ./cmd
+
+# Sanity check: fail the stage immediately if go build did not produce an ELF
+# executable. Catches the failure mode where -o file points to a non-main
+# package and Go writes an ar-format archive that passes COPY + chmod but is
+# not exec-able by the kernel, surfacing only as an opaque plugin-not-found
+# error from the Docker CLI plugin manager hundreds of build steps later.
+# `od -tx1` is used instead of `-c` because busybox and GNU coreutils render
+# `-c` with different field padding; hex output is stable across both.
+RUN test -f /build/docker-compose \
+ && magic=$(dd if=/build/docker-compose bs=1 count=4 status=none | od -An -tx1 | tr -d ' \n') \
+ && [ "$magic" = "7f454c46" ]
 
 # Stage 5: Production runtime
 # Runs on the TARGET platform - no compilation happens here.

--- a/security/vex/sencho.openvex.json
+++ b/security/vex/sencho.openvex.json
@@ -26,7 +26,7 @@
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "The authz bypass applies to Docker daemon plugin authorization hooks. docker-compose v5.1.2 statically bundles docker/docker v28.5.2+incompatible as a library but never acts as a daemon and never runs authorization hooks. Sencho invokes compose only for up/down/ps operations against local user-authored compose files. The daemon authz code path is not reachable."
+      "impact_statement": "The authz bypass affects Docker Engine's daemon-side plugin authorization hook on oversized request bodies. docker-compose v5.1.2 statically bundles docker/docker v28.5.2+incompatible as a client-side library for API types and codecs; it never acts as a daemon and never runs authorization hooks. Sencho invokes compose only for up/down/ps operations against local user-authored compose files. The daemon authz code path is not reachable. Note on remediation: the advisory's 'fixed in 29.3.1' refers to Docker Engine the daemon product. The Go library that contains the corresponding source fix is github.com/moby/moby/v2 (a new module path adopted on the docker-29.x branch), not github.com/docker/docker which compose v5.1.2 still imports. Until upstream compose migrates to the v2 import path the v28.5.2+incompatible bundled library is the only Go-module-resolvable version, and the not_affected status is the principled triage rather than a deferred upgrade."
     },
     {
       "vulnerability": {

--- a/security/vex/sencho.openvex.json
+++ b/security/vex/sencho.openvex.json
@@ -4,8 +4,8 @@
   "author": "Studio Saelix",
   "role": "Vendor",
   "timestamp": "2026-04-26T00:00:00Z",
-  "last_updated": "2026-04-26T00:00:00Z",
-  "version": 1,
+  "last_updated": "2026-04-27T00:00:00Z",
+  "version": 2,
   "statements": [
     {
       "vulnerability": {
@@ -18,7 +18,7 @@
           "@id": "pkg:oci/sencho",
           "subcomponents": [
             {
-              "@id": "pkg:golang/github.com/docker/docker@v28.5.2",
+              "@id": "pkg:golang/github.com/docker/docker@v28.5.2+incompatible",
               "location": "/usr/local/lib/docker/cli-plugins/docker-compose"
             }
           ]
@@ -26,7 +26,7 @@
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "The authz bypass applies to Docker daemon plugin authorization hooks. docker-compose v5.1.2 statically bundles docker/docker v28.5.2 as a library but never acts as a daemon and never runs authorization hooks. Sencho invokes compose only for up/down/ps operations against local user-authored compose files. The daemon authz code path is not reachable."
+      "impact_statement": "The authz bypass applies to Docker daemon plugin authorization hooks. docker-compose v5.1.2 statically bundles docker/docker v28.5.2+incompatible as a library but never acts as a daemon and never runs authorization hooks. Sencho invokes compose only for up/down/ps operations against local user-authored compose files. The daemon authz code path is not reachable."
     },
     {
       "vulnerability": {


### PR DESCRIPTION
## Summary

The `chore(main): release 0.64.0 (#728)` Release PR merged successfully, but the resulting `Build and Publish Docker Image` workflow failed at the new pre-publish smoke step with:

```
Docker version 29.4.0, build source-go1.26.2
docker: unknown command: docker compose
```

No 0.64.0 image was pushed to Docker Hub; `latest` is still 0.63.0. The smoke step worked exactly as intended; it caught a real regression introduced in #789's source-built Docker CLI/Compose work that PR CI did not exercise.

## Root cause

The `compose-builder` stage in `Dockerfile` built `./cmd/compose`, but in `docker/compose@v5.1.2` that directory is `package compose` (47 cobra command files: `up.go`, `down.go`, `compose.go`, etc., all library code). The actual CLI plugin entry point with `plugin.Run(...)` lives at `./cmd/main.go` (`package main`), which is also what the upstream Makefile builds.

`go build -o file pkg` against a non-main package writes a Go archive (`!<arch>` format), not an ELF executable. The COPY and chmod into Stage 5 accepted that archive, but Docker CLI's plugin manager could not exec it and rejected it silently, emitting its standard plugin-not-found message.

Secondary bug: the `-X .../internal.Version=v5.1.2` ldflag pointed at `github.com/docker/compose/v2/internal`, but the v5 release moved the module path to `.../v5`. The linker silently dropped the symbol and `docker compose version` would have printed an empty string even after the package-path fix.

## Changes (4 commits on this branch)

**1. `fix(docker):` Dockerfile compose-builder + PR CI gate**
- `./cmd/compose` -> `./cmd`
- `github.com/docker/compose/v2/internal.Version` -> `github.com/docker/compose/v5/internal.Version`
- Add `-trimpath` and `-s -w` for parity with the upstream Makefile.
- Add an inline ELF-magic sanity check (`dd | od -tx1` matched against `7f454c46`) so this exact failure mode fails inside the producer stage rather than at the smoke gate hundreds of build steps later. Hex match because busybox and GNU coreutils render `od -c` field padding differently.
- `.github/workflows/ci.yml` `docker-validate`: add a smoke step after the Trivy scan that runs `docker --version && docker compose version` against the loaded `sencho:pr-test` image, mirroring the release-time gate so this regression class cannot reach `main` again.

**2. `fix(vex):` Match Trivy purl format for the now-detected dep**
- Once the binary is a real ELF (commit 1), Trivy can finally read embedded Go module metadata and reports the bundled docker/docker dep as `v28.5.2+incompatible`. The pre-existing OpenVEX subcomponent `@id` was `pkg:golang/github.com/docker/docker@v28.5.2` (no Go-module suffix), so Trivy's purl matcher rejected it.
- Updated the @id to the literal version Trivy emits and bumped the OpenVEX document version per spec. Justification (compose runs as a CLI client, never as a daemon, so the authz hook code path is unreachable) is unchanged.

**3. `docs(security):` Explain why an upgrade past v28.5.2+incompatible is not possible**
- Tried the actual upgrade in build: `go get github.com/docker/docker@<docker-v29.3.1 commit>` failed with `invalid version: go.mod has post-v1 module path "github.com/moby/moby/v2" at revision ...`. moby/moby migrated its Go module path to `github.com/moby/moby/v2` on the docker-29.x branch; the legacy `github.com/docker/docker` import path is frozen at `v28.5.2+incompatible` from Go's perspective. `proxy.golang.org/github.com/docker/docker/@v/list` confirms no v29.x is resolvable.
- compose v5.1.2 and v5.1.3 (current latest) both still import the legacy path. Until upstream compose migrates to `github.com/moby/moby/v2`, the bundled docker/docker library cannot be moved past v28.5.2+incompatible.
- Documented the constraint in the Dockerfile compose-builder comment block and in the VEX statement's `impact_statement`, so a future maintainer is not tempted to re-attempt the same dead-end upgrade.

**4. `fix(security):` Mirror CVE-2026-34040 VEX entry in .trivyignore**
- Trivy logged `Some vulnerabilities have been ignored/suppressed` but still failed on CVE-2026-34040, because the OpenVEX statement's product `pkg:oci/sencho` cannot match a build-local image like `sencho:pr-test` (Trivy does not emit an OCI purl for images without a registry digest, aquasecurity/trivy#9399). The dual-layer pattern is documented in `.trivyignore`'s header and was already in use for CVE-2026-39883: VEX is the canonical, signed, attested triage record, and `.trivyignore` mirrors entries that scan-time matching cannot resolve. CVE-2026-34040 now follows the same pattern, with a comment that points back to the OpenVEX justification.

## Conflict check vs. prior security hardening

| Hardening | Status |
|---|---|
| #789: build CLI/Compose from source, pin FROM digests, SHA-pin actions | Preserved. Source builds remain; my fix is *to* the source build, not away from it. Digests and action SHAs untouched. |
| #789: pre-publish smoke gate | Preserved + reinforced. Same gate now in PR CI. ELF magic check inside compose-builder kills the failure at the producer. |
| #790: OpenVEX as canonical triage record, .trivyignore reduced to a build-time mirror | Preserved. Other 4 VEX statements (buildkit, otel) unchanged. CVE-2026-34040 statement retains the same `not_affected / vulnerable_code_not_in_execute_path` status with an enriched justification citing the upstream module split. .trivyignore continues its documented dual-layer role: VEX is canonical, .trivyignore mirrors entries Trivy can't auto-suppress at scan time on local images. |
| #790: SBOM CycloneDX/SPDX, cosign attestations | Untouched. |
| #791: CodeQL + Dependabot Docker ecosystem | Untouched. |

## Test plan

- [x] Local build (`docker buildx build --target compose-builder --output type=tar,...`) succeeds, including the new ELF sanity check (`magic = 7f454c46`).
- [x] Extracted binary is a true ELF (`\x7f E L F`, 29 MB statically-linked Go binary). Pre-fix it was a Go archive (`!<arch>`).
- [x] In-build upgrade attempt confirmed infeasible (`go get github.com/docker/docker@<docker-v29.3.1>` fails on the moby/moby/v2 module path migration), justifying the VEX path with concrete evidence rather than convenience.
- [ ] CI green on this PR. Trivy step should now report 0 high/critical findings against the rebuilt image. Smoke step should pass against the working compose plugin.

## Re-release path after merge

`release-please` will detect the `fix:` commits and open `chore(main): release 0.64.1`. Merging that triggers `docker-publish.yml` against `v0.64.1`; with this fix the smoke step passes and the image, cosign signature, SBOM/VEX attestations, and GitHub Release assets all publish as intended. The orphan `v0.64.0` GitHub Release will be tidied separately (note pointing to 0.64.1; tag preserved so release-please state stays consistent).

Closes the failure of run #238 (https://github.com/AnsoCode/Sencho/actions/runs/24977257105).