### PR TITLE
fix(backend): use URL parser for registry scheme + template host check

### DIFF
--- a/backend/src/routes/registries.ts
+++ b/backend/src/routes/registries.ts
@@ -11,17 +11,14 @@ function isValidRegistryUrl(url: string, type: string): boolean {
   if (type === 'dockerhub') return true;
   const trimmed = url.trim();
   if (!trimmed) return false;
-  const lower = trimmed.toLowerCase();
-  if (lower.startsWith('javascript:') || lower.startsWith('data:') || lower.startsWith('file:') || lower.startsWith('ftp:')) {
-    return false;
-  }
+  let parsed: URL;
   try {
-    const parsed = new URL(trimmed.includes('://') ? trimmed : `https://${trimmed}`);
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
-    if (!parsed.hostname) return false;
+    parsed = new URL(trimmed.includes('://') ? trimmed : `https://${trimmed}`);
   } catch {
     return false;
   }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+  if (!parsed.hostname) return false;
   return true;
 }
 

--- a/backend/src/services/TemplateService.ts
+++ b/backend/src/services/TemplateService.ts
@@ -233,7 +233,9 @@ export class TemplateService {
                     console.log(`[Templates] Fetching from registry: ${registryUrl}`);
                     const debug = isDebugEnabled();
 
-                    if (registryUrl.includes('api.linuxserver.io')) {
+                    let registryHost = '';
+                    try { registryHost = new URL(registryUrl).hostname.toLowerCase(); } catch { /* invalid URL, treated as non-LSIO */ }
+                    if (registryHost === 'api.linuxserver.io') {
                         const response = await axios.get<LsioApiResponse>(registryUrl, { timeout: 20_000 });
                         // Official LSIO API Schema Mapping
                         const lsioApps = response.data?.data?.repositories?.linuxserver ?? {};


### PR DESCRIPTION
## Summary
Closes two CodeQL alerts with surgical edits:

- **routes/registries.ts** (\`js/incomplete-url-scheme-check\`): the \`startsWith\` block-list (\`javascript:\`, \`data:\`, \`file:\`, \`ftp:\`) was unreachable defense, the protocol allow-list immediately below already rejects any non-http/https scheme. Drop the duplicate check.
- **services/TemplateService.ts** (\`js/incomplete-url-substring-sanitization\`): replace \`registryUrl.includes('api.linuxserver.io')\` with a hostname compare (\`new URL(registryUrl).hostname.toLowerCase() === 'api.linuxserver.io'\`). The substring form would mis-classify an admin-set URL like \`https://evil.example/api.linuxserver.io/...\` as the LSIO registry and apply the LSIO response parser to its payload.

## Test plan
- [x] \`npx tsc --noEmit\` clean.
- [x] Vitest: \`registry-service.test.ts\` (35) + \`template-service.test.ts\` (9) all pass.

## Notes
Behavioral parity for the happy path: every previously-accepted URL still parses; the LSIO branch still triggers when the hostname is exactly \`api.linuxserver.io\`.