### PR TITLE
perf(backend): cache global_settings reads in DatabaseService

### DIFF
--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -41,7 +41,7 @@ export const settingsRouter = Router();
 
 settingsRouter.get('/', authMiddleware, async (_req: Request, res: Response): Promise<void> => {
   try {
-    const settings = DatabaseService.getInstance().getGlobalSettings();
+    const settings = { ...DatabaseService.getInstance().getGlobalSettings() };
     for (const key of PRIVATE_SETTINGS_KEYS) {
       delete settings[key];
     }

--- a/backend/src/services/DatabaseService.ts
+++ b/backend/src/services/DatabaseService.ts
@@ -470,6 +470,13 @@ export interface ScanSummary {
 export class DatabaseService {
     private static instance: DatabaseService;
     private db: Database.Database;
+    // Cache of the global_settings table, populated on first read and
+    // invalidated by updateGlobalSetting(). Hot paths (auth middleware,
+    // WS upgrade, the audit-log debug gate) read this on every request,
+    // so the round-trip to SQLite is worth eliminating. Assumes this
+    // process is the sole writer to global_settings; sidecar tools that
+    // edit the row directly will not invalidate the cache.
+    private cachedGlobalSettings: Readonly<Record<string, string>> | null = null;
 
     private constructor() {
         const dataDir = process.env.DATA_DIR || path.join(process.cwd(), 'data');
@@ -497,6 +504,11 @@ export class DatabaseService {
         this.migrateAgentsAndNotificationsNodeId();
         this.migratePolicyEvaluationColumn();
         this.migrateNotificationCategory();
+
+        // Reset the cache once at end of constructor in case any migration
+        // populated it via getGlobalSettings() and a subsequent migration
+        // changed the underlying rows.
+        this.cachedGlobalSettings = null;
     }
 
     public static getInstance(): DatabaseService {
@@ -1330,18 +1342,20 @@ export class DatabaseService {
 
     // --- Global Settings ---
 
-    public getGlobalSettings(): Record<string, string> {
+    public getGlobalSettings(): Readonly<Record<string, string>> {
+        if (this.cachedGlobalSettings) return this.cachedGlobalSettings;
         const stmt = this.db.prepare('SELECT * FROM global_settings');
+        const rows = stmt.all() as Array<{ key: string; value: string }>;
         const settings: Record<string, string> = {};
-        stmt.all().forEach((row: any) => {
-            settings[row.key] = row.value;
-        });
-        return settings;
+        for (const row of rows) settings[row.key] = row.value;
+        this.cachedGlobalSettings = Object.freeze(settings);
+        return this.cachedGlobalSettings;
     }
 
     public updateGlobalSetting(key: string, value: string): void {
         const stmt = this.db.prepare('INSERT OR REPLACE INTO global_settings (key, value) VALUES (?, ?)');
         stmt.run(key, value);
+        this.cachedGlobalSettings = null;
     }
 
     // --- System State (operational/runtime values - not user-defined config) ---

--- a/backend/src/utils/debug.ts
+++ b/backend/src/utils/debug.ts
@@ -1,30 +1,18 @@
 /**
- * Shared diagnostic logging gate.
- *
- * Reads `developer_mode` from the global settings, cached for a short
- * window so hot paths (per-request, per-log-line) do not hit SQLite
- * on every call.
+ * Shared diagnostic logging gate. Reads `developer_mode` from
+ * DatabaseService, which caches the global_settings snapshot internally
+ * and invalidates on write, so hot-path callers can query freely.
  */
 
-let cachedValue = false;
-let cacheExpiry = 0;
-const CACHE_TTL_MS = 5_000;
-
 export function isDebugEnabled(): boolean {
-  const now = Date.now();
-  if (now < cacheExpiry) return cachedValue;
-
   try {
     // Dynamic require avoids circular-dependency issues when this
     // utility is imported from services that DatabaseService itself
     // depends on, and prevents SQLite side effects during tests.
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { DatabaseService } = require('../services/DatabaseService');
-    cachedValue = DatabaseService.getInstance().getGlobalSettings().developer_mode === '1';
+    return DatabaseService.getInstance().getGlobalSettings().developer_mode === '1';
   } catch {
-    cachedValue = false;
+    return false;
   }
-
-  cacheExpiry = now + CACHE_TTL_MS;
-  return cachedValue;
 }


### PR DESCRIPTION
## Summary

- Caches the result of `DatabaseService.getGlobalSettings()` (a `SELECT *` on the `global_settings` table) inside the service. Invalidates automatically on `updateGlobalSetting()`.
- The same call is invoked from 22 files, including hot paths: every authenticated HTTP request (`middleware/auth.ts`), every WebSocket upgrade (`websocket/upgradeHandler.ts`), and every diagnostic log line via the debug-mode gate (`utils/debug.ts`).
- The cached snapshot is `Object.freeze`'d and the public return type tightened to `Readonly<Record<string, string>>` so accidental mutations are caught at compile time. One pre-existing caller (`routes/settings.ts` GET) was deleting private keys from the returned object — replaced with a defensive shallow copy via spread before delete.
- The redundant 5-second TTL cache in `utils/debug.ts` is now subsumed by the service-level cache (which is strictly fresher because it invalidates on write).

Implements audit findings 1.3 (WS upgrade hot-path DB reads) and 2.7 (the broader `getGlobalSettings()` caching).

## Test plan

- [x] `npx tsc --noEmit` clean (the new `Readonly` return type surfaced one mutation at `settings.ts:46`, fixed in this PR).
- [x] `npm run lint` clean (0 errors; baseline warnings dropped by one because the `forEach((row: any) => ...)` was rewritten to a typed `for ... of` while the line was being touched).
- [x] All 14 settings-routes tests pass (covers the GET path that delete's private keys).
- [x] All 31 auth + stack-update-settings tests pass.
- [x] Pre-existing fork-pool flakes (rate-limiting, metrics-routes timeouts) reproduce on `main` and are unrelated.
- [x] Manual smoke: `/api/health` and `/api/auth/status` respond 200 with the cache in place.

## Notes

- Constructor invariant documented: assumes this process is the sole writer to `global_settings`. Sidecar tools that edit the row directly will not invalidate the cache.
- Belt-and-suspenders: cache is reset once at the end of the constructor in case any future migration calls `getGlobalSettings()` and a later migration changes the underlying rows.
- Init-time `INSERT OR IGNORE` paths (defaults, legacy JSON config migration) run before any external consumer can read the cache, so they do not need to invalidate.