### PR TITLE
perf(backend): parallelize independent startup initializers

### DIFF
--- a/backend/src/bootstrap/startup.ts
+++ b/backend/src/bootstrap/startup.ts
@@ -29,26 +29,28 @@ export async function startServer(server: Server): Promise<void> {
     console.error('Migration failed:', error);
   }
 
+  // Synchronous starts: schedule background timers and continue. None of
+  // these fire their first tick for at least a few seconds, so they
+  // safely run alongside the async initializers below.
   LicenseService.getInstance().initialize();
-
-  await SelfUpdateService.getInstance().initialize();
-
   MonitorService.getInstance().start();
   AutoHealService.getInstance().start();
-
-  await DockerEventManager.getInstance().start();
-
-  await TrivyService.getInstance().initialize();
-
   ImageUpdateService.getInstance().start();
-
   SchedulerService.getInstance().start();
+  MfaService.getInstance().start();
 
+  // Async initializers are independent of each other; run in parallel
+  // so total boot time is the slowest one rather than the sum.
+  await Promise.all([
+    SelfUpdateService.getInstance().initialize(),
+    DockerEventManager.getInstance().start(),
+    TrivyService.getInstance().initialize(),
+  ]);
+
+  // Fire-and-forget housekeeping; logged but never awaited.
   sweepStaleGitTempDirs().catch((err) => {
     console.warn('[GitSource] Temp dir sweep failed:', (err as Error).message);
   });
-
-  MfaService.getInstance().start();
 
   const isPilotAgent = process.env.SENCHO_MODE === 'pilot';
   const listenHost = isPilotAgent ? '127.0.0.1' : undefined;

--- a/backend/src/services/SelfUpdateService.ts
+++ b/backend/src/services/SelfUpdateService.ts
@@ -1,4 +1,4 @@
-import { execFileSync, execFile } from 'child_process';
+import { execFile } from 'child_process';
 import { promisify } from 'util';
 import * as fs from 'fs';
 import DockerController from './DockerController';
@@ -63,9 +63,12 @@ class SelfUpdateService {
         return;
       }
 
-      // Verify docker compose CLI is available inside the container
+      // Verify docker compose CLI is available inside the container.
+      // execFileAsync (not Sync) so the parallel boot-task block in
+      // bootstrap/startup.ts can actually run TrivyService and DockerEventManager
+      // concurrently instead of waiting on a 5s blocking spawn here.
       try {
-        execFileSync('docker', ['compose', 'version'], { stdio: 'pipe', timeout: 5000 });
+        await execFileAsync('docker', ['compose', 'version'], { timeout: 5000 });
       } catch {
         console.log('[SelfUpdate] docker compose CLI not available in container');
         disableCapability('self-update');


### PR DESCRIPTION
## Summary

- Groups the three independent async initializers in `bootstrap/startup.ts` (`SelfUpdateService.initialize`, `DockerEventManager.start`, `TrivyService.initialize`) behind a single `Promise.all` instead of awaiting each one sequentially. Total cold-start time is now bounded by the slowest of the three rather than the sum.
- Converts the inner `docker compose version` probe in `SelfUpdateService.initialize` from `execFileSync` to `execFileAsync`. The sync spawn was blocking the event loop for up to 5 seconds, which would have silently serialized the other two members of the parallel block on in-container boots.
- Reorders synchronous starts (`Monitor`, `AutoHeal`, `ImageUpdate`, `Scheduler`, `Mfa`) to a single block before the parallel awaits. They schedule timers whose first ticks fire 5+ seconds out, so they safely run alongside the awaited block.

Implements audit finding 2.3.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npm run lint` clean (0 errors, baseline warnings unchanged).
- [x] 18 docker-event-manager + trivy-service tests pass.
- [x] Boot smoke test: `npm run dev`, observed `Migration check completed`, `[SchedulerService] Started`, `[SelfUpdate]`, `[Trivy]`, and `[DockerEvents] Started; watching 1 local node(s)` log lines, and `/api/health` returns 200.

## Notes

- Independence verified by reading each initializer end-to-end: `SelfUpdateService.initialize` reads its own container labels via Dockerode, `DockerEventManager.start` connects to the local Docker socket and spawns one watcher per local node (already parallel internally), `TrivyService.initialize` runs trivy binary detection. None share mutable state outside of disjoint `CapabilityRegistry` entries (`self-update` vs `vulnerability-scanning`).
- Error semantics preserved: with sequential await, the first throw aborted boot and prevented `server.listen`. With `Promise.all`, the first rejection has the same effect. Switching to `Promise.allSettled` would make the boot more resilient (continue listening even if a non-critical init fails) but is a behavior change worth a separate decision.