### PR TITLE
perf(backend): lazy-load composerize and isomorphic-git

### DIFF
--- a/backend/src/routes/convert.ts
+++ b/backend/src/routes/convert.ts
@@ -1,10 +1,18 @@
 import { Router, type Request, type Response } from 'express';
-// @ts-ignore - composerize lacks proper type definitions
-import composerize from 'composerize';
 import { authMiddleware } from '../middleware/auth';
 import { sanitizeForLog } from '../utils/safeLog';
 
 const MAX_DOCKER_RUN_LENGTH = 8192;
+
+// composerize is only used when a user pastes a `docker run` command into the
+// converter UI. Lazy-load it so cold boot does not parse the ~2 MB module.
+let cachedComposerize: ((dockerRun: string) => string) | undefined;
+async function loadComposerize(): Promise<(dockerRun: string) => string> {
+  if (!cachedComposerize) {
+    cachedComposerize = (await import('composerize')).default;
+  }
+  return cachedComposerize;
+}
 
 export const convertRouter = Router();
 
@@ -30,6 +38,7 @@ convertRouter.post('/', authMiddleware, async (req: Request, res: Response): Pro
 
   let yaml: unknown;
   try {
+    const composerize = await loadComposerize();
     yaml = composerize(trimmed);
   } catch (error) {
     console.error('Conversion error:', error);

--- a/backend/src/services/GitSourceService.ts
+++ b/backend/src/services/GitSourceService.ts
@@ -3,8 +3,6 @@ import { spawn } from 'child_process';
 import crypto from 'crypto';
 import os from 'os';
 import path from 'path';
-import git from 'isomorphic-git';
-import gitHttp from 'isomorphic-git/http/node';
 import YAML from 'yaml';
 import { CryptoService } from './CryptoService';
 import { DatabaseService, type StackGitSource, type GitSourceAuthType } from './DatabaseService';
@@ -12,6 +10,27 @@ import { FileSystemService } from './FileSystemService';
 import { ComposeService } from './ComposeService';
 import { isDebugEnabled } from '../utils/debug';
 import { sanitizeForLog } from '../utils/safeLog';
+
+// isomorphic-git is the heaviest dependency in the backend (~5 MB) and only
+// fires when a stack is created from a Git source. Lazy-load it so cold
+// boots without any Git-sourced stacks never parse the module.
+type IsomorphicGit = typeof import('isomorphic-git')['default'];
+type IsomorphicGitHttp = typeof import('isomorphic-git/http/node')['default'];
+
+let cachedGit: IsomorphicGit | undefined;
+let cachedGitHttp: IsomorphicGitHttp | undefined;
+
+async function loadIsomorphicGit(): Promise<{ git: IsomorphicGit; gitHttp: IsomorphicGitHttp }> {
+    if (!cachedGit || !cachedGitHttp) {
+        const [gitMod, gitHttpMod] = await Promise.all([
+            import('isomorphic-git'),
+            import('isomorphic-git/http/node'),
+        ]);
+        cachedGit = gitMod.default;
+        cachedGitHttp = gitHttpMod.default;
+    }
+    return { git: cachedGit, gitHttp: cachedGitHttp };
+}
 
 /**
  * GitSourceService - fetch compose files from a Git repository and apply
@@ -393,6 +412,7 @@ export class GitSourceService {
             : undefined;
 
         try {
+            const { git, gitHttp } = await loadIsomorphicGit();
             // isomorphic-git does not natively accept an AbortSignal, so we
             // wrap the clone in a Promise.race against a timeout rejection.
             // The clone will keep running in the background until the socket


### PR DESCRIPTION
## Summary

- `composerize` (2.0 MB on disk) was imported at module scope by `routes/convert.ts` even though the `/api/convert` endpoint only fires when a user pastes a `docker run` command into the converter UI. Wrapped in a `loadComposerize()` helper that imports on first call.
- `isomorphic-git` plus `isomorphic-git/http/node` (5.1 MB combined) were imported at module scope by `services/GitSourceService.ts` even though they only fire when a stack is created from a Git source. Wrapped in a `loadIsomorphicGit()` helper that loads both in parallel on first call and caches the result.
- Removes a vestigial `// @ts-ignore - composerize lacks proper type definitions` line; the project ships its own `backend/src/types/composerize.d.ts` declaration so the import has always been typed correctly.

Implements audit findings 2.1 and 2.2.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npm run lint` clean (baseline warnings unchanged).
- [x] All 63 git-source-service + convert tests pass without changes. The existing `vi.mock('isomorphic-git', ...)` works unchanged because dynamic `import()` and static `import` resolve through the same module registry.

## Notes

- Pattern matches the existing dynamic `import('@aws-sdk/client-ecr')` in `RegistryService.fetchEcrToken` (the codebase precedent for opt-in lazy loading).
- Concurrent first calls are harmless: Node's module loader caches modules itself, so two simultaneous `await import('isomorphic-git')` calls during a cold race resolve to the same instance.
- Out of scope (flagged by review for follow-up): `@aws-sdk/client-s3` in `CloudBackupService.ts` and the SSO modules (`ldapts`, `openid-client`) in `SSOService.ts` are next candidates. The S3 client is already covered by audit Tier 1.5.