### PR TITLE
perf(docker): switch builder stages to npm ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /app/frontend
 COPY frontend/package*.json frontend/.npmrc ./
 RUN npm config set fetch-retry-maxtimeout 120000 && \
     npm config set fetch-retries 5 && \
-    npm install
+    npm ci
 
 COPY frontend/ ./
 # vite.config.ts reads the root package.json for the app version
@@ -31,7 +31,7 @@ RUN apk add --no-cache python3 make g++
 COPY backend/package*.json backend/.npmrc ./
 RUN npm config set fetch-retry-maxtimeout 120000 && \
     npm config set fetch-retries 5 && \
-    npm install
+    npm ci
 
 COPY backend/ ./
 # prebuild hook (generate-version.js) reads the root package.json for the app version


### PR DESCRIPTION
## Summary

Both `frontend-builder` and `backend-builder` ran `npm install` even though the `prod-deps` stage already used `npm ci`. `npm install` walks the full dep graph and silently rewrites the lockfile when there is drift, which costs build time and lets a stale lockfile slip into a release image. `npm ci` enforces the lockfile, fails fast on drift, and skips the resolution work because the dep tree is already fully described by the lockfile.

Implements audit finding 1.8.

## Test plan

- [x] Verified both lockfiles are clean: `cd backend && npm install --package-lock-only --no-audit --no-fund` and the same in `frontend/` both reported "up to date" with no diff.
- [x] Ran `docker build --target frontend-builder` locally. The new `npm ci` step completed cleanly; the Vite build at the next step failed with SIGABRT (V8 OOM) on this Docker Desktop VM, which is unrelated to the `npm` step. The existing `docker-validate` CI job runs on a stable runner and exercises the full multi-stage build end-to-end.
- [x] No source-code change, so `tsc`, `lint`, and the unit suites are unaffected.

## Notes

- Behaviour delta: a future PR that bumps a dep without regenerating its `package-lock.json` will now fail the Docker build instead of producing a subtly different image. That is the desired behaviour and matches the existing `prod-deps` stage's contract.
- No change to the rest of the multi-stage build, the daily APK cache-bust, the cross-compilation prod-deps logic, or the source-built CLI/Compose stages.