### PR TITLE
perf(frontend): lazy-load Monaco editor + diff editor

### DIFF
--- a/frontend/src/components/EditorLayout.tsx
+++ b/frontend/src/components/EditorLayout.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import { useState, useEffect, useRef, useMemo, useCallback, Suspense } from 'react';
 
 type Theme = 'light' | 'dark' | 'auto';
-import Editor from '@monaco-editor/react';
+import { Editor } from '@/lib/monacoLoader';
 import TerminalComponent from './Terminal';
 import ErrorBoundary from './ErrorBoundary';
 import HomeDashboard from './HomeDashboard';
@@ -2841,29 +2841,31 @@ export default function EditorLayout() {
                         )}
                         <div className="flex-1 min-h-0 overflow-hidden">
                           {!isFileLoading && (
-                            <Editor
-                              height="100%"
-                              language={activeTab === 'compose' ? 'yaml' : 'plaintext'}
-                              theme={isDarkMode ? 'vs-dark' : 'vs'}
-                              value={activeTab === 'compose' ? safeContent : safeEnvContent}
-                              onMount={(editor) => { monacoEditorRef.current = editor; }}
-                              onChange={(value) => {
-                                if (!isEditing) return; // Prevent changes in view mode
-                                if (activeTab === 'compose') {
-                                  setContent(value || '');
-                                } else {
-                                  setEnvContent(value || '');
-                                }
-                              }}
-                              options={{
-                                minimap: { enabled: false },
-                                fontFamily: "'Geist Mono', monospace",
-                                fontSize: 14,
-                                padding: { top: 10 },
-                                scrollBeyondLastLine: false,
-                                readOnly: !isEditing || !can('stack:edit', 'stack', stackName),
-                              }}
-                            />
+                            <Suspense fallback={<div className="w-full h-full" aria-busy="true" />}>
+                              <Editor
+                                height="100%"
+                                language={activeTab === 'compose' ? 'yaml' : 'plaintext'}
+                                theme={isDarkMode ? 'vs-dark' : 'vs'}
+                                value={activeTab === 'compose' ? safeContent : safeEnvContent}
+                                onMount={(editor) => { monacoEditorRef.current = editor; }}
+                                onChange={(value) => {
+                                  if (!isEditing) return; // Prevent changes in view mode
+                                  if (activeTab === 'compose') {
+                                    setContent(value || '');
+                                  } else {
+                                    setEnvContent(value || '');
+                                  }
+                                }}
+                                options={{
+                                  minimap: { enabled: false },
+                                  fontFamily: "'Geist Mono', monospace",
+                                  fontSize: 14,
+                                  padding: { top: 10 },
+                                  scrollBeyondLastLine: false,
+                                  readOnly: !isEditing || !can('stack:edit', 'stack', stackName),
+                                }}
+                              />
+                            </Suspense>
                           )}
                           {isFileLoading && (
                             <div className="flex items-center justify-center h-full text-muted-foreground">

--- a/frontend/src/components/files/FileViewer.tsx
+++ b/frontend/src/components/files/FileViewer.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useMemo } from 'react';
-import Editor from '@monaco-editor/react';
+import { useState, useEffect, useMemo, Suspense } from 'react';
+import { Editor } from '@/lib/monacoLoader';
 import { AlertCircle, FileIcon, Download, Lock, Loader2, Save } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -276,16 +276,18 @@ export function FileViewer({
       </div>
 
       <div className="flex-1 min-h-0">
-        <Editor
-          height="100%"
-          language={language}
-          value={content}
-          onChange={(val) => {
-            if (!readOnly) setContent(val ?? '');
-          }}
-          theme={isDarkMode ? 'vs-dark' : 'light'}
-          options={editorOptions}
-        />
+        <Suspense fallback={<div className="w-full h-full" aria-busy="true" />}>
+          <Editor
+            height="100%"
+            language={language}
+            value={content}
+            onChange={(val) => {
+              if (!readOnly) setContent(val ?? '');
+            }}
+            theme={isDarkMode ? 'vs-dark' : 'light'}
+            options={editorOptions}
+          />
+        </Suspense>
       </div>
     </div>
   );

--- a/frontend/src/components/files/__tests__/FileViewer.test.tsx
+++ b/frontend/src/components/files/__tests__/FileViewer.test.tsx
@@ -9,8 +9,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import type { FileContentResult } from '@/lib/stackFilesApi';
 
-vi.mock('@monaco-editor/react', () => ({
-  default: () => <div data-testid="monaco-editor" />,
+// FileViewer now imports `Editor` from the lazy loader, not directly from
+// @monaco-editor/react. Mock the loader so tests skip Monaco's setup path
+// and the editor renders synchronously.
+vi.mock('@/lib/monacoLoader', () => ({
+  Editor: () => <div data-testid="monaco-editor" />,
+  DiffEditor: () => <div data-testid="monaco-diff-editor" />,
 }));
 
 vi.mock('@/lib/stackFilesApi', () => ({

--- a/frontend/src/components/stack/GitSourceDiffDialog.tsx
+++ b/frontend/src/components/stack/GitSourceDiffDialog.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { DiffEditor } from '@monaco-editor/react';
+import { useState, Suspense } from 'react';
+import { DiffEditor } from '@/lib/monacoLoader';
 import { AlertTriangle, GitBranch, Loader2 } from 'lucide-react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '@/components/ui/alert-dialog';
@@ -124,21 +124,23 @@ export function GitSourceDiffDialog({
 
           <div className="px-6 pb-4 pt-3">
             <div className="h-[55vh] border border-glass-border rounded-md overflow-hidden">
-              <DiffEditor
-                height="100%"
-                language={effectiveTab === 'compose' ? 'yaml' : 'ini'}
-                theme={isDarkMode ? 'vs-dark' : 'vs'}
-                original={currentValue}
-                modified={incomingValue}
-                options={{
-                  readOnly: true,
-                  renderSideBySide: true,
-                  minimap: { enabled: false },
-                  scrollBeyondLastLine: false,
-                  fontFamily: "'Geist Mono', monospace",
-                  fontSize: 12,
-                }}
-              />
+              <Suspense fallback={<div className="w-full h-full" aria-busy="true" />}>
+                <DiffEditor
+                  height="100%"
+                  language={effectiveTab === 'compose' ? 'yaml' : 'ini'}
+                  theme={isDarkMode ? 'vs-dark' : 'vs'}
+                  original={currentValue}
+                  modified={incomingValue}
+                  options={{
+                    readOnly: true,
+                    renderSideBySide: true,
+                    minimap: { enabled: false },
+                    scrollBeyondLastLine: false,
+                    fontFamily: "'Geist Mono', monospace",
+                    fontSize: 12,
+                  }}
+                />
+              </Suspense>
             </div>
           </div>
 

--- a/frontend/src/lib/monacoLoader.tsx
+++ b/frontend/src/lib/monacoLoader.tsx
@@ -1,0 +1,52 @@
+import { lazy } from 'react';
+
+/**
+ * Lazy-loaded Monaco. Replaces the eager imports that used to live in
+ * `main.tsx`. The 3 MB monaco-editor + @monaco-editor/react chunk no longer
+ * loads on cold app start; it loads the first time any consumer renders an
+ * editor, and subsequent editor mounts reuse the already-loaded module.
+ *
+ * `setupMonaco` registers the locally bundled Monaco with @monaco-editor/react
+ * (so it does not fetch from the CDN, which the CSP `script-src 'self'` blocks)
+ * and wires the editor worker. The setup runs at most once per process; the
+ * shared promise dedupes concurrent first mounts.
+ */
+
+declare global {
+  interface Window {
+    MonacoEnvironment?: { getWorker: (workerId: string, label: string) => Worker };
+  }
+}
+
+let setupPromise: Promise<void> | null = null;
+
+function setupMonaco(): Promise<void> {
+  if (!setupPromise) {
+    setupPromise = (async () => {
+      const [monacoMod, reactMonaco, editorWorkerMod] = await Promise.all([
+        import('monaco-editor'),
+        import('@monaco-editor/react'),
+        import('monaco-editor/esm/vs/editor/editor.worker?worker'),
+      ]);
+      window.MonacoEnvironment = {
+        getWorker(): Worker {
+          return new editorWorkerMod.default();
+        },
+      };
+      reactMonaco.loader.config({ monaco: monacoMod });
+    })();
+  }
+  return setupPromise;
+}
+
+export const Editor = lazy(async () => {
+  await setupMonaco();
+  const mod = await import('@monaco-editor/react');
+  return { default: mod.default };
+});
+
+export const DiffEditor = lazy(async () => {
+  await setupMonaco();
+  const mod = await import('@monaco-editor/react');
+  return { default: mod.DiffEditor };
+});

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,20 +4,6 @@ import './index.css'
 import App from './App.tsx'
 import ErrorBoundary from './components/ErrorBoundary.tsx'
 import { initializeDensity } from './hooks/use-density'
-import * as monaco from 'monaco-editor'
-import { loader } from '@monaco-editor/react'
-import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker'
-
-// Use the locally bundled Monaco instead of fetching from cdn.jsdelivr.net.
-// The CSP (scriptSrc: 'self') blocks external CDN scripts; bundling avoids
-// that entirely. Sencho only needs YAML/plaintext so the base editorWorker
-// covers all language modes - no additional language workers required.
-window.MonacoEnvironment = {
-  getWorker(): Worker {
-    return new editorWorker()
-  },
-}
-loader.config({ monaco })
 
 initializeDensity()
 


### PR DESCRIPTION
## Summary

- Monaco was imported eagerly from `main.tsx` so the ~3 MB chunk landed in every cold app start, even for users who never opened the compose editor. Move the bootstrap into a new `frontend/src/lib/monacoLoader.tsx` module that exports `React.lazy`-wrapped `Editor` and `DiffEditor` components. The first time either mounts, the lazy factory dynamic-imports `monaco-editor`, `@monaco-editor/react`, and the editor worker; runs `loader.config({ monaco })`; sets `window.MonacoEnvironment.getWorker`; then resolves to the real component. Subsequent mounts hit the module cache and render immediately.
- Concurrent first mounts share a single setup promise so the work runs at most once per process.
- Three consumers (`EditorLayout`, `files/FileViewer`, `stack/GitSourceDiffDialog`) swap `from '@monaco-editor/react'` for `from '@/lib/monacoLoader'` and wrap their editor in `<Suspense fallback={<div className="w-full h-full" aria-busy="true" />}>`. The fallback is a transparent placeholder so the layout doesn't shift when Monaco loads.
- `main.tsx` loses three eager imports plus the `MonacoEnvironment` + `loader.config` bootstrap.

Implements audit finding 1.1 (Monaco half). The xterm half is a follow-up PR; the changes here are large enough to land independently and the patterns are different enough that splitting keeps each PR reviewable.

The `vite.config.ts` `manualChunks` group from #823 was already prepared for this — the `monaco` chunk now loads on demand instead of as part of the entry chunk.

## Test plan

- [x] FileViewer test was updated: it previously mocked `@monaco-editor/react` directly; it now mocks `@/lib/monacoLoader` so tests skip Monaco's setup path and the editor renders synchronously.
- [x] CSP / loader ordering: `loader.config({ monaco })` and `MonacoEnvironment` are set inside `setupMonaco()` which the lazy factory awaits before resolving. React doesn't render the underlying `<Editor>` until setup is complete, so @monaco-editor/react never has a chance to fall back to the CDN.
- [ ] Local Windows file-locks blocked a fresh `npm install`, so `tsc -b && vite build` ran in CI's frontend job, not locally. Manual smoke (open the editor, save, switch tabs, exercise GitSourceDiffDialog) is recommended after merge to verify the first-mount behaviour end-to-end.

## Notes

- Monaco's runtime CSS injection still works under lazy loading — styles get inserted when the dynamic import evaluates.
- The `useRef<import('monaco-editor').editor.IStandaloneCodeEditor | null>(null)` in EditorLayout is a TypeScript type-only inline import, fully erased at compile time, so it doesn't pull the runtime monaco-editor back in.
- `window.MonacoEnvironment` is now declared via a `declare global` augmentation in the loader file (the previous static import of `@monaco-editor/react` brought it into scope ambiently; the dynamic-import path doesn't, so the declaration makes the assignment type-correct under strict mode).