### PR TITLE
perf(frontend): parallelize auth bootstrap fetches

### DIFF
--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -72,27 +72,29 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
 
       // Auth check and permissions fetch are independent for an authenticated
-      // session, so fire them in parallel. The permissions request is wasted
-      // if the auth check fails, but the not-authenticated branch is rare
-      // (cookie expired / logged out) and saving a round-trip on the common
-      // success path is the better trade.
-      const [authResponse, permsResponse] = await Promise.all([
-        fetch('/api/auth/check', { credentials: 'include' }),
-        fetch('/api/permissions/me', { credentials: 'include' }).catch(() => null),
-      ]);
+      // session, so fire both on the wire at the same time. Await only the
+      // auth check before committing app state — otherwise a slow
+      // /permissions/me delays setAppStatus('authenticated') and races
+      // post-reload UI that expects the dashboard to commit promptly. The
+      // permissions promise updates state in the background when it resolves.
+      const authPromise = fetch('/api/auth/check', { credentials: 'include' });
+      const permsPromise = fetch('/api/permissions/me', { credentials: 'include' }).catch(() => null);
 
+      const authResponse = await authPromise;
       if (authResponse.ok) {
         const data = await authResponse.json();
         setUser(data.user ?? null);
         setAppStatus('authenticated');
 
-        if (permsResponse?.ok) {
-          try {
-            setPermissions(await permsResponse.json());
-          } catch {
-            // Permissions fetch is non-critical — fallback to global role only
+        void permsPromise.then(async (res) => {
+          if (res?.ok) {
+            try {
+              setPermissions(await res.json());
+            } catch {
+              // Permissions fetch is non-critical — fallback to global role only
+            }
           }
-        }
+        });
       } else {
         setUser(null);
         setPermissions(null);

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -71,24 +71,27 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         return;
       }
 
-      // Then check if already authenticated
-      const authResponse = await fetch('/api/auth/check', {
-        credentials: 'include',
-      });
+      // Auth check and permissions fetch are independent for an authenticated
+      // session, so fire them in parallel. The permissions request is wasted
+      // if the auth check fails, but the not-authenticated branch is rare
+      // (cookie expired / logged out) and saving a round-trip on the common
+      // success path is the better trade.
+      const [authResponse, permsResponse] = await Promise.all([
+        fetch('/api/auth/check', { credentials: 'include' }),
+        fetch('/api/permissions/me', { credentials: 'include' }).catch(() => null),
+      ]);
 
       if (authResponse.ok) {
         const data = await authResponse.json();
         setUser(data.user ?? null);
         setAppStatus('authenticated');
 
-        // Fetch effective permissions
-        try {
-          const permsRes = await fetch('/api/permissions/me', { credentials: 'include' });
-          if (permsRes.ok) {
-            setPermissions(await permsRes.json());
+        if (permsResponse?.ok) {
+          try {
+            setPermissions(await permsResponse.json());
+          } catch {
+            // Permissions fetch is non-critical — fallback to global role only
           }
-        } catch {
-          // Permissions fetch is non-critical — fallback to global role only
         }
       } else {
         setUser(null);


### PR DESCRIPTION
## Summary

`AuthContext.checkAuth` previously chained three sequential fetches: `/api/auth/status`, then `/api/auth/check`, then `/api/permissions/me`. The status check has to come first because its response decides whether to early-return on the setup or mfa-pending path. The next two are independent for an authenticated session and were costing an extra round-trip on every cold load.

Fire both on the wire at the same time, then `await` only `/auth/check` before committing app state. The permissions promise updates state in the background via `void permsPromise.then(...)` when it resolves. Non-critical errors / network failures fall back to no permissions data, with the global role still authoritative — same fault tolerance as the original try/catch.

Implements audit finding 2.8.

## Test plan

- [x] No existing tests cover this path (no AuthContext test files).
- [x] Behavior preserved on every branch: needs-setup early return, mfa-pending early return, authenticated success (both responses ok), authenticated with permissions failure (network / non-2xx / malformed JSON), not-authenticated (auth check 401).
- [x] AuthContext intentionally uses raw `fetch` (not the `apiFetch` wrapper) so the parallel 401 from a not-authenticated session does not dispatch the global `sencho-unauthorized` event during bootstrap.
- [x] Critically: `setAppStatus('authenticated')` commits as soon as `/auth/check` returns. It does NOT wait for `/permissions/me`. This preserves the original commit timing so post-reload UI (the deploy-feedback E2E tests in particular) does not race the slower of the two responses.

## Fixup

The first push used `Promise.all([authCheck, permsCheck])`, which delayed `setAppStatus('authenticated')` until the slower of the two responses arrived. That broke `e2e/deploy-log-panel.spec.ts:168` and `:236` — the tests reload the page and expect the dashboard to commit promptly so a stack-name click can register; with the slow-permissions delay, the click was firing before the handler was wired and `GET /api/stacks/<name>` never came. The second commit on this branch reorders to the awaited-auth + background-permissions form described above; the parallelism on the wire is preserved but the commit timing matches the original sequential code.