### PR TITLE
perf(build): enable incremental tsc

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -9,7 +9,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "incremental": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "incremental": true,
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "incremental": true,
     "target": "ES2023",
     "lib": ["ES2023"],
     "module": "ESNext",


### PR DESCRIPTION
## Summary

- `backend/tsconfig.json` had no `incremental` setting, so every `tsc` run re-checked the full project from cold.
- The two frontend tsconfigs (`tsconfig.app.json`, `tsconfig.node.json`) already declared a `tsBuildInfoFile` path under `node_modules/.tmp/`, but without `incremental: true` the file was never written. The path itself sat inside `node_modules` which `npm ci` wipes on every fresh install, so even if the flag had been set the cache wouldn't have survived.
- Add `incremental: true` to all three configs and drop the broken `tsBuildInfoFile` overrides. TypeScript's default places the buildinfo next to the tsconfig (e.g. `backend/tsconfig.tsbuildinfo`); the root `.gitignore` already covers `*.tsbuildinfo` so nothing leaks into git.

Implements audit finding 1.7. CI cache wiring (the audit's secondary suggestion) is not in scope here — runners still rebuild from cold; that's a separate workflow change.

## Test plan

- [x] Local cold-vs-warm `tsc --noEmit` on the backend dropped from ~3.0s to ~1.4s — ~2x speedup on the warm path.
- [x] Buildinfo file lands at `backend/tsconfig.tsbuildinfo` (and equivalents next to the frontend tsconfigs); `git check-ignore` confirms `*.tsbuildinfo` is matched.
- [x] `npm run lint` clean (baseline 204 warnings unchanged).
- [x] CI runs `npm ci && npm run build` from a clean tree, so the change is invariant on CI: incremental enabled but no prior buildinfo to use, identical wall time as before.

## Notes

- Three-line addition. No source code touched.
- The default buildinfo location is structurally identical to a manually-set one outside `node_modules/`, just less ceremony. Keeping the explicit override would add maintenance with no behavior gain.