### PR TITLE
perf(test): cap vitest fork pool at 4 workers

### DIFF
--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -8,11 +8,19 @@ export default defineConfig({
     exclude: ['dist/**', 'node_modules/**'],
     // Each test file gets its own worker so singletons are fresh between files.
     pool: 'forks',
+    // Cap concurrency: each worker dynamic-imports the full Express stack
+    // (TypeScript transform + DB init + every migration), so an uncapped
+    // fork pool that scales with availableParallelism saturates CPU and
+    // the suite spends most of its wall time waiting on cold-start
+    // contention. Four parallel workers is a sweet spot on both CI
+    // runners and laptops.
+    maxWorkers: 4,
+    minWorkers: 1,
     // Timeout generous for DB init and HTTP calls.
     testTimeout: 30_000,
     // Every test file dynamic-imports the full Express stack; each fork pays
     // TypeScript transformation cost and can take tens of seconds under
-    // CPU contention when all 64 fork workers run at once.
+    // CPU contention.
     hookTimeout: 45_000,
     // Sequential within each file (DB state is shared per file).
     sequence: { concurrent: false },


### PR DESCRIPTION
## Summary

Vitest's fork pool default scales with `availableParallelism`, which on machines with many cores spawns dozens of fresh workers. Each worker dynamic-imports the full Express stack (TypeScript transform + DB constructor + every migration), saturating CPU on cold start. Most of the previous suite wall time was spent waiting on this contention rather than running tests.

Cap concurrency at 4 workers via the top-level `maxWorkers` / `minWorkers` options (Vitest 4 unified the previous `poolOptions.forks.maxForks` syntax under `maxWorkers` across pool types — the audit's recommended `poolOptions.forks` form is now deprecated).

Implements audit finding 2.4.

## Test plan

- [x] Local backend wall time drops from ~93 s to ~32-60 s on typical runs (some variance from background processes / Windows AV).
- [x] The pre-existing fork-contention flakes (rate limiting, metrics-routes, fleet integration) clear consistently on warm runs; remaining variance is environmental, not contention.
- [x] All 1556+ tests pass in the warm runs; the timeout values stay at 30 s / 45 s so the stress path in database-metrics and the HTTP integration suites still cover their cold-start envelope on slow runners. (The audit also suggested tightening to 10 s / 15 s; that broke the legitimate stress and HTTP integration paths and is left out of this PR.)

## Notes

- One-line addition (well, two — `maxWorkers: 4` and `minWorkers: 1`). No source code touched.
- Audit finding 2.9 (shared baseline DB via `vitest.globalSetup` + `db.backup()`) is the natural follow-up: the cap removes contention as the wall-time bottleneck, which makes per-file DB init the next thing to attack.