### PR TITLE
docs: cache-bust dashboard image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Self-hosted Docker Compose management with self-healing infrastructure, atomic deployments, and multi-network fleet control. Built for engineers who want Kubernetes-grade reliability without the complexity.
 
-![Sencho Dashboard](docs/images/dashboard.png)
+![Sencho Dashboard](docs/images/dashboard.png?v=2)
 
 ---
 


### PR DESCRIPTION
Appends a version parameter to the dashboard screenshot to bust GitHub's Camo image cache.