### PR TITLE
fix(convert): resolve TS7016 and TS2322 for composerize dynamic import

### DIFF
--- a/backend/src/routes/convert.ts
+++ b/backend/src/routes/convert.ts
@@ -1,4 +1,3 @@
-/// <reference path="../types/composerize.d.ts" />
 import { Router, type Request, type Response } from 'express';
 import { authMiddleware } from '../middleware/auth';
 import { sanitizeForLog } from '../utils/safeLog';

--- a/backend/src/routes/convert.ts
+++ b/backend/src/routes/convert.ts
@@ -1,3 +1,4 @@
+/// <reference path="../types/composerize.d.ts" />
 import { Router, type Request, type Response } from 'express';
 import { authMiddleware } from '../middleware/auth';
 import { sanitizeForLog } from '../utils/safeLog';
@@ -11,7 +12,7 @@ async function loadComposerize(): Promise<(dockerRun: string) => string> {
   if (!cachedComposerize) {
     cachedComposerize = (await import('composerize')).default;
   }
-  return cachedComposerize;
+  return cachedComposerize!;
 }
 
 export const convertRouter = Router();


### PR DESCRIPTION
## Summary

Fix a TypeScript 6 control-flow narrowing issue in `backend/src/routes/convert.ts` that prevented compilation.

## Changes

- **TS2322**: Added `!` non-null assertion on `return cachedComposerize!` in `loadComposerize()`. TypeScript 6 tightened control-flow narrowing for module-level mutable `let` variables: after an `await`, the compiler no longer narrows the variable to non-undefined inside the enclosing `if`-block. The assertion is safe because the assignment on the preceding line guarantees a defined value at the return site.
- **Removed `/// <reference>` directive**: The initial fix included a `/// <reference path>` directive to solve a ts-node JIT resolution issue for the `composerize` ambient module declaration. This was rejected by ESLint's `@typescript-eslint/triple-slash-reference` rule. The directive is unnecessary because `tsconfig.json` already includes `src/**/*`, which covers `src/types/composerize.d.ts` for both `tsc` and `ts-node`.

## Test plan

- `cd backend && npx tsc --noEmit` reports zero errors (verified locally).
- ESLint passes with no errors from the changed file.

## Notes

No behavior changes. This is a type-system fix only; runtime behavior is identical.
