### PR TITLE
fix(backend): resolve ts-node dynamic import and TS2322 narrowing errors

### DIFF
--- a/backend/src/routes/convert.ts
+++ b/backend/src/routes/convert.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="../types/composerize.d.ts" />
 import { Router, type Request, type Response } from 'express';
 import { authMiddleware } from '../middleware/auth';

--- a/backend/src/routes/convert.ts
+++ b/backend/src/routes/convert.ts
@@ -1,3 +1,4 @@
+/// <reference path="../types/composerize.d.ts" />
 import { Router, type Request, type Response } from 'express';
 import { authMiddleware } from '../middleware/auth';
 import { sanitizeForLog } from '../utils/safeLog';
@@ -11,7 +12,7 @@ async function loadComposerize(): Promise<(dockerRun: string) => string> {
   if (!cachedComposerize) {
     cachedComposerize = (await import('composerize')).default;
   }
-  return cachedComposerize;
+  return cachedComposerize!;
 }
 
 export const convertRouter = Router();


### PR DESCRIPTION
Resolves TS7016 by explicitly referencing the composerize declaration for ts-node, and TS2322 by using non-null assertion narrowing after the async import.