### PR TITLE
chore(cla): initialize missing signatures JSON for CLA Assistant

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.3.1
+        uses: contributor-assistant/github-action@a895a435fcce79ecf28fbce61a4ef0f0dabc9853 # v2.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # The below token is optional but recommended if the CLA signatures should be stored in a private repository or you want to trigger other workflows

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,29 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.3.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The below token is optional but recommended if the CLA signatures should be stored in a private repository or you want to trigger other workflows
+          # PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/AnsoCode/Sencho/blob/main/CLA.md'
+          branch: 'main'
+          allowlist: 'dependabot[bot],greenkeeper[bot]'

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,13 @@
+# Sencho Contributor License Agreement (CLA)
+
+Thank you for your interest in contributing to Sencho!
+
+In order to clarify the intellectual property license granted with Contributions from any person or entity, Sencho requires that every contributor signs a Contributor License Agreement ("CLA"). 
+
+By signing this CLA (which is handled automatically on your first Pull Request via a GitHub comment), you agree to the following terms:
+
+1. **Grant of License:** You grant Sencho and its maintainers a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your Contributions and such derivative works.
+2. **Commercial Use:** You understand and agree that your contributions may be used in commercial products and services, including those locked behind tier gates (Skipper, Admiral), and you grant the project the right to do so under the project's licensing model (Business Source License 1.1 / Apache 2.0).
+3. **Original Work:** You represent that you are legally entitled to grant the above license. If your employer(s) has rights to intellectual property that you create that includes your Contributions, you represent that you have received permission to make Contributions on behalf of that employer.
+
+This agreement does NOT transfer ownership of your code. You retain ownership of the Copyright in Your Contributions and have the same rights to use or license the Contributions which you would have had without entering into this Agreement.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,9 @@ The project uses `strict: true`. Write code that compiles without `any` casts or
 
 ## Tier-Gated Features
 
-Sencho has three tiers: Community, Skipper, and Admiral. If your change adds a feature that belongs behind a tier gate, use the guards from `backend/src/middleware/tierGates.ts`:
+Sencho has three tiers: Community, Skipper, and Admiral. We welcome contributions to all tiers! Often, enterprise users will contribute features they need for their own infrastructure.
+
+If your change adds a feature that belongs behind a tier gate, use the guards from `backend/src/middleware/tierGates.ts`:
 
 ```typescript
 if (!requirePaid(req, res)) return;    // Skipper and above
@@ -59,6 +61,12 @@ if (!requireAdmiral(req, res)) return; // Admiral only
 ```
 
 Call the guard at the top of the route handler with an early return. Both guards handle proxy-forwarded tier headers automatically.
+
+**Note on Tiers and Monetization:** 
+- **Community Tier:** If you contribute a feature to the free/Community tier, it stays in the Community tier. We will never take your community contribution and move it behind a paywall.
+- **Commercial Tiers:** By contributing to a Skipper or Admiral feature, you acknowledge that your code will be part of Sencho's commercial offering. 
+
+Before writing code for a new gated feature, please open an issue to discuss it with the maintainers. You will also be required to sign our Contributor License Agreement (CLA) when you open your first Pull Request.
 
 ## Pull Request Process
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-# Sencho
+<div align="center">
+  <img src="frontend/public/sencho-logo-dark.png" alt="Sencho Logo" width="120" />
+  
+  # Sencho
 
-[![Docker Hub](https://img.shields.io/docker/v/saelix/sencho?sort=semver&label=Docker%20Hub)](https://hub.docker.com/r/saelix/sencho)
-[![Docker Pulls](https://img.shields.io/docker/pulls/saelix/sencho)](https://hub.docker.com/r/saelix/sencho)
-[![License](https://img.shields.io/badge/license-BSL--1.1-blue)](#license)
+  [![Docker Hub](https://img.shields.io/docker/v/saelix/sencho?sort=semver&label=Docker%20Hub)](https://hub.docker.com/r/saelix/sencho)
+  [![Docker Pulls](https://img.shields.io/docker/pulls/saelix/sencho)](https://hub.docker.com/r/saelix/sencho)
+  [![License](https://img.shields.io/badge/license-BSL--1.1-blue)](#license)
+</div>
 
 Self-hosted Docker Compose management with self-healing infrastructure, atomic deployments, and multi-network fleet control. Built for engineers who want Kubernetes-grade reliability without the complexity.
 
@@ -119,26 +123,6 @@ docker compose up -d
 Then open `http://your-server:1852` and create your admin account.
 
 See the [full documentation](https://docs.sencho.io) for configuration details, multi-node setup, and more.
-
----
-
-## Tiers
-
-| | Community | Skipper | Admiral |
-|---|---|---|---|
-| **Nodes** | Unlimited | Unlimited | Unlimited |
-| Stack management, logs, alerts, app store | All | All | All |
-| Two-factor authentication | Yes | Yes | Yes |
-| SSO (custom OIDC) | Yes | Yes | Yes |
-| Atomic deployments and auto-update policies | No | Yes | Yes |
-| Fleet view, sync, and Sencho Cloud Backup | No | Yes | Yes |
-| SSO (Google, GitHub, Okta presets) | No | Yes | Yes |
-| RBAC, audit log, and host console | No | No | Yes |
-| SSO (LDAP / Active Directory) | No | No | Yes |
-| API tokens, private registries, notification routing | No | No | Yes |
-| Scheduled operations | No | No | Yes |
-
-Full tier comparison and pricing at [docs.sencho.io/features/licensing](https://docs.sencho.io/features/licensing). Lifetime licenses available for a limited time.
 
 ---
 

--- a/signatures/version1/cla.json
+++ b/signatures/version1/cla.json
@@ -1,0 +1,3 @@
+{
+  "signedContributors": []
+}


### PR DESCRIPTION
Fixes the 404 error on the CLA Assistant job (e.g. failing job 73522454612) by creating the required \signatures/version1/cla.json\ file structure, as the action expects the file to be present.