### PR TITLE
ci: add workflow_dispatch to release-please for manual recovery

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches:
       - main
+  # Manual recovery lever for cases where the action fails on a transient
+  # GitHub API issue (e.g. duplicate-release-tag during a retry) and exits
+  # before scanning main for new conventional commits. Re-running from the
+  # Actions tab requeues the same logic against the current main HEAD; no
+  # code push needed. Triggering manually does NOT skip the action's own
+  # state checks, so it cannot accidentally double-publish a release.
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Adds a manual recovery lever for the release-please workflow.

## Why

release-please-action v5.0.0 (release-please library 17.6.0) returns exit code 1 when it tries to create a GitHub Release whose tag already exists, even when the underlying state is consistent. This causes the action to abort before the "open or update release PR" step, leaving new conventional commits unprocessed.

This was observed after merging #862: the v0.66.0 release was already tagged and published, but the action kept finding PR #853 in its pending-release scanner and exiting on `Validation Failed: tag_name already_exists`. Removing the `autorelease: tagged` label from #853 and re-running the workflow recovered cleanly (release PR #864 then opened for v0.66.1).

A version bump is not an option here — release-please-action v5.0.0 (released 2026-04-22) is the latest major and release-please 17.6.0 (released 2026-04-13) is the latest library. Both are bleeding edge; there is nowhere to upgrade to.

## What this PR does

Adds `workflow_dispatch:` to `release-please.yml` so a maintainer can re-run the action manually from the Actions tab once any inconsistent label state is cleared. No code push needed to retrigger. The workflow's internal state checks still run on every dispatch, so manual triggers cannot double-publish a release.

## Recovery procedure (documented for future incidents)

If `release-please.yml` fails with `Validation Failed: tag_name already_exists`:

1. Verify the underlying release IS published: `gh release view <tag>` shows the tag, the GitHub Release page exists, and the SBOM/VEX assets are attached.
2. Find the corresponding release PR: `gh pr list --state closed --search "chore(main): release <version>"`.
3. Strip the autorelease labels: `gh pr edit <num> --remove-label "autorelease: pending" --remove-label "autorelease: tagged"`.
4. Trigger the workflow manually: open the Actions tab → Release Please → Run workflow → main, OR run `gh workflow run release-please.yml`.
5. Verify a new release PR opens for the accumulated conventional commits.

## Test plan

- [x] YAML is syntactically valid (the `workflow_dispatch:` form with no inputs is the canonical no-args trigger)
- [ ] First post-merge `push` to main triggers release-please as before (unchanged behavior)
- [ ] Manual trigger from Actions tab also runs successfully (new behavior)

## Notes

- Upstream issue tracker has `googleapis/release-please#2746` covering a similar collision scenario for multi-package monorepos. Our single-package case may not be tracked yet — worth opening a separate issue with the reproducer (label state + duplicate tag + exit-1) once we have one or two more occurrences to characterize the trigger.
- This branch is independent of #863 (workflow-hardening). Either order of merge is fine.