### PR TITLE
fix(license): reject activation when LS response is missing instance.id

### DIFF
--- a/backend/src/__tests__/license-service-id-validation.test.ts
+++ b/backend/src/__tests__/license-service-id-validation.test.ts
@@ -152,6 +152,51 @@ describe('LicenseService.activate() - catalog ID guard', () => {
         expect(mockSetSystemState).not.toHaveBeenCalledWith('license_status', 'active');
     });
 
+    it('rejects activation when the LS response is missing the instance object', async () => {
+        // Storing an empty license_instance_id would silently break later
+        // validate() and deactivate() calls. Reject up front so the user
+        // sees a clear error instead of a deceptive "Activated successfully".
+        mockAxiosPost.mockResolvedValueOnce({
+            data: {
+                activated: true,
+                license_key: { id: 1, status: 'active', key: 'k', activation_limit: 1, activation_usage: 1, created_at: '2026-01-01', expires_at: null },
+                meta: {
+                    store_id: SENCHO_LS_STORE_ID,
+                    product_id: SENCHO_LS_PRODUCT_ID_SKIPPER,
+                    variant_id: VARIANT_SKIPPER_MONTHLY,
+                    variant_name: 'Skipper Monthly',
+                    product_name: 'Sencho Skipper',
+                },
+                // instance: omitted on purpose
+            },
+        });
+        const result = await svc.activate('NO-INSTANCE-OBJECT-KEY');
+        expect(result.success).toBe(false);
+        expect(result.error).toBe('License server returned an incomplete activation. Please try again.');
+        expect(mockSetSystemState).not.toHaveBeenCalled();
+    });
+
+    it('rejects activation when LS returns instance with empty id', async () => {
+        mockAxiosPost.mockResolvedValueOnce({
+            data: {
+                activated: true,
+                license_key: { id: 1, status: 'active', key: 'k', activation_limit: 1, activation_usage: 1, created_at: '2026-01-01', expires_at: null },
+                instance: { id: '', name: 'test', created_at: '2026-01-01' },
+                meta: {
+                    store_id: SENCHO_LS_STORE_ID,
+                    product_id: SENCHO_LS_PRODUCT_ID_ADMIRAL,
+                    variant_id: VARIANT_ADMIRAL_LIFETIME,
+                    variant_name: 'Admiral Lifetime',
+                    product_name: 'Sencho Admiral',
+                },
+            },
+        });
+        const result = await svc.activate('EMPTY-INSTANCE-ID-KEY');
+        expect(result.success).toBe(false);
+        expect(result.error).toBe('License server returned an incomplete activation. Please try again.');
+        expect(mockSetSystemState).not.toHaveBeenCalled();
+    });
+
     it('writes nothing to system_state when the catalog guard rejects', async () => {
         // Stronger than checking individual keys: any future code that adds a
         // setSystemState() call above the guard would silently break the

--- a/backend/src/services/LicenseService.ts
+++ b/backend/src/services/LicenseService.ts
@@ -195,6 +195,24 @@ export class LicenseService {
     }
 
     /**
+     * Two distinct identifiers live in `system_state` and the names are
+     * confusingly close, so for future maintainers (and audit agents):
+     *
+     *   `instance_id`           local UUID generated once on first boot. We
+     *                           send it to LS as the activation's
+     *                           `instance_name` (LS treats this as a
+     *                           free-form label, e.g. a hostname).
+     *
+     *   `license_instance_id`   the activation ID LS returns on /activate.
+     *                           We send it back to LS as the `instance_id`
+     *                           parameter on /validate and /deactivate.
+     *
+     * They are NOT redundant and NEITHER overwrites the other. Renaming
+     * `instance_id` to e.g. `local_install_id` would be clearer but would
+     * churn frontend consumers and migrations for no functional change.
+     */
+
+    /**
      * Initialize the license service on startup.
      * Ensures an instance ID exists and starts periodic validation for active licenses.
      * Fresh installs land on Community; trials are issued by Lemon Squeezy via the
@@ -451,9 +469,24 @@ export class LicenseService {
                 return { success: false, error: 'This license key is not valid for Sencho.' };
             }
 
+            // Reject if LS did not return a usable instance id. Storing an
+            // empty license_instance_id would silently break later validate()
+            // and deactivate() calls, both of which short-circuit on a falsy
+            // instance id with a generic "no active license" error. Better to
+            // surface the broken activation immediately than ship a state where
+            // the user thinks they are activated but every subsequent call
+            // fails. LS has historically always returned data.instance.id on
+            // a successful activation; this is a defense against an API change
+            // or transient malformed response, not a routinely-hit branch.
+            const lsInstanceId = data.instance?.id;
+            if (!lsInstanceId) {
+                console.warn('[License] Activation rejected: LS response missing instance.id.');
+                return { success: false, error: 'License server returned an incomplete activation. Please try again.' };
+            }
+
             // Store license data
             db.setSystemState('license_key', licenseKey);
-            db.setSystemState('license_instance_id', data.instance?.id || '');
+            db.setSystemState('license_instance_id', lsInstanceId);
             this.setLicenseStatus('active');
             db.setSystemState('license_last_validated', Date.now().toString());
 


### PR DESCRIPTION
## Summary

Closes a state-divergence shipping bug in `LicenseService.activate()` and adds a docstring that prevents future readers from misreading the dual-instance-id naming.

## Why

Before this PR, `activate()` stored `data.instance?.id || ''` on success. If LS ever returned `activated: true` without an `instance.id` (malformed response, API change, transient bug), the user saw "Activated successfully" but every subsequent `validate()` and `deactivate()` short-circuited on the empty `license_instance_id` with a generic "no active license" error. The activation appeared to succeed while leaving the install in a broken state.

LS has historically always returned `instance.id` on a successful activation, so this is a defensive check, not a routinely-hit branch. The cost is one conditional on the happy path; the win is converting a silent state divergence into a clear, actionable error.

## What changed

1. **`LicenseService.activate()`:** after the existing catalog-id guard, also require a non-empty `data.instance.id`. Reject with `"License server returned an incomplete activation. Please try again."` and persist nothing.

2. **Dual-name docstring above `initialize()`:** explains that `system_state.instance_id` (local UUID, sent to LS as `instance_name`) and `system_state.license_instance_id` (LS-issued activation id, sent to LS as `instance_id` on validate/deactivate) are conceptually distinct keys with separate purposes. Same area, swapped names, no overlap. Documents *why* both exist so future maintainers do not "fix" the perceived redundancy.

3. **Two new tests:** `instance` field absent and `instance.id` empty string. Both assert `expect(mockSetSystemState).not.toHaveBeenCalled()`, which catches any future code that accidentally writes state above the guard.

## Background on the docstring

The original LS-licensing audit reported "activate() can overwrite the persistent UUID" as a partial bug. Re-reading the code showed the claim was wrong: `instance_id` and `license_instance_id` are separate DB rows, neither overwrites the other, and they map to two different LS API fields. The docstring records that conclusion in the code so the next audit (human or agent) starts from the correct mental model.

## Test plan

- [x] `cd backend && npx tsc --noEmit` clean
- [x] New tests pass (2 added; 25 total in `license-service-id-validation.test.ts`)
- [x] Existing tests still pass (29 in `license-service.test.ts`)
- [x] Full backend suite: 89 files, 1652 passing, 5 pre-existing skips
- [x] Code review: no actionable findings, ship-ready

## Notes

- Ships as a PATCH bump via release-please.
- The deferred HMAC-cache work (B3.2 in the original audit roadmap) is complementary, not redundant: this guard prevents bad activations from landing in the DB; HMAC would protect rows already at rest from being forged or mutated by an attacker with filesystem access.
- The `crypto.randomUUID()` fallback at the top of `activate()` is left in place. `initialize()` invariant generates `instance_id` on first boot, so the fallback is dead in production but harmless and defensive against any future code path that calls `activate()` before `initialize()`. Not worth changing here.