### PR TITLE
feat(frontend): code-split paid-tier settings sections out of Community bundle

### DIFF
--- a/frontend/src/components/settings/SettingsPage.tsx
+++ b/frontend/src/components/settings/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState, useCallback, useMemo, useEffect } from 'react';
+import { useLayoutEffect, useRef, useState, useCallback, useMemo, useEffect, lazy, Suspense } from 'react';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import {
     CommandDialog,
@@ -9,29 +9,22 @@ import {
     CommandList,
 } from '@/components/ui/command';
 import { PageMasthead, type MastheadMetadataItem } from '@/components/ui/PageMasthead';
+import { Skeleton } from '@/components/ui/skeleton';
 import { useAuth } from '@/context/AuthContext';
 import { useLicense } from '@/context/LicenseContext';
 import { useNodes } from '@/context/NodeContext';
 import { NodeManager } from '../NodeManager';
 import { SSOSection } from '../SSOSection';
-import { ApiTokensSection } from '../ApiTokensSection';
-import { RegistriesSection } from '../RegistriesSection';
 import {
     AccountSection,
     AppearanceSection,
     LicenseSection,
-    UsersSection,
     SystemSection,
     NotificationsSection,
-    NotificationRoutingSection,
-    WebhooksSection,
-    SecuritySection,
-    CloudBackupSection,
     DeveloperSection,
     AppStoreSection,
     SupportSection,
     AboutSection,
-    LabelsSection,
     SETTINGS_ITEMS,
     SETTINGS_GROUPS,
     getSettingsItem,
@@ -45,6 +38,53 @@ import { SettingsSidebar } from './SettingsSidebar';
 import { MastheadStatsProvider, useMastheadStatsValue } from './MastheadStatsContext';
 import { TierLockChip } from './TierLockChip';
 import { cn } from '@/lib/utils';
+
+// Paid-tier sections are loaded on demand. SectionGate short-circuits to a
+// TierLockedCard for Community / wrong-variant operators before reaching the
+// JSX that would mount these components, so the chunks are never fetched on
+// those installs and the JSX, copy, and prop shapes never enter the bundle a
+// Community user downloads. Bypassing the ./index barrel keeps each component
+// in its own chunk; importing through the barrel would pull every named
+// export into the same chunk and defeat the split.
+const UsersSection = lazy(() =>
+    import('./UsersSection').then(m => ({ default: m.UsersSection })),
+);
+const WebhooksSection = lazy(() =>
+    import('./WebhooksSection').then(m => ({ default: m.WebhooksSection })),
+);
+const SecuritySection = lazy(() =>
+    import('./SecuritySection').then(m => ({ default: m.SecuritySection })),
+);
+const LabelsSection = lazy(() =>
+    import('./LabelsSection').then(m => ({ default: m.LabelsSection })),
+);
+const NotificationRoutingSection = lazy(() =>
+    import('./NotificationRoutingSection').then(m => ({ default: m.NotificationRoutingSection })),
+);
+const CloudBackupSection = lazy(() =>
+    import('./CloudBackupSection').then(m => ({ default: m.CloudBackupSection })),
+);
+const ApiTokensSection = lazy(() =>
+    import('../ApiTokensSection').then(m => ({ default: m.ApiTokensSection })),
+);
+const RegistriesSection = lazy(() =>
+    import('../RegistriesSection').then(m => ({ default: m.RegistriesSection })),
+);
+
+// Approximation of a settings section's first-paint shape: a header strip and
+// a couple of field rows. Visible only on the brief window between an unlocked
+// section's chunk request and its first render. SectionGate's TierLockedCard
+// path never mounts the lazy children, so this never flashes for locked tiers.
+function SectionSkeleton() {
+    return (
+        <div className="flex flex-col gap-4" aria-busy="true">
+            <Skeleton className="h-8 w-1/3 rounded-md" />
+            <Skeleton className="h-20 w-full rounded-lg" />
+            <Skeleton className="h-20 w-full rounded-lg" />
+            <Skeleton className="h-20 w-full rounded-lg" />
+        </div>
+    );
+}
 
 interface SettingsPageProps {
     currentSection: SectionId;
@@ -212,9 +252,14 @@ function SettingsPageInner({ currentSection, onSectionChange }: SettingsPageProp
                                     {activeItem.description}
                                 </p>
                             ) : null}
-                            <SectionGate sectionId={safeSection}>
-                                {sectionElement}
-                            </SectionGate>
+                            {/* Suspense outside SectionGate so the locked-tier
+                                path (which never mounts the lazy children)
+                                does not see a fallback flash. */}
+                            <Suspense fallback={<SectionSkeleton />}>
+                                <SectionGate sectionId={safeSection}>
+                                    {sectionElement}
+                                </SectionGate>
+                            </Suspense>
                         </div>
                     </ScrollArea>
                 </div>

--- a/frontend/src/components/settings/index.ts
+++ b/frontend/src/components/settings/index.ts
@@ -1,18 +1,22 @@
+// Free-tier sections are exported eagerly: every operator sees them on every
+// install so static imports keep first-paint fast.
 export { AccountSection } from './AccountSection';
 export { AppearanceSection } from './AppearanceSection';
 export { LicenseSection } from './LicenseSection';
-export { UsersSection } from './UsersSection';
 export { SystemSection } from './SystemSection';
 export { NotificationsSection } from './NotificationsSection';
-export { WebhooksSection } from './WebhooksSection';
-export { SecuritySection } from './SecuritySection';
-export { CloudBackupSection } from './CloudBackupSection';
 export { DeveloperSection } from './DeveloperSection';
 export { AppStoreSection } from './AppStoreSection';
 export { SupportSection } from './SupportSection';
 export { AboutSection } from './AboutSection';
-export { LabelsSection } from './LabelsSection';
-export { NotificationRoutingSection } from './NotificationRoutingSection';
+
+// Paid-tier sections (UsersSection, WebhooksSection, SecuritySection,
+// LabelsSection, CloudBackupSection, NotificationRoutingSection) are NOT
+// re-exported from this barrel. They are dynamically imported with
+// React.lazy in SettingsPage.tsx so their JSX, copy, and prop shapes do not
+// land in the bundle a Community user downloads. Re-adding any of them as a
+// static export here would defeat the split: rollup detects the static path
+// and keeps the module in the main chunk regardless of the lazy() call.
 export { DEFAULT_SETTINGS } from './types';
 export type { PatchableSettings, SectionId, Agent } from './types';
 export {


### PR DESCRIPTION
## Summary

Closes the audit's CRITICAL frontend bundle leakage finding: every paid-tier settings section's JSX, copy, error messages, and prop interfaces shipped in the JavaScript bundle that Community installs download. SectionGate's runtime tier check hid components from view but did not gate the download — anyone could open DevTools and read the source.

This PR converts the 8 paid-tier settings sections to `React.lazy()` and removes them from the settings barrel so rollup actually splits the chunks. The behavior visible to paid users is functionally unchanged; the behavior visible to Community users is that the paid feature code is no longer in their bundle.

## What changed

- **`frontend/src/components/settings/SettingsPage.tsx`:** added `lazy, Suspense` imports plus `Skeleton`. Replaced static imports of `UsersSection`, `WebhooksSection`, `SecuritySection`, `LabelsSection`, `NotificationRoutingSection`, `CloudBackupSection`, `ApiTokensSection`, `RegistriesSection` with `lazy(() => import('./X').then(m => ({ default: m.X })))` declarations. Wrapped the existing `<SectionGate>{sectionElement}</SectionGate>` block in `<Suspense fallback={<SectionSkeleton />}>`. Suspense sits outside SectionGate intentionally — SectionGate short-circuits synchronously for locked tiers, so the lazy children never mount and no fallback flashes for Community users.
- **`frontend/src/components/settings/index.ts`:** removed the named re-exports for the 6 paid sections that live inside the settings folder. Kept all free-tier section re-exports. Added a comment explaining that re-adding any paid section as a static export would defeat the split — rollup detects the static path and keeps the module in the main chunk regardless of the `lazy()` call. This is enforced by the build: with the barrel exports in place, rollup emits `INEFFECTIVE_DYNAMIC_IMPORT` warnings; without them, each section is a clean separate chunk.

## Build evidence (vite production build)

| Section | Chunk size raw | Chunk size gzip |
|---|---|---|
| LabelsSection | 5.05 kB | 2.05 kB |
| ApiTokensSection | 6.96 kB | 2.51 kB |
| WebhooksSection | 8.90 kB | 2.90 kB |
| RegistriesSection | 9.41 kB | 2.95 kB |
| UsersSection | 11.44 kB | 3.34 kB |
| CloudBackupSection | 12.88 kB | 3.60 kB |
| NotificationRoutingSection | 13.04 kB | 3.84 kB |
| SecuritySection | 21.06 kB | 5.60 kB |
| **Total split out** | **88.74 kB** | **26.79 kB** |

Main bundle shrunk from 1,537 kB → 1,468 kB (raw) and 421 kB → 407 kB (gzip). No `INEFFECTIVE_DYNAMIC_IMPORT` warnings remain.

## Runtime evidence (vite dev server + manual end-to-end)

- Logged in as Admiral admin, navigated to Settings.
- Initial page load fetched `AccountSection.tsx` as request **#221** (eager static import via the barrel — expected for free-tier sections).
- Clicking the "Cloud Backup" sidebar entry fetched `CloudBackupSection.tsx` as request **#351** — i.e., on demand, after interaction.

Free sections preload, paid sections load on demand. Confirms the lazy mechanism works end-to-end.

## Test plan

- [x] `cd frontend && npx tsc -b --noEmit` clean
- [x] `npm run build` clean, no INEFFECTIVE_DYNAMIC_IMPORT warnings
- [x] Bundle inspection: 8 paid section chunks present, main bundle shrunk
- [x] Sanity grep: paid section copy strings ("Cloud Backup" etc.) only in their dedicated chunks for feature implementation; main bundle's 2 occurrences are navigation metadata (registry label + masthead status pill)
- [x] Dev-server smoke test: free sections eager-load, paid sections lazy-load on click
- [ ] **Recommended manual check before merge:** log in to a Community-tier install, navigate to Settings, click each paid section in the sidebar. The `<TierLockedCard>` should render and the Network tab should show NO request for the section's `.tsx` (dev) or `.js` chunk (prod). This proves the IP exposure is closed.

## Out of scope (follow-ups)

- **Non-settings paid views** (FleetView, AuditLogView, AutoUpdateReadinessView, ScheduledOperationsView, GlobalObservabilityView, HostConsole, SecurityHistoryView) are still statically imported into `EditorLayout.tsx`. Same threat shape, separate PR.
- **ErrorBoundary around the Suspense.** Today, a chunk fetch failure (deploy mid-session, network hiccup) bubbles to the app-level boundary. A section-local boundary with a "Reload" CTA would be friendlier.
- **Bundle visualization output** is not committed. Run locally with `ANALYZE=true npm run build` when investigating chunk shape.

## Notes

- Ships as a `feat:` (MINOR bump via release-please) because the loading behavior is a deliberate change — paid users see a brief skeleton flash on first open of a paid section. Functionally identical otherwise.
- Internal architecture doc captures the three invariants (paid sections never in the barrel; lazy declarations always go through direct paths, not the barrel; SectionGate must remain synchronous). Re-adding a barrel export silently breaks the split, so the doc exists to keep that knowledge alive.