### PR TITLE
feat(frontend): code-split non-settings paid views and security overlay

### DIFF
--- a/frontend/src/components/EditorLayout.tsx
+++ b/frontend/src/components/EditorLayout.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo, useCallback, Suspense } from 'react';
+import { useState, useEffect, useRef, useMemo, useCallback, lazy, Suspense } from 'react';
 
 type Theme = 'light' | 'dark' | 'auto';
 import { Editor } from '@/lib/monacoLoader';
@@ -8,7 +8,7 @@ import ErrorBoundary from './ErrorBoundary';
 import HomeDashboard from './HomeDashboard';
 import type { NotificationItem } from './dashboard/types';
 import BashExecModal from './BashExecModal';
-import HostConsole from './HostConsole';
+import { Skeleton } from '@/components/ui/skeleton';
 import { AdmiralGate } from './AdmiralGate';
 import { CapabilityGate } from './CapabilityGate';
 import ResourcesView from './ResourcesView';
@@ -46,12 +46,48 @@ import { LogViewer } from './LogViewer';
 import StructuredLogViewer from './StructuredLogViewer';
 import StackAnatomyPanel from './StackAnatomyPanel';
 import { Sparkline } from './ui/sparkline';
-import { GlobalObservabilityView } from './GlobalObservabilityView';
-import { FleetView } from './FleetView';
-import { AuditLogView } from './AuditLogView';
-import ScheduledOperationsView, { type ScheduleTaskPrefill } from './ScheduledOperationsView';
-import AutoUpdateReadinessView from './AutoUpdateReadinessView';
-import { SecurityHistoryView } from './SecurityHistoryView';
+import type { ScheduleTaskPrefill } from './ScheduledOperationsView';
+
+// Paid-tier views and the security-history overlay are loaded on demand.
+// Their internal PaidGate / AdmiralGate / CapabilityGate wrappers render
+// the upsell or capability-missing card with blurred children rather than
+// short-circuiting, so a tier-locked or capability-missing operator
+// opening one of these tabs still triggers the chunk fetch to render the
+// blurred preview. The gate-short-circuit fix lives in a follow-up
+// branch. What this lazy split closes is the much larger initial-bundle
+// leak: every Community user used to download the full FleetView,
+// AuditLogView, etc. on first page load even if they never clicked those
+// tabs. After this change, the chunks fetch only on tab open.
+//
+// GlobalObservabilityView is a free-tier feature with no internal gate;
+// it is split here purely for the bundle-size win, not for IP protection.
+const HostConsole = lazy(() => import('./HostConsole'));
+const GlobalObservabilityView = lazy(() =>
+    import('./GlobalObservabilityView').then(m => ({ default: m.GlobalObservabilityView })),
+);
+const FleetView = lazy(() =>
+    import('./FleetView').then(m => ({ default: m.FleetView })),
+);
+const AuditLogView = lazy(() =>
+    import('./AuditLogView').then(m => ({ default: m.AuditLogView })),
+);
+const SecurityHistoryView = lazy(() =>
+    import('./SecurityHistoryView').then(m => ({ default: m.SecurityHistoryView })),
+);
+const ScheduledOperationsView = lazy(() => import('./ScheduledOperationsView'));
+const AutoUpdateReadinessView = lazy(() => import('./AutoUpdateReadinessView'));
+
+// Sized for the main workspace area (flex-1 with p-6 padding). Visible
+// only during the brief window between an unlocked view's chunk request
+// and its first render.
+function ViewSkeleton() {
+    return (
+        <div className="flex flex-col gap-6" aria-busy="true">
+            <Skeleton className="h-10 w-1/3 rounded-md" />
+            <Skeleton className="h-96 w-full rounded-lg" />
+        </div>
+    );
+}
 import { SENCHO_NAVIGATE_EVENT } from './NodeManager';
 import type { SenchoNavigateDetail } from './NodeManager';
 import { NodeSwitcher } from './NodeSwitcher';
@@ -2487,7 +2523,9 @@ export default function EditorLayout() {
           ) : activeView === 'host-console' ? (
             <AdmiralGate featureName="Host Console">
               <CapabilityGate capability="host-console" featureName="Host Console">
-                <HostConsole stackName={selectedFile} onClose={() => setActiveView(selectedFile ? 'editor' : 'dashboard')} />
+                <Suspense fallback={<ViewSkeleton />}>
+                  <HostConsole stackName={selectedFile} onClose={() => setActiveView(selectedFile ? 'editor' : 'dashboard')} />
+                </Suspense>
               </CapabilityGate>
             </AdmiralGate>
           ) : !isLoading && selectedFile && activeView === 'editor' ? (
@@ -3026,37 +3064,47 @@ export default function EditorLayout() {
               </div>
             </ErrorBoundary>
           ) : activeView === 'global-observability' ? (
-            <GlobalObservabilityView />
+            <Suspense fallback={<ViewSkeleton />}>
+              <GlobalObservabilityView />
+            </Suspense>
           ) : activeView === 'fleet' ? (
             <CapabilityGate capability="fleet" featureName="Fleet Management">
-              <FleetView onNavigateToNode={(nodeId, stackName) => {
-                const node = nodes.find(n => n.id === nodeId);
-                if (node) {
-                  if (activeNode?.id === nodeId) {
-                    loadFile(stackName);
-                  } else {
-                    pendingStackLoadRef.current = stackName;
-                    setActiveNode(node);
+              <Suspense fallback={<ViewSkeleton />}>
+                <FleetView onNavigateToNode={(nodeId, stackName) => {
+                  const node = nodes.find(n => n.id === nodeId);
+                  if (node) {
+                    if (activeNode?.id === nodeId) {
+                      loadFile(stackName);
+                    } else {
+                      pendingStackLoadRef.current = stackName;
+                      setActiveNode(node);
+                    }
                   }
-                }
-              }} />
+                }} />
+              </Suspense>
             </CapabilityGate>
           ) : activeView === 'audit-log' ? (
             <CapabilityGate capability="audit-log" featureName="Audit Log">
-              <AuditLogView />
+              <Suspense fallback={<ViewSkeleton />}>
+                <AuditLogView />
+              </Suspense>
             </CapabilityGate>
           ) : activeView === 'auto-updates' ? (
             <CapabilityGate capability="auto-updates" featureName="Auto-Update Readiness">
-              <AutoUpdateReadinessView />
+              <Suspense fallback={<ViewSkeleton />}>
+                <AutoUpdateReadinessView />
+              </Suspense>
             </CapabilityGate>
           ) : activeView === 'scheduled-ops' ? (
             <CapabilityGate capability="scheduled-ops" featureName="Scheduled Operations">
-              <ScheduledOperationsView
-                filterNodeId={filterNodeId}
-                onClearFilter={() => setFilterNodeId(null)}
-                prefill={schedulePrefill}
-                onPrefillConsumed={handlePrefillConsumed}
-              />
+              <Suspense fallback={<ViewSkeleton />}>
+                <ScheduledOperationsView
+                  filterNodeId={filterNodeId}
+                  onClearFilter={() => setFilterNodeId(null)}
+                  prefill={schedulePrefill}
+                  onPrefillConsumed={handlePrefillConsumed}
+                />
+              </Suspense>
             </CapabilityGate>
           ) : (
             <HomeDashboard
@@ -3274,11 +3322,19 @@ export default function EditorLayout() {
         }}
       />
 
-      {/* Scan history overlay */}
-      <SecurityHistoryView
-        open={securityHistoryOpen}
-        onClose={() => setSecurityHistoryOpen(false)}
-      />
+      {/* Scan history overlay. Conditionally mounted so the lazy chunk
+          only fetches when the user opens the overlay; an always-mounted
+          lazy component would fetch on EditorLayout's first render and
+          defeat the split. The overlay has no internal state that needs
+          to persist across opens. */}
+      {securityHistoryOpen ? (
+        <Suspense fallback={null}>
+          <SecurityHistoryView
+            open
+            onClose={() => setSecurityHistoryOpen(false)}
+          />
+        </Suspense>
+      ) : null}
     </div>
     </GlobalCommandPaletteProvider>
   );


### PR DESCRIPTION
## Summary

Follow-up to #870, which split the 8 paid-tier settings sections out of the Community bundle. This PR extends the same lazy-loading pattern to the 6 paid full-screen views and the security-history overlay in `EditorLayout`.

## What changed

`frontend/src/components/EditorLayout.tsx` (only file touched):

- Removed static imports for `HostConsole`, `GlobalObservabilityView`, `FleetView`, `AuditLogView`, `ScheduledOperationsView`, `AutoUpdateReadinessView`, `SecurityHistoryView`. Replaced with module-scope `lazy()` declarations using the named-export shim where needed.
- Added a small `ViewSkeleton` (header strip + large pulse block) using the existing `<Skeleton>` primitive. Sized for the main workspace area where the views render.
- Wrapped each paid-view call site in `<Suspense fallback={<ViewSkeleton />}>`. Suspense sits inside the existing `<CapabilityGate>` (and `<AdmiralGate>` for HostConsole) wrappers so that, when those gates eventually short-circuit, the placement is already correct.
- For `SecurityHistoryView` (an overlay controlled by `securityHistoryOpen` state), the call site is now conditionally mounted: `{open ? <Suspense fallback={null}><SecurityHistoryView open onClose={...} /></Suspense> : null}`. A naive always-mounted lazy overlay would fetch the chunk on `EditorLayout`'s first render and defeat the split.

## Build evidence (vite production build)

| Chunk | Raw | Gzip |
|---|---|---|
| HostConsole | 6.55 kB | 2.57 kB |
| SecurityHistoryView | 6.90 kB | 2.64 kB |
| GlobalObservabilityView | 12.80 kB | 4.75 kB |
| AutoUpdateReadinessView | 13.80 kB | 4.33 kB |
| ScheduledOperationsView | 44.87 kB | 12.31 kB |
| AuditLogView | 83.74 kB | 24.30 kB |
| FleetView | 139.90 kB | 32.27 kB |
| **Total split out** | **~308 kB** | **~83 kB** |

Main bundle shrunk from 1,467.80 kB → 1,164.55 kB (raw) and 406.66 kB → 331.62 kB (gzip). No `INEFFECTIVE_DYNAMIC_IMPORT` warnings.

**Combined with #870:** Community users save **~390 kB raw / ~107 kB gzip** on initial app load.

## Runtime evidence (vite dev server + manual end-to-end)

- Initial page load: zero requests for any of the 7 lazy view files.
- Click "Fleet" tab: `FleetView.tsx` fetched as request **#295**.
- Click "Audit" tab: `AuditLogView.tsx` fetched as request **#328**.

Lazy mechanism confirmed end-to-end.

## Scope: what this PR does NOT close

`PaidGate`, `AdmiralGate`, and `CapabilityGate` currently render a blurred preview with an upsell card instead of short-circuiting. So when a tier-locked or capability-missing operator opens a paid tab, the chunk still fetches to render the blurred preview. The click-time IP exposure is therefore unchanged by this PR.

What this PR closes is the much larger initial-bundle leak: every Community user used to download `FleetView` (~140 kB raw), `AuditLogView` (~84 kB raw), etc. on first page load even if they never clicked those tabs. Now those chunks fetch only on tab open.

The gate-short-circuit refactor is a deliberately separate follow-up (touches three gate components, has visual-regression risk, deserves its own design decision).

## Note on `GlobalObservabilityView`

It is a free-tier feature with no internal tier gate. It is split in this PR purely for the bundle-size win, not for IP protection. Reviewers may flag it as a regression at first glance — confirmed not.

## Test plan

- [x] `cd frontend && npx tsc -b --noEmit` clean
- [x] `npm run build` clean, no INEFFECTIVE_DYNAMIC_IMPORT warnings, all 7 chunks present
- [x] Dev-server smoke test: paid views lazy-load on tab click; initial load fetches zero view chunks
- [x] Code-reviewer agent run: 4 actionable findings addressed inline (CapabilityGate behavior noted in header comment, SecurityHistoryView conditional-mount folded in, internal docs extended, header comment phrased per Directive 20)
- [ ] **Recommended manual check before merge:** log in as a tier-locked operator and confirm that opening a paid tab (Fleet, Audit, etc.) renders the existing upsell card. The chunk WILL still fetch on click — that's expected for this PR; the gate-short-circuit follow-up will close that.

## Out of scope (follow-ups)

- **Gate short-circuit refactor** — make `PaidGate` / `AdmiralGate` / `CapabilityGate` short-circuit instead of rendering blurred children. Closes click-time IP exposure for views.
- **ErrorBoundary around the Suspense** — graceful UX when a chunk fetch fails (deploy mid-session, network hiccup).
- **Bundle visualization output** — run `ANALYZE=true npm run build` locally for chunk-graph inspection.