### PR TITLE
fix(frontend): short-circuit CapabilityGate and extract shared LockCard

### DIFF
--- a/frontend/src/components/CapabilityGate.tsx
+++ b/frontend/src/components/CapabilityGate.tsx
@@ -3,6 +3,7 @@ import { Unplug } from 'lucide-react';
 import { useNodes } from '@/context/NodeContext';
 import type { Capability } from '@/lib/capabilities';
 import { isValidVersion } from '@/lib/version';
+import { LockCard } from './ui/LockCard';
 
 interface CapabilityGateProps {
   capability: Capability;
@@ -10,6 +11,18 @@ interface CapabilityGateProps {
   children: ReactNode;
 }
 
+/**
+ * Renders children only when the active node advertises the required
+ * capability. When it does not, returns a clean lock card explaining the
+ * version mismatch instead of rendering the gated UI.
+ *
+ * Short-circuiting is load-bearing: callers wrap CapabilityGate around
+ * lazy-loaded views, and rendering the gated children to "blur and
+ * overlay" them would still trigger the chunk fetch (and ship the JSX
+ * to anyone who opens DevTools). The lock card has no children
+ * dependency and adds no chunk weight, so a node that lacks the
+ * capability never downloads the gated module.
+ */
 export function CapabilityGate({ capability, featureName = 'This feature', children }: CapabilityGateProps) {
   const { hasCapability, activeNode, activeNodeMeta } = useNodes();
 
@@ -17,20 +30,14 @@ export function CapabilityGate({ capability, featureName = 'This feature', child
 
   const nodeName = activeNode?.name ?? 'this node';
   const versionHint = isValidVersion(activeNodeMeta?.version)
-    ? `${nodeName} is running v${activeNodeMeta.version}`
-    : `${nodeName} does not support this capability`;
+    ? `${nodeName} is running v${activeNodeMeta.version}.`
+    : `${nodeName} does not advertise this capability.`;
 
   return (
-    <div className="relative">
-      <div className="opacity-40 pointer-events-none select-none blur-[2px]">
-        {children}
-      </div>
-      <div className="absolute inset-0 flex items-start justify-center pt-8">
-        <div className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-muted/80 border border-border text-muted-foreground text-xs">
-          <Unplug className="w-3 h-3" strokeWidth={1.5} />
-          {featureName} is not available: {versionHint}
-        </div>
-      </div>
-    </div>
+    <LockCard
+      icon={Unplug}
+      title={`${featureName} is not available on this node`}
+      body={`${versionHint} Upgrade the node to use this feature.`}
+    />
   );
 }

--- a/frontend/src/components/settings/SectionGate.tsx
+++ b/frontend/src/components/settings/SectionGate.tsx
@@ -6,6 +6,7 @@ import { useNodes } from '@/context/NodeContext';
 import { getSettingsItem, isItemVisible, isItemLocked } from './registry';
 import type { VisibilityContext } from './registry';
 import type { SectionId } from './types';
+import { LockCard } from '../ui/LockCard';
 
 interface TierLockedCardProps {
     tier: 'skipper' | 'admiral';
@@ -13,19 +14,8 @@ interface TierLockedCardProps {
 
 function TierLockedCard({ tier }: TierLockedCardProps) {
     const title = tier === 'admiral' ? 'Admiral feature' : 'Skipper feature';
-
     return (
-        <div className="flex flex-1 items-center justify-center p-8">
-            <div className="flex flex-col items-center gap-4 rounded-xl border border-glass-border bg-glass px-10 py-8 text-center">
-                <div className="flex h-12 w-12 items-center justify-center rounded-full border border-glass-border bg-glass">
-                    <Lock className="h-5 w-5 text-stat-subtitle" />
-                </div>
-                <div className="flex flex-col gap-1">
-                    <p className="text-sm font-semibold text-stat-value">{title}</p>
-                    <p className="text-sm text-stat-subtitle">Upgrade to unlock more features.</p>
-                </div>
-            </div>
-        </div>
+        <LockCard icon={Lock} title={title} body="Upgrade to unlock more features." />
     );
 }
 

--- a/frontend/src/components/ui/LockCard.tsx
+++ b/frontend/src/components/ui/LockCard.tsx
@@ -1,0 +1,39 @@
+import { type LucideIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+/**
+ * Centered glass-card lock state shared by tier gates and capability
+ * gates. Both gate variants short-circuit before mounting their gated
+ * children, so this card lives in the "no children rendered" branch and
+ * cannot trigger any lazy chunk fetches.
+ *
+ * Sized via `min-h-[280px]` so the card looks reasonable in inline
+ * contexts (e.g. a settings section panel) where the parent has no
+ * explicit height. Full-page contexts with explicit height stretch the
+ * card via `flex-1`. Override the outer layout with `className` when a
+ * specific consumer needs different proportions; the inner card box is
+ * intentionally fixed so all lock states across the app share the same
+ * geometry.
+ */
+interface LockCardProps {
+    icon: LucideIcon;
+    title: string;
+    body: string;
+    className?: string;
+}
+
+export function LockCard({ icon: Icon, title, body, className }: LockCardProps) {
+    return (
+        <div className={cn('flex flex-1 items-center justify-center p-8 min-h-[280px]', className)}>
+            <div className="flex flex-col items-center gap-4 rounded-xl border border-glass-border bg-glass px-10 py-8 text-center max-w-md">
+                <div className="flex items-center justify-center w-12 h-12 rounded-full border border-glass-border bg-glass">
+                    <Icon className="w-5 h-5 text-stat-subtitle" strokeWidth={1.5} />
+                </div>
+                <div className="flex flex-col gap-1">
+                    <p className="text-sm font-semibold text-stat-value">{title}</p>
+                    <p className="text-sm text-stat-subtitle">{body}</p>
+                </div>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

Closes the last always-leaking gate in the app. Combined with the lazy-loading work from #870 and #872, a node lacking a capability no longer downloads the chunk for the gated view (Fleet, Audit Log, Host Console, etc.).

## Why

`CapabilityGate` previously rendered the gated children behind a blur filter and overlay pill when the active node lacked the required capability. After #872 lazy-loaded the views, this meant the chunk for `FleetView`, `AuditLogView`, `HostConsole`, etc. still fetched on click even when the user could not use the feature, defeating the click-time IP protection the lazy split was meant to deliver. `CapabilityGate` was the only always-leaking gate (`PaidGate` and `AdmiralGate` already short-circuit by default; their post-dismissal blur path is a separate concern).

## What changed

**`frontend/src/components/CapabilityGate.tsx`** — replace the blurred-children render with a `<LockCard>` invocation. Children are no longer rendered when `hasCapability(capability)` returns false, so the lazy children never mount and the chunk never fetches.

**`frontend/src/components/ui/LockCard.tsx` (new)** — shared centered glass-card lock primitive. Accepts `icon`, `title`, `body`, and an optional `className` for layout overrides. The inner card geometry (rounded-xl, glass border + bg, max-w-md, fixed icon framing) is intentionally fixed so every lock state across the app shares the same visual rhythm. Sized via `min-h-[280px]` so the card looks right in inline contexts as well as full-page views.

**`frontend/src/components/settings/SectionGate.tsx`** — `TierLockedCard` was 95% identical to `CapabilityGate`'s lock card. Replace its hand-rolled JSX with a `<LockCard>` invocation so the two stay in sync.

## Behavior diff per consumer (13 total)

For every consumer, the only behavioral change is when the gate FAILS (capability mismatch):

- **Full-page views (5):** `host-console`, `fleet`, `audit-log`, `auto-updates`, `scheduled-ops`. Lock card replaces the blurred view. Chunk no longer fetches when the gate fails.
- **Settings sections (7):** `api-tokens`, `registries`, `webhooks`, `labels`, `users`, `notification-routing`, `sso`. Lock card replaces the blurred section content.
- **ResourcesView inline (1):** `network-topology`. Lock card replaces the blurred topology graph. The card-in-card aesthetic is slightly heavier than the previous small-pill treatment for this specific consumer; a follow-up could add a `variant="inline"` mode if it proves jarring in practice.

When the gate PASSES, behavior is unchanged.

## Test plan

- [x] `cd frontend && npx tsc -b --noEmit` clean
- [x] `npm run build` clean
- [ ] **Recommended manual check before merge:** connect to a remote Sencho node running an older version that lacks one of the capabilities (e.g., `fleet`, `audit-log`). Switch to that node and click the corresponding tab. Verify: (a) the lock card renders, (b) the Network tab shows NO request for `FleetView.tsx` / `AuditLogView.tsx` / etc. The second part is the actual proof the click-time exposure is closed. The happy-path code (line 33 `if (hasCapability(capability)) return <>{children}</>;`) is unchanged so paid users on capable nodes are unaffected.

## Internal docs

`docs/internal/architecture/settings-tier-code-splitting.md` (gitignored) updated to reflect that `CapabilityGate` now short-circuits and that the remaining click-time exposure is only the `PaidGate`/`AdmiralGate` post-dismissal path.

## Out of scope (follow-ups)

- **`PaidGate` / `AdmiralGate` post-dismissal blur path.** After a user clicks Dismiss on a paid feature's upsell card, the gate falls through to a 24h "blurred preview with small pill" mode that does render children. Closing this requires either removing the dismissal flow or rendering a static placeholder; UX decision worth its own PR.
- **`compact={true}` mode** on `PaidGate` / `AdmiralGate` (used for inline locks like individual SSO provider cards) still blurs children. Minor IP exposure for tiny inline UI; intentional UX.
- **`variant="inline"` mode for `LockCard`** if the card-in-card aesthetic for `network-topology` proves heavy in practice.