### PR TITLE
fix(frontend): replace post-dismissal blur in PaidGate / AdmiralGate with click-to-restore pill

### DIFF
--- a/e2e/stack-files.spec.ts
+++ b/e2e/stack-files.spec.ts
@@ -198,7 +198,7 @@ test.describe('File explorer - community (read-only)', () => {
 
   test('upgrade pill is visible in the left pane', async ({ page }) => {
     await expect(
-      page.getByRole('button', { name: /upgrade to unlock/i })
+      page.getByRole('button', { name: /upgrade to unlock upload/i })
     ).toBeVisible({ timeout: 5_000 });
   });
 

--- a/frontend/src/components/AdmiralGate.tsx
+++ b/frontend/src/components/AdmiralGate.tsx
@@ -25,7 +25,11 @@ export function AdmiralGate({ children, featureName = 'This feature', compact = 
 
     if (isPaid && license?.variant === 'admiral') return <>{children}</>;
 
-    if (compact || dismissed) {
+    // Inline lock for list items (single SSO provider card, etc.). Renders the
+    // children blurred behind a small pill so the surrounding list keeps its
+    // shape; the IP exposure is minor because the children are tiny inline UI,
+    // and the visual continuity is intentional. Dismissal does not apply here.
+    if (compact) {
         return (
             <div className="relative">
                 <div className="opacity-40 pointer-events-none select-none blur-[2px]">
@@ -37,6 +41,30 @@ export function AdmiralGate({ children, featureName = 'This feature', compact = 
                         Upgrade to Admiral to unlock
                     </div>
                 </div>
+            </div>
+        );
+    }
+
+    // Post-dismissal placeholder for full-page consumers. Renders only the
+    // pill so the lazy-loaded children behind an Admiral view never mount
+    // during the dismissal window. Clicking the pill clears the dismissal
+    // flag and restores the full upsell card so users who dismissed
+    // accidentally or want to revisit pricing have a way back without
+    // clearing localStorage.
+    if (dismissed) {
+        return (
+            <div className="flex items-start justify-center pt-8 min-h-[200px]">
+                <button
+                    type="button"
+                    onClick={() => {
+                        localStorage.removeItem(DISMISS_KEY);
+                        setDismissed(false);
+                    }}
+                    className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-muted/80 border border-border text-muted-foreground text-xs hover:bg-muted hover:text-foreground transition-colors"
+                >
+                    <ShipWheel className="w-3 h-3" />
+                    Upgrade to Admiral to unlock
+                </button>
             </div>
         );
     }

--- a/frontend/src/components/PaidGate.tsx
+++ b/frontend/src/components/PaidGate.tsx
@@ -25,7 +25,11 @@ export function PaidGate({ children, featureName = 'This feature', compact = fal
 
     if (isPaid) return <>{children}</>;
 
-    if (compact || dismissed) {
+    // Inline lock for list items (single SSO provider card, etc.). Renders the
+    // children blurred behind a small pill so the surrounding list keeps its
+    // shape; the IP exposure is minor because the children are tiny inline UI,
+    // and the visual continuity is intentional. Dismissal does not apply here.
+    if (compact) {
         return (
             <div className="relative">
                 <div className="opacity-40 pointer-events-none select-none blur-[2px]">
@@ -37,6 +41,29 @@ export function PaidGate({ children, featureName = 'This feature', compact = fal
                         Upgrade to unlock {featureName}
                     </div>
                 </div>
+            </div>
+        );
+    }
+
+    // Post-dismissal placeholder for full-page consumers. Renders only the
+    // pill so the lazy-loaded children behind a paid view never mount during
+    // the dismissal window. Clicking the pill clears the dismissal flag and
+    // restores the full upsell card so users who dismissed accidentally or
+    // want to revisit pricing have a way back without clearing localStorage.
+    if (dismissed) {
+        return (
+            <div className="flex items-start justify-center pt-8 min-h-[200px]">
+                <button
+                    type="button"
+                    onClick={() => {
+                        localStorage.removeItem(DISMISS_KEY);
+                        setDismissed(false);
+                    }}
+                    className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-muted/80 border border-border text-muted-foreground text-xs hover:bg-muted hover:text-foreground transition-colors"
+                >
+                    <Compass className="w-3 h-3" />
+                    Upgrade to unlock {featureName}
+                </button>
             </div>
         );
     }


### PR DESCRIPTION
## Summary

Closes the last lazy-chunk leakage path in the frontend gate stack. After this PR, no Sencho gate renders blurred children behind a paid view; the dismissal UX is preserved.

## Why

After #870 (lazy-loaded settings), #872 (lazy-loaded views), and #873 (CapabilityGate short-circuit), the only remaining click-time chunk fetch happened when a tier-locked user clicked Dismiss on a paid feature's full-page upsell. The 24h post-dismissal mode rendered the gated children behind a blur filter so users could see the locked feature still existed in their nav. That render mounted the lazy children, which fetched the chunk and shipped the JSX to anyone with DevTools.

You wanted to keep the dismissal flow (lets users mute upsell pressure without losing visual continuity for the locked feature). The fix here splits the dismissed branch from the compact branch and renders a static placeholder pill in dismissed mode, no children mounted.

## What changed

**`frontend/src/components/PaidGate.tsx` and `AdmiralGate.tsx`** (mirror change):

- `compact` branch: unchanged. Inline list-item locks (single SSO provider card, etc.) still render blurred children behind a small pill. The IP exposure is minor (tiny inline UI), and the visual continuity is intentional.
- `dismissed` branch (new): renders only a small pill in an empty 200px-tall area, no children mounted. The pill is a `<button>` that clears the dismissal flag from localStorage and re-renders the full upsell card on click. Users who dismissed accidentally or want to revisit pricing have a way back without clearing site data manually.

**`e2e/stack-files.spec.ts`** (follow-up fix for CI):

The new dismissed branch renders a `<button>` (previously a `<div>`), which made the test's generic `/upgrade to unlock/i` locator match two elements: the FileUploadDropzone button and the Auto-Heal dismissed-state pill. Narrowed the locator to `/upgrade to unlock upload/i` so it targets only the file-upload pill, which is what the test was verifying.

## Test plan

- [x] `cd frontend && npx tsc -b --noEmit` clean
- [x] `npm run build` clean
- [x] Code reviewed: all findings LOW/INFO with deferred recommendations
- [x] E2E fix: narrowed `getByRole` locator in `stack-files.spec.ts` to resolve strict-mode ambiguity
- [ ] **Recommended manual check before merge:**
  1. Log in as a Community user.
  2. Navigate to a paid view (e.g., Fleet) — full upsell card should render. Click "Dismiss."
  3. Navigate away and back to Fleet — small pill should render in an empty area (not blurred children behind it). Network tab should show NO request for `FleetView.tsx` / `FleetView-*.js`.
  4. Click the pill — full upsell card should reappear. localStorage key `sencho-upgrade-prompt-dismissed` should be cleared.
  5. Repeat for an Admiral feature (e.g., Audit Log) to verify AdmiralGate mirror.

## Internal docs

`docs/internal/architecture/settings-tier-code-splitting.md` (gitignored) updated to remove the "post-dismissal click-time leak" out-of-scope caveat (this PR closes it) and document the new dismissal placeholder behavior.

## What this completes

The frontend bundle-leakage story end-to-end:

| PR | What | Surface |
|---|---|---|
| #870 | lazy-load 8 paid settings sections | initial bundle |
| #872 | lazy-load 6 paid views + security overlay | initial bundle |
| #873 | CapabilityGate short-circuits + LockCard primitive | click-time, capability mismatch |
| **this PR** | **PaidGate / AdmiralGate post-dismissal short-circuit** | **click-time, after dismissal** |

Combined: no Community user (or tier-locked operator on a capable node, regardless of dismissal state) downloads the JSX of a paid feature they cannot use. The only remaining chunk-fetch path is `compact={true}` mode (inline lock for tiny list items like individual SSO provider cards), which is intentional UX.

## Out of scope (follow-ups)

- **Cross-tab dismissal sync** — `dismissed` is seeded from localStorage once per mount; tabs opened before the dismissal don't pick it up. Soft UX nicety, not a security boundary, deferred.
- **`featureName` symmetry** — AdmiralGate's pill omits `{featureName}` ("Upgrade to Admiral to unlock") while PaidGate's includes it ("Upgrade to unlock {featureName}"). Pre-existing inheritance from the compact-mode render, not introduced by this PR. Could symmetrize in a copy-polish PR.
- **Two-gate near-duplication** — PaidGate and AdmiralGate are now ~95% identical. Reviewer flagged but recommended deferring extraction until a third consumer appears (rule of three). Worth a follow-up issue for visibility.
- **ErrorBoundary around Suspense** — friendlier UX on chunk fetch failures.