### PR TITLE
feat(frontend): add LazyBoundary for chunk-load failure recovery

### DIFF
--- a/frontend/src/components/EditorLayout.tsx
+++ b/frontend/src/components/EditorLayout.tsx
@@ -8,6 +8,7 @@ import ErrorBoundary from './ErrorBoundary';
 import HomeDashboard from './HomeDashboard';
 import type { NotificationItem } from './dashboard/types';
 import BashExecModal from './BashExecModal';
+import LazyBoundary from './LazyBoundary';
 import { Skeleton } from '@/components/ui/skeleton';
 import { AdmiralGate } from './AdmiralGate';
 import { CapabilityGate } from './CapabilityGate';
@@ -2523,9 +2524,11 @@ export default function EditorLayout() {
           ) : activeView === 'host-console' ? (
             <AdmiralGate featureName="Host Console">
               <CapabilityGate capability="host-console" featureName="Host Console">
-                <Suspense fallback={<ViewSkeleton />}>
-                  <HostConsole stackName={selectedFile} onClose={() => setActiveView(selectedFile ? 'editor' : 'dashboard')} />
-                </Suspense>
+                <LazyBoundary>
+                  <Suspense fallback={<ViewSkeleton />}>
+                    <HostConsole stackName={selectedFile} onClose={() => setActiveView(selectedFile ? 'editor' : 'dashboard')} />
+                  </Suspense>
+                </LazyBoundary>
               </CapabilityGate>
             </AdmiralGate>
           ) : !isLoading && selectedFile && activeView === 'editor' ? (
@@ -3064,47 +3067,57 @@ export default function EditorLayout() {
               </div>
             </ErrorBoundary>
           ) : activeView === 'global-observability' ? (
-            <Suspense fallback={<ViewSkeleton />}>
-              <GlobalObservabilityView />
-            </Suspense>
+            <LazyBoundary>
+              <Suspense fallback={<ViewSkeleton />}>
+                <GlobalObservabilityView />
+              </Suspense>
+            </LazyBoundary>
           ) : activeView === 'fleet' ? (
             <CapabilityGate capability="fleet" featureName="Fleet Management">
-              <Suspense fallback={<ViewSkeleton />}>
-                <FleetView onNavigateToNode={(nodeId, stackName) => {
-                  const node = nodes.find(n => n.id === nodeId);
-                  if (node) {
-                    if (activeNode?.id === nodeId) {
-                      loadFile(stackName);
-                    } else {
-                      pendingStackLoadRef.current = stackName;
-                      setActiveNode(node);
+              <LazyBoundary>
+                <Suspense fallback={<ViewSkeleton />}>
+                  <FleetView onNavigateToNode={(nodeId, stackName) => {
+                    const node = nodes.find(n => n.id === nodeId);
+                    if (node) {
+                      if (activeNode?.id === nodeId) {
+                        loadFile(stackName);
+                      } else {
+                        pendingStackLoadRef.current = stackName;
+                        setActiveNode(node);
+                      }
                     }
-                  }
-                }} />
-              </Suspense>
+                  }} />
+                </Suspense>
+              </LazyBoundary>
             </CapabilityGate>
           ) : activeView === 'audit-log' ? (
             <CapabilityGate capability="audit-log" featureName="Audit Log">
-              <Suspense fallback={<ViewSkeleton />}>
-                <AuditLogView />
-              </Suspense>
+              <LazyBoundary>
+                <Suspense fallback={<ViewSkeleton />}>
+                  <AuditLogView />
+                </Suspense>
+              </LazyBoundary>
             </CapabilityGate>
           ) : activeView === 'auto-updates' ? (
             <CapabilityGate capability="auto-updates" featureName="Auto-Update Readiness">
-              <Suspense fallback={<ViewSkeleton />}>
-                <AutoUpdateReadinessView />
-              </Suspense>
+              <LazyBoundary>
+                <Suspense fallback={<ViewSkeleton />}>
+                  <AutoUpdateReadinessView />
+                </Suspense>
+              </LazyBoundary>
             </CapabilityGate>
           ) : activeView === 'scheduled-ops' ? (
             <CapabilityGate capability="scheduled-ops" featureName="Scheduled Operations">
-              <Suspense fallback={<ViewSkeleton />}>
-                <ScheduledOperationsView
-                  filterNodeId={filterNodeId}
-                  onClearFilter={() => setFilterNodeId(null)}
-                  prefill={schedulePrefill}
-                  onPrefillConsumed={handlePrefillConsumed}
-                />
-              </Suspense>
+              <LazyBoundary>
+                <Suspense fallback={<ViewSkeleton />}>
+                  <ScheduledOperationsView
+                    filterNodeId={filterNodeId}
+                    onClearFilter={() => setFilterNodeId(null)}
+                    prefill={schedulePrefill}
+                    onPrefillConsumed={handlePrefillConsumed}
+                  />
+                </Suspense>
+              </LazyBoundary>
             </CapabilityGate>
           ) : (
             <HomeDashboard
@@ -3328,12 +3341,14 @@ export default function EditorLayout() {
           defeat the split. The overlay has no internal state that needs
           to persist across opens. */}
       {securityHistoryOpen ? (
-        <Suspense fallback={null}>
-          <SecurityHistoryView
-            open
-            onClose={() => setSecurityHistoryOpen(false)}
-          />
-        </Suspense>
+        <LazyBoundary>
+          <Suspense fallback={null}>
+            <SecurityHistoryView
+              open
+              onClose={() => setSecurityHistoryOpen(false)}
+            />
+          </Suspense>
+        </LazyBoundary>
       ) : null}
     </div>
     </GlobalCommandPaletteProvider>

--- a/frontend/src/components/LazyBoundary.tsx
+++ b/frontend/src/components/LazyBoundary.tsx
@@ -2,6 +2,7 @@ import { Component } from 'react';
 import type { ErrorInfo, ReactNode } from 'react';
 import { AlertTriangle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { isChunkLoadError } from './isChunkLoadError';
 
 interface Props {
     children: ReactNode;
@@ -10,37 +11,6 @@ interface Props {
 interface State {
     hasError: boolean;
     error: Error | null;
-}
-
-/**
- * Recognises the error messages browsers throw when a dynamically-imported
- * chunk URL is no longer reachable. Each runtime worded the failure
- * differently, so the heuristic is a substring union rather than a single
- * regex; broadening to a generic "module + fail" match would over-fire on
- * legitimate runtime errors and route them to a misleading Reload CTA.
- *
- * Currently covered:
- *   - Chrome / Edge:  "Failed to fetch dynamically imported module: <url>"
- *   - Safari:         "Importing a module script failed."
- *   - Firefox:        "Loading module from \"<url>\" was blocked because of a disallowed MIME type (\"text/html\")."
- *                     (fired when a deploy serves the SPA index.html for a missing chunk URL)
- *   - Older Webpack:  "Error loading dynamically imported module"
- *   - Vite:           "Loading chunk N failed." / "Loading CSS chunk N failed"
- *
- * Add new substrings here as new browser variants surface; cover them in
- * the matching unit test so a regression in one runtime is caught early.
- */
-export function isChunkLoadError(error: Error | null | undefined): boolean {
-    if (!error) return false;
-    const msg = error.message.toLowerCase();
-    return (
-        msg.includes('failed to fetch dynamically imported module') ||
-        msg.includes('importing a module script failed') ||
-        msg.includes('error loading dynamically imported module') ||
-        msg.includes('disallowed mime type') ||
-        msg.includes('loading chunk') ||
-        msg.includes('loading css chunk')
-    );
 }
 
 /**

--- a/frontend/src/components/LazyBoundary.tsx
+++ b/frontend/src/components/LazyBoundary.tsx
@@ -1,0 +1,110 @@
+import { Component } from 'react';
+import type { ErrorInfo, ReactNode } from 'react';
+import { AlertTriangle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface Props {
+    children: ReactNode;
+}
+
+interface State {
+    hasError: boolean;
+    error: Error | null;
+}
+
+/**
+ * Recognises the error messages browsers throw when a dynamically-imported
+ * chunk URL is no longer reachable. Each runtime worded the failure
+ * differently, so the heuristic is a substring union rather than a single
+ * regex; broadening to a generic "module + fail" match would over-fire on
+ * legitimate runtime errors and route them to a misleading Reload CTA.
+ *
+ * Currently covered:
+ *   - Chrome / Edge:  "Failed to fetch dynamically imported module: <url>"
+ *   - Safari:         "Importing a module script failed."
+ *   - Firefox:        "Loading module from \"<url>\" was blocked because of a disallowed MIME type (\"text/html\")."
+ *                     (fired when a deploy serves the SPA index.html for a missing chunk URL)
+ *   - Older Webpack:  "Error loading dynamically imported module"
+ *   - Vite:           "Loading chunk N failed." / "Loading CSS chunk N failed"
+ *
+ * Add new substrings here as new browser variants surface; cover them in
+ * the matching unit test so a regression in one runtime is caught early.
+ */
+export function isChunkLoadError(error: Error | null | undefined): boolean {
+    if (!error) return false;
+    const msg = error.message.toLowerCase();
+    return (
+        msg.includes('failed to fetch dynamically imported module') ||
+        msg.includes('importing a module script failed') ||
+        msg.includes('error loading dynamically imported module') ||
+        msg.includes('disallowed mime type') ||
+        msg.includes('loading chunk') ||
+        msg.includes('loading css chunk')
+    );
+}
+
+/**
+ * Specialized error boundary for lazy-loaded subtrees. Catches errors
+ * thrown during chunk fetch and renders a small card inviting the user
+ * to reload. Reload is the actual remedy because the stale tab is asking
+ * for chunk URLs that the deployed bundle no longer emits; a "Try again"
+ * against the same URL would just fail again.
+ *
+ * For non-chunk runtime errors (the lazy module loaded but threw during
+ * render) the boundary falls back to a "Try again" CTA that resets state
+ * and re-renders the children. This is safe because the lazy import has
+ * already resolved on this path, so re-rendering does not re-trigger a
+ * chunk fetch; if the underlying error is non-deterministic (e.g. a stale
+ * API response) the retry can succeed. If the error is deterministic the
+ * card just reappears, which is the expected behavior of any boundary.
+ *
+ * Sized via min-h-[280px] to look at home in both the workspace area
+ * and inline-section contexts that wrap lazy components.
+ */
+class LazyBoundary extends Component<Props, State> {
+    public state: State = {
+        hasError: false,
+        error: null,
+    };
+
+    public static getDerivedStateFromError(error: Error): State {
+        return { hasError: true, error };
+    }
+
+    public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+        console.error('LazyBoundary caught an error:', error, errorInfo);
+    }
+
+    public render() {
+        if (!this.state.hasError) return this.props.children;
+
+        const isChunk = isChunkLoadError(this.state.error);
+        const title = isChunk ? 'This part of Sencho needs a reload' : 'Something went wrong';
+        const body = isChunk
+            ? 'A newer version may have shipped while this tab was open. Reload to fetch the latest.'
+            : this.state.error?.message || 'Unknown error';
+        const ctaLabel = isChunk ? 'Reload' : 'Try again';
+        const onCta = isChunk
+            ? () => window.location.reload()
+            : () => this.setState({ hasError: false, error: null });
+
+        return (
+            <div className="flex flex-1 items-center justify-center min-h-[280px] p-8" role="alert">
+                <div className="flex flex-col items-center gap-4 rounded-xl border border-glass-border bg-glass px-10 py-8 text-center max-w-md">
+                    <div className="flex items-center justify-center w-12 h-12 rounded-full border border-glass-border bg-glass">
+                        <AlertTriangle className="w-5 h-5 text-stat-subtitle" strokeWidth={1.5} />
+                    </div>
+                    <div className="flex flex-col gap-1">
+                        <p className="text-sm font-semibold text-stat-value">{title}</p>
+                        <p className="text-sm text-stat-subtitle">{body}</p>
+                    </div>
+                    <Button variant="outline" size="sm" onClick={onCta}>
+                        {ctaLabel}
+                    </Button>
+                </div>
+            </div>
+        );
+    }
+}
+
+export default LazyBoundary;

--- a/frontend/src/components/ResourcesView.tsx
+++ b/frontend/src/components/ResourcesView.tsx
@@ -29,6 +29,7 @@ import { useAuth } from '@/context/AuthContext';
 import { useLicense } from '@/context/LicenseContext';
 import { PaidGate } from './PaidGate';
 import { CapabilityGate } from './CapabilityGate';
+import LazyBoundary from './LazyBoundary';
 import { formatBytes } from '@/lib/utils';
 import { cn } from '@/lib/utils';
 import { SENCHO_OPEN_LOGS_EVENT } from '@/lib/events';
@@ -1022,20 +1023,22 @@ export default function ResourcesView() {
                             <div className="p-4">
                                 <PaidGate featureName="Network Topology">
                                     <CapabilityGate capability="network-topology" featureName="Network Topology">
-                                        <Suspense fallback={
-                                            <div className="flex items-center justify-center h-[400px] text-muted-foreground gap-2">
-                                                <span className="text-sm">Loading topology...</span>
-                                            </div>
-                                        }>
-                                            <NetworkTopologyView
-                                                key={activeNode?.id}
-                                                onContainerClick={(id, name) => {
-                                                    window.dispatchEvent(new CustomEvent<SenchoOpenLogsDetail>(SENCHO_OPEN_LOGS_EVENT, {
-                                                        detail: { containerId: id, containerName: name },
-                                                    }));
-                                                }}
-                                            />
-                                        </Suspense>
+                                        <LazyBoundary>
+                                            <Suspense fallback={
+                                                <div className="flex items-center justify-center h-[400px] text-muted-foreground gap-2">
+                                                    <span className="text-sm">Loading topology...</span>
+                                                </div>
+                                            }>
+                                                <NetworkTopologyView
+                                                    key={activeNode?.id}
+                                                    onContainerClick={(id, name) => {
+                                                        window.dispatchEvent(new CustomEvent<SenchoOpenLogsDetail>(SENCHO_OPEN_LOGS_EVENT, {
+                                                            detail: { containerId: id, containerName: name },
+                                                        }));
+                                                    }}
+                                                />
+                                            </Suspense>
+                                        </LazyBoundary>
                                     </CapabilityGate>
                                 </PaidGate>
                             </div>

--- a/frontend/src/components/__tests__/LazyBoundary.test.ts
+++ b/frontend/src/components/__tests__/LazyBoundary.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isChunkLoadError } from '../LazyBoundary';
+import { isChunkLoadError } from '../isChunkLoadError';
 
 /**
  * isChunkLoadError is a substring union over the messages browsers emit

--- a/frontend/src/components/__tests__/LazyBoundary.test.ts
+++ b/frontend/src/components/__tests__/LazyBoundary.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { isChunkLoadError } from '../LazyBoundary';
+
+/**
+ * isChunkLoadError is a substring union over the messages browsers emit
+ * when a dynamically-imported chunk URL is no longer reachable. The heuristic
+ * is the entire feature: a missed variant routes a stale-tab user to a
+ * misleading "Try again" CTA instead of "Reload", and "Try again" can never
+ * succeed against a chunk URL that no longer exists. Keep this fixture in
+ * sync with the documented browser variants in LazyBoundary.tsx.
+ */
+describe('isChunkLoadError', () => {
+    it('returns false for null', () => {
+        expect(isChunkLoadError(null)).toBe(false);
+    });
+
+    it('returns false for undefined', () => {
+        expect(isChunkLoadError(undefined)).toBe(false);
+    });
+
+    it('returns false for unrelated runtime errors', () => {
+        expect(isChunkLoadError(new Error('Cannot read properties of undefined'))).toBe(false);
+        expect(isChunkLoadError(new Error('Maximum update depth exceeded'))).toBe(false);
+        expect(isChunkLoadError(new Error('Network request failed'))).toBe(false);
+    });
+
+    it('matches Chrome / Edge "Failed to fetch dynamically imported module"', () => {
+        const err = new Error('Failed to fetch dynamically imported module: https://app.example/assets/FleetView-abc123.js');
+        expect(isChunkLoadError(err)).toBe(true);
+    });
+
+    it('matches Safari "Importing a module script failed."', () => {
+        expect(isChunkLoadError(new Error('Importing a module script failed.'))).toBe(true);
+    });
+
+    it('matches Firefox MIME-type variant produced when a deploy serves index.html for a missing chunk', () => {
+        const err = new Error(
+            'Loading module from "https://app.example/assets/FleetView-abc123.js" was blocked because of a disallowed MIME type ("text/html").',
+        );
+        expect(isChunkLoadError(err)).toBe(true);
+    });
+
+    it('matches older Webpack "Error loading dynamically imported module"', () => {
+        expect(isChunkLoadError(new Error('Error loading dynamically imported module'))).toBe(true);
+    });
+
+    it('matches Vite "Loading chunk N failed."', () => {
+        expect(isChunkLoadError(new Error('Loading chunk 42 failed.'))).toBe(true);
+    });
+
+    it('matches Vite "Loading CSS chunk N failed"', () => {
+        expect(isChunkLoadError(new Error('Loading CSS chunk 42 failed'))).toBe(true);
+    });
+
+    it('is case-insensitive', () => {
+        expect(isChunkLoadError(new Error('FAILED TO FETCH DYNAMICALLY IMPORTED MODULE'))).toBe(true);
+        expect(isChunkLoadError(new Error('Loading Chunk 12 Failed'))).toBe(true);
+    });
+});

--- a/frontend/src/components/isChunkLoadError.ts
+++ b/frontend/src/components/isChunkLoadError.ts
@@ -1,0 +1,30 @@
+/**
+ * Recognises the error messages browsers throw when a dynamically-imported
+ * chunk URL is no longer reachable. Each runtime worded the failure
+ * differently, so the heuristic is a substring union rather than a single
+ * regex; broadening to a generic "module + fail" match would over-fire on
+ * legitimate runtime errors and route them to a misleading Reload CTA.
+ *
+ * Currently covered:
+ *   - Chrome / Edge:  "Failed to fetch dynamically imported module: <url>"
+ *   - Safari:         "Importing a module script failed."
+ *   - Firefox:        "Loading module from \"<url>\" was blocked because of a disallowed MIME type (\"text/html\")."
+ *                     (fired when a deploy serves the SPA index.html for a missing chunk URL)
+ *   - Older Webpack:  "Error loading dynamically imported module"
+ *   - Vite:           "Loading chunk N failed." / "Loading CSS chunk N failed"
+ *
+ * Add new substrings here as new browser variants surface; cover them in
+ * the matching unit test so a regression in one runtime is caught early.
+ */
+export function isChunkLoadError(error: Error | null | undefined): boolean {
+    if (!error) return false;
+    const msg = error.message.toLowerCase();
+    return (
+        msg.includes('failed to fetch dynamically imported module') ||
+        msg.includes('importing a module script failed') ||
+        msg.includes('error loading dynamically imported module') ||
+        msg.includes('disallowed mime type') ||
+        msg.includes('loading chunk') ||
+        msg.includes('loading css chunk')
+    );
+}

--- a/frontend/src/components/settings/SettingsPage.tsx
+++ b/frontend/src/components/settings/SettingsPage.tsx
@@ -33,6 +33,7 @@ import {
     isItemLocked,
 } from './index';
 import type { SectionId, SettingsItemMeta, VisibilityContext } from './index';
+import LazyBoundary from '../LazyBoundary';
 import { SectionGate } from './SectionGate';
 import { SettingsSidebar } from './SettingsSidebar';
 import { MastheadStatsProvider, useMastheadStatsValue } from './MastheadStatsContext';
@@ -254,12 +255,17 @@ function SettingsPageInner({ currentSection, onSectionChange }: SettingsPageProp
                             ) : null}
                             {/* Suspense outside SectionGate so the locked-tier
                                 path (which never mounts the lazy children)
-                                does not see a fallback flash. */}
-                            <Suspense fallback={<SectionSkeleton />}>
-                                <SectionGate sectionId={safeSection}>
-                                    {sectionElement}
-                                </SectionGate>
-                            </Suspense>
+                                does not see a fallback flash. LazyBoundary
+                                outside Suspense catches chunk-fetch failures
+                                so a stale tab spans-deploy mismatch shows a
+                                Reload card instead of crashing the workspace. */}
+                            <LazyBoundary>
+                                <Suspense fallback={<SectionSkeleton />}>
+                                    <SectionGate sectionId={safeSection}>
+                                        {sectionElement}
+                                    </SectionGate>
+                                </Suspense>
+                            </LazyBoundary>
                         </div>
                     </ScrollArea>
                 </div>


### PR DESCRIPTION
## Summary

Closes the last UX gap from the recent lazy-loading work: when a chunk fetch fails (typical post-deploy case where the tab was opened against an older bundle), the user now sees an in-place \"Reload\" card instead of the generic top-level \"Something went wrong\" + \"Try again\" UI. Reload is the actual remedy because \"Try again\" can never succeed against a chunk URL that no longer exists on the server.

## What changed

**`frontend/src/components/isChunkLoadError.ts` (new):**
- Standalone utility that detects browser chunk-load error messages. Covers Chrome/Edge, Safari, Firefox, older Webpack, and Vite variants.
- Lives in its own file so `LazyBoundary.tsx` exports only a component (required by `react-refresh/only-export-components`).

**`frontend/src/components/LazyBoundary.tsx` (new):**
- Class-based React error boundary specialized for lazy-loaded subtrees.
- For chunk errors: glass-card matching LockCard aesthetic (`AlertTriangle` icon, glass border, `min-h-[280px]`) with copy "This part of Sencho needs a reload" / "A newer version may have shipped while this tab was open. Reload to fetch the latest." and a Reload CTA that calls `window.location.reload()`.
- For non-chunk runtime errors: falls back to "Something went wrong" + the error message + "Try again" CTA. Try again is safe on this path because the lazy import has already resolved (the inline comment explains this so a future maintainer does not "fix" it).
- `role="alert"` on the outer container so screen readers announce the failure.
- `console.error` in `componentDidCatch` so the underlying failure stays observable.

**`frontend/src/components/__tests__/LazyBoundary.test.ts` (new):**
- 10 unit tests for `isChunkLoadError`, one fixture per documented browser variant. The heuristic IS the feature, so the fixture is the regression guard.

**Wrapped 9 existing Suspense sites:**
- `frontend/src/components/settings/SettingsPage.tsx` - 1 site (around the `<SectionGate>{sectionElement}</SectionGate>` lazy section block).
- `frontend/src/components/EditorLayout.tsx` - 7 sites: HostConsole, GlobalObservabilityView, FleetView, AuditLogView, AutoUpdateReadinessView, ScheduledOperationsView, plus the conditionally-mounted SecurityHistoryView overlay.
- `frontend/src/components/ResourcesView.tsx` - 1 site (around NetworkTopologyView).

Pattern at every site: `<LazyBoundary><Suspense fallback={<ViewSkeleton />}><LazyComponent /></Suspense></LazyBoundary>`. LazyBoundary outside Suspense so chunk-fetch errors (which propagate up through Suspense's pending state) are caught by the boundary.

## Test plan

- [x] `cd frontend && npx tsc -b --noEmit` clean
- [x] `npm run build` clean
- [x] New unit tests: 10 / 10 passing (each browser's documented chunk-load message recognized; unrelated runtime errors correctly NOT recognized)
- [x] CI lint fix: `isChunkLoadError` moved to its own file (`isChunkLoadError.ts`); `LazyBoundary.tsx` now exports only a component, satisfying `react-refresh/only-export-components`
- [x] Code-reviewed: 3 actionable findings folded in (Firefox MIME-type heuristic, role="alert", inline comment explaining "Try again" safety on the non-chunk path)
- [ ] **Recommended manual check before merge:** in DevTools, intercept and 404 a paid-section chunk request (Network tab -> right-click -> "Block request URL"), then click that section. Verify the LazyBoundary card renders with the Reload CTA and clicking Reload triggers a page reload.

## What this completes

After this PR, the frontend lazy-loading story has full UX coverage:

| PR | What | Surface |
|---|---|---|
| #870 | 8 paid settings sections lazy | initial bundle |
| #872 | 6 paid views + security overlay lazy | initial bundle |
| #873 | CapabilityGate short-circuits + LockCard primitive | click-time on capability mismatch |
| #874 | PaidGate / AdmiralGate post-dismissal short-circuit | click-time after dismissal |
| **this PR** | **LazyBoundary for chunk-load failures** | **transient deploy / network errors** |

## Out of scope (follow-ups)

- **Keyboard focus management** on the LazyBoundary CTA - when the boundary trips, focus stays wherever it was (often `<body>`). A `ref` on the Button and a `componentDidUpdate` focus shift would surface the CTA for keyboard users. ~10 min, deferred.
- **AppErrorBoundary unification** - the existing top-level `ErrorBoundary.tsx` could be consolidated with LazyBoundary's design language (currently red theme, "Something went wrong"). Different scope, separate PR.
- **Two-gate near-duplication** (PaidGate / AdmiralGate at 95% identical) - flagged by reviewer of #874, deferred per rule-of-three.