### PR TITLE
refactor(entitlements): migrate type-only consumers to entitlements/types

### DIFF
--- a/backend/src/routes/dashboard.ts
+++ b/backend/src/routes/dashboard.ts
@@ -3,7 +3,7 @@ import { DatabaseService } from '../services/DatabaseService';
 import { CloudBackupService } from '../services/CloudBackupService';
 import { authMiddleware } from '../middleware/auth';
 import { effectiveTier, effectiveVariant } from '../middleware/tierGates';
-import type { LicenseTier, LicenseVariant } from '../services/LicenseService';
+import type { LicenseTier, LicenseVariant } from '../entitlements/types';
 
 export const dashboardRouter = Router();
 

--- a/backend/src/services/LicenseService.ts
+++ b/backend/src/services/LicenseService.ts
@@ -10,14 +10,6 @@ import type {
     SeatLimits,
 } from '../entitlements/types';
 
-// Back-compat re-exports. The canonical type definitions live in
-// `entitlements/types.ts`; this re-export keeps existing imports
-// (`import type { LicenseTier } from '@/services/LicenseService'`)
-// working until consumers migrate. A follow-up PR titled
-// `refactor(entitlements): migrate type-only consumers to entitlements/types`
-// will sweep the remaining ~20 consumers; Phase 2 deletes this file.
-export type { LicenseInfo, LicenseStatus, LicenseTier, LicenseVariant, SeatLimits };
-
 // Header constants and tier/variant normalizers previously exported
 // from this file moved to `../entitlements/headers` and
 // `../entitlements/normalize` respectively, where they live in the
@@ -25,9 +17,9 @@ export type { LicenseInfo, LicenseStatus, LicenseTier, LicenseVariant, SeatLimit
 // LicenseService imports them back for internal use.
 import { isLicenseVariant, normalizeVariant } from '../entitlements/normalize';
 
-// LicenseInfo and SeatLimits live in `entitlements/types.ts` and are
-// re-exported above. The literal seat-limit table for paid variants
-// stays here because it is specific to the LemonSqueezy implementation.
+// The seat-limit table for paid variants is specific to the
+// LemonSqueezy implementation and stays in this file. Phase 2 moves it
+// to `@studio-saelix/sencho-pro` along with the rest of the file.
 const SEAT_LIMITS: Record<string, SeatLimits> = {
     skipper: { maxAdmins: 1, maxViewers: 3 },
     admiral: { maxAdmins: null, maxViewers: null },

--- a/backend/src/types/express.ts
+++ b/backend/src/types/express.ts
@@ -1,5 +1,5 @@
 import type { UserRole, ApiTokenScope } from '../services/DatabaseService';
-import type { LicenseTier, LicenseVariant } from '../services/LicenseService';
+import type { LicenseTier, LicenseVariant } from '../entitlements/types';
 
 // Extend Express Request type for user and node context.
 // This file is imported for its side effects only (ambient declaration).


### PR DESCRIPTION
## Summary

Phase 1 follow-up to #878. After Phase 1 introduced `entitlements/types`, two consumers still imported their tier types from `services/LicenseService` via the back-compat re-export. This PR points them at the canonical location and drops the re-export block.

After this lands, `services/LicenseService.ts` has no public type re-exports. Phase 2's deletion of that file becomes a zero-change operation for the public-core consumer surface (only the loader and the LS-specific test file reference it directly, both of which go away in Phase 2 alongside the file move).

## Smaller than the ADR estimated

The ADR (`docs/internal/adrs/2026-05-02-open-core-hybrid-strategy.md`) estimated "~20 type-only consumers" for this sweep. The actual count is **2**: `types/express.ts` and `routes/dashboard.ts`. Most of the apparent type imports were already runtime imports of the `LicenseService` class itself, which are migrated to `getEntitlementProvider()` already in Phase 1.

The remaining two grep hits for `from '../services/LicenseService'` after this PR are intentional:

- `entitlements/loadProvider.ts` — runtime import of the `LicenseService` class. Phase 1 binding site; replaced in Phase 2 by dynamic import of `@studio-saelix/sencho-pro`.
- `__tests__/license-service-id-validation.test.ts` — imports `SENCHO_LS_*` catalog constants and `resolveSenchoVariantFromMeta` for testing. These are LemonSqueezy-implementation-specific helpers that stay in `services/LicenseService.ts` until Phase 2 moves the file to the private package.

## What changed

```diff
-import type { LicenseTier, LicenseVariant } from '../services/LicenseService';
+import type { LicenseTier, LicenseVariant } from '../entitlements/types';
```

Applied to `types/express.ts` and `routes/dashboard.ts`. Plus removal of the now-unused `export type { LicenseInfo, LicenseStatus, LicenseTier, LicenseVariant, SeatLimits }` block from `services/LicenseService.ts`.

3 files, +5 / -13 lines.

## Test plan

- [x] `cd backend && npx tsc --noEmit` clean
- [x] Full backend suite: 89/89 files clean, 1657 passing tests, 5 pre-existing skips, plus the same pre-existing `database-metrics > handles 1000+ metrics` stress flake under parallel load that consistently passes solo. Same flake observed in #862, #863, #878.

## Notes

- Originally drafted as a stacked PR with `base: refactor/entitlement-provider-phase-1`, but #878 merged before push so this targets `main` directly.
- The ADR's "~20 consumers" estimate was based on a grep that conflated runtime + type imports; once Phase 1 migrated the runtime ones, only 2 type-only consumers remained.