### PR TITLE
feat(entitlements): wire dynamic import of @studio-saelix/sencho-pro (Phase 2 public-side)

### DIFF
--- a/backend/eslint.config.mjs
+++ b/backend/eslint.config.mjs
@@ -25,6 +25,26 @@ export default tseslint.config(
       // New in ESLint 10 recommended - existing patterns, suppress until addressed
       'no-useless-assignment': 'warn',
       'preserve-caught-error': 'warn',
+      // The private @studio-saelix/sencho-pro package is loaded at
+      // runtime via dynamic import in entitlements/loadProvider.ts.
+      // A static import would (a) bundle the package into the public
+      // BSL build via TypeScript's module resolution, defeating the
+      // privacy split, and (b) break in Community-only environments
+      // where the package is not installed. Use loadEntitlementProvider()
+      // and the registry instead.
+      // no-restricted-imports flags ES `import` statements only by
+      // default; dynamic `import()` expressions are not flagged unless
+      // we set `allowDynamicImports: false`. The loader uses
+      // `await import('@studio-saelix/sencho-pro')` and is therefore
+      // not affected without an extra opt-in.
+      'no-restricted-imports': ['error', {
+        patterns: [
+          {
+            group: ['@studio-saelix/sencho-pro', '@studio-saelix/sencho-pro/*'],
+            message: 'Do not statically import the private package. Use loadEntitlementProvider() and getEntitlementProvider() from src/entitlements/.',
+          },
+        ],
+      }],
     },
   },
 )

--- a/backend/src/__tests__/load-entitlement-provider.test.ts
+++ b/backend/src/__tests__/load-entitlement-provider.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests for the loader's module-not-found discrimination. The
+ * predicate is a security boundary: a too-wide match silently
+ * downgrades a paid install to community on a transitive-dependency
+ * bug; a too-narrow match crashes bootstrap on a legitimate
+ * Community-only build. Keep these fixtures aligned with the runtime
+ * codes Node and bundlers actually produce.
+ */
+import { describe, it, expect } from 'vitest';
+import { isProPackageNotInstalled } from '../entitlements/loadProvider';
+
+function withCode<T extends Error>(err: T, code: string): T {
+    (err as Error & { code?: string }).code = code;
+    return err;
+}
+
+describe('isProPackageNotInstalled', () => {
+    it('returns false for non-Error values', () => {
+        expect(isProPackageNotInstalled(undefined)).toBe(false);
+        expect(isProPackageNotInstalled(null)).toBe(false);
+        expect(isProPackageNotInstalled('not an error')).toBe(false);
+        expect(isProPackageNotInstalled({})).toBe(false);
+    });
+
+    it('returns false for Error without a code', () => {
+        expect(isProPackageNotInstalled(new Error('something broke'))).toBe(false);
+    });
+
+    it('returns true for ERR_MODULE_NOT_FOUND on the private package (Node ESM)', () => {
+        const err = withCode(
+            new Error("Cannot find package '@studio-saelix/sencho-pro' imported from /app/dist/entitlements/loadProvider.js"),
+            'ERR_MODULE_NOT_FOUND',
+        );
+        expect(isProPackageNotInstalled(err)).toBe(true);
+    });
+
+    it('returns true for MODULE_NOT_FOUND on the private package (CJS / older Node)', () => {
+        const err = withCode(
+            new Error("Cannot find module '@studio-saelix/sencho-pro'"),
+            'MODULE_NOT_FOUND',
+        );
+        expect(isProPackageNotInstalled(err)).toBe(true);
+    });
+
+    it('returns false for MODULE_NOT_FOUND on a transitive dep of the private package', () => {
+        // The private package was installed but one of its dependencies is
+        // missing. We must NOT classify this as "package not installed";
+        // re-raising surfaces the bug instead of silently downgrading to
+        // community.
+        const err = withCode(
+            new Error("Cannot find module 'axios'"),
+            'MODULE_NOT_FOUND',
+        );
+        expect(isProPackageNotInstalled(err)).toBe(false);
+    });
+
+    it('returns false for ERR_PACKAGE_PATH_NOT_EXPORTED', () => {
+        // Package was resolved but its exports map does not include the
+        // path we asked for; this is a packaging bug, not a missing
+        // package, and should re-raise.
+        const err = withCode(
+            new Error("Package subpath './internal' is not defined by exports in @studio-saelix/sencho-pro/package.json"),
+            'ERR_PACKAGE_PATH_NOT_EXPORTED',
+        );
+        expect(isProPackageNotInstalled(err)).toBe(false);
+    });
+
+    it('returns false for an unrelated runtime error during construction', () => {
+        // The package loaded successfully but threw inside its
+        // constructor. The loader must re-raise; silently falling back
+        // would be a license-bypass surface.
+        const err = new TypeError('Cannot read property of undefined');
+        expect(isProPackageNotInstalled(err)).toBe(false);
+    });
+});

--- a/backend/src/entitlements/loadProvider.ts
+++ b/backend/src/entitlements/loadProvider.ts
@@ -1,22 +1,78 @@
+import { DatabaseService } from '../services/DatabaseService';
 import { LicenseService } from '../services/LicenseService';
 import type { EntitlementProvider } from './types';
+
+const PRO_PACKAGE = '@studio-saelix/sencho-pro';
 
 /**
  * Resolve the EntitlementProvider implementation for this build.
  *
- * Phase 1 (today): the in-tree `LicenseService` (the existing Lemon
- * Squeezy client) implements `EntitlementProvider`. We return its
- * singleton directly. No dynamic import, no fallback path.
+ * Phase 2: try to dynamic-import `@studio-saelix/sencho-pro` first.
  *
- * Phase 2: this function will switch to a dynamic import that
- * distinguishes "package not installed" (fall back to Community) from
- * "package loaded but threw during construction" (re-raise). The
- * narrowing matters because silently downgrading a paid install to
- * Community on a load-time bug would be a license-bypass surface.
+ *   - **Module-not-found** (the package is not installed in this build,
+ *     e.g. the public BSL Community-only image): fall back to the
+ *     in-tree `LicenseService.getInstance()` so existing functionality
+ *     is preserved during this transition window. A later cleanup PR
+ *     will switch this fallback to `CommunityEntitlementProvider` and
+ *     remove `services/LicenseService.ts` from the public repo
+ *     entirely; until then, the in-tree fallback keeps the public BSL
+ *     repo runnable on its own.
  *
- * The function is async today so the Phase-2 swap doesn't change the
- * signature; bootstrap already awaits it.
+ *   - **Module loaded but threw during construction**: re-raise. A
+ *     silent fallback to community would be a license-bypass surface
+ *     (a paid install whose private package init bug downgrades them
+ *     to community without surfacing the failure). The bootstrap
+ *     should crash and the operator investigates.
+ *
+ * The function is async so the dynamic import does not change the
+ * call-site contract.
  */
 export async function loadEntitlementProvider(): Promise<EntitlementProvider> {
-    return LicenseService.getInstance();
+    try {
+        const mod = await import(PRO_PACKAGE);
+        // Explicit typing so a structural drift between Sencho's
+        // DatabaseService and the package's DatabaseAdapter (e.g. a
+        // future widening of the adapter interface) fails type-check
+        // here rather than only at production-CI dual-image build
+        // time. Sencho's DatabaseService satisfies the adapter shape
+        // structurally today.
+        const db: import('@studio-saelix/sencho-pro').DatabaseAdapter = DatabaseService.getInstance();
+        return new mod.LemonSqueezyEntitlementProvider(db);
+    } catch (err) {
+        if (isProPackageNotInstalled(err)) {
+            // Phase 2 transitional fallback: keep the in-tree
+            // LicenseService binding so a Community-only build (no
+            // private package installed) still runs through the
+            // existing LemonSqueezy path. A follow-up PR will replace
+            // this with a CommunityEntitlementProvider and remove
+            // services/LicenseService.ts from the public repo.
+            return LicenseService.getInstance();
+        }
+        throw err;
+    }
+}
+
+/**
+ * Distinguish "the private package itself is not installed" (legitimate
+ * fallback path) from "the package loaded but threw / a transitive dep
+ * is missing" (re-raise so the operator sees the failure).
+ *
+ * The error code alone is not specific enough: a missing transitive
+ * dependency in an installed paid package surfaces with the same
+ * `MODULE_NOT_FOUND` code as the package itself missing. We additionally
+ * require the error message to mention the private package by name, so
+ * the fallback only triggers when Node could not resolve
+ * `@studio-saelix/sencho-pro` at the top level.
+ *
+ * Codes covered: `ERR_MODULE_NOT_FOUND` (Node >=20 ESM), `MODULE_NOT_FOUND`
+ * (CJS / older Node). `ERR_PACKAGE_PATH_NOT_EXPORTED` is intentionally
+ * NOT treated as "not installed": that fires when the package was
+ * resolved but its exports map does not include the path we asked for,
+ * which is a packaging bug we want to surface, not silently downgrade.
+ */
+export function isProPackageNotInstalled(err: unknown): boolean {
+    if (!(err instanceof Error)) return false;
+    const code = (err as Error & { code?: string }).code;
+    if (code !== 'ERR_MODULE_NOT_FOUND' && code !== 'MODULE_NOT_FOUND') return false;
+    return err.message.includes(PRO_PACKAGE);
 }

--- a/backend/src/types/sencho-pro.d.ts
+++ b/backend/src/types/sencho-pro.d.ts
@@ -1,0 +1,34 @@
+/**
+ * Ambient declaration for the private `@studio-saelix/sencho-pro`
+ * package so the public Sencho core's TypeScript build passes whether
+ * or not the package is installed locally. The runtime shape is
+ * defined by the package itself; this stub mirrors the surface the
+ * loader uses and nothing more.
+ *
+ * In production CI the Dockerfile installs the real package; the stub
+ * is shadowed by the package's own types and any drift fails the
+ * build. Local development without GitHub Packages auth falls back to
+ * the stub plus the loader's in-tree LicenseService binding, which
+ * keeps `npm install` and `tsc` working for everyone.
+ *
+ * The `implements EntitlementProvider` clause carries the full method
+ * surface; we do not redeclare individual methods here. If the real
+ * package ever ships a narrower return type than the interface
+ * permits, the local stub would over-widen and lose call-site type
+ * info — but call sites only consume the interface (via the registry),
+ * so that risk does not materialise.
+ */
+declare module '@studio-saelix/sencho-pro' {
+    import type { EntitlementProvider } from '../entitlements/types';
+
+    /** Minimal database surface the provider needs. The public core's
+     * `DatabaseService` satisfies this structurally. */
+    export interface DatabaseAdapter {
+        getSystemState(key: string): string | null;
+        setSystemState(key: string, value: string): void;
+    }
+
+    export class LemonSqueezyEntitlementProvider implements EntitlementProvider {
+        constructor(db: DatabaseAdapter);
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the open-core hybrid extraction (ADR `docs/internal/adrs/2026-05-02-open-core-hybrid-strategy.md`). The private `@studio-saelix/sencho-pro` package is now created and v0.1.0 is published to GitHub Packages with the LemonSqueezy implementation. This PR delivers the public-side hookup so the loader prefers the private package when installed and falls back to the in-tree `LicenseService` when not.

The Dockerfile change to install the package is intentionally split out as Phase 2b (next PR) to keep this one focused on the loader hookup.

## Distribution decision

The ADR originally proposed publishing two Docker images (`saelix/sencho` Community-only + `saelix/sencho-pro` paid). After working it through, the dual-image plan would break the customer purchase flow: customers buying Skipper would need to pull a second image from private GitHub Packages, which requires GitHub auth they do not have.

**Single image, package always installed.** `saelix/sencho` is the only image; the Dockerfile installs `@studio-saelix/sencho-pro` at build time using `GITHUB_TOKEN`. Community and paid users receive the same image. Activation is a license-key paste, identical to today. Source secrecy on GitHub is preserved by the private repo; source secrecy in the filesystem is not (compiled JS in every install) but that benefit was mostly imaginary against any pirate willing to run `docker save`.

The ADR's "Distribution decision" section captures the reasoning. PR #880 itself is unaffected by the simplification — the loader and stub work the same way; only the Dockerfile and CI plan got smaller.

## What's already done outside this PR

- **Private repo `Studio-Saelix/sencho-pro` created** as a private GitHub repo. Source: `LemonSqueezyEntitlementProvider` (constructor-injected `DatabaseAdapter`), full LS validation logic 1:1 with the in-tree class. Catalog ID guard, 30-day offline grace, 72h periodic re-validation, instance_id persistence, billing portal cache — all preserved.
- **v0.1.0 published to GitHub Packages** at `https://npm.pkg.github.com/@studio-saelix/sencho-pro` (private visibility). Verified via `gh api orgs/Studio-Saelix/packages/npm/sencho-pro` (`version_count: 1, visibility: private`).

## What this PR changes

**`backend/src/entitlements/loadProvider.ts`** — the loader tries `await import('@studio-saelix/sencho-pro')` first. On `ERR_MODULE_NOT_FOUND` / `MODULE_NOT_FOUND` for the package itself (the package is not installed in this build), it falls back to the in-tree `LicenseService.getInstance()`. On any other error, it re-raises.

The discrimination uses two checks:

1. The error code is `ERR_MODULE_NOT_FOUND` (Node ≥20 ESM) or `MODULE_NOT_FOUND` (CJS / older Node).
2. The error message includes the literal package name `@studio-saelix/sencho-pro`.

Without the second check, a missing transitive dep in a paid install would surface with the same code as the package itself missing, and the loader would silently downgrade the install to community. The message check anchors the fallback to "Node could not resolve `@studio-saelix/sencho-pro` at the top level" specifically.

`ERR_PACKAGE_PATH_NOT_EXPORTED` is intentionally NOT treated as "not installed" because it fires when the package resolved but its exports map does not include the requested path — a packaging bug we want surfaced.

**`backend/src/types/sencho-pro.d.ts` (new)** — ambient module stub so `tsc` passes whether or not the package is installed locally. Uses `class LemonSqueezyEntitlementProvider implements EntitlementProvider` so the interface clause carries the full method surface; the package's own `dist/index.d.ts` shadows the stub when installed.

**`backend/eslint.config.mjs`** — `no-restricted-imports` rule blocking static imports of `@studio-saelix/sencho-pro` and any subpath. The loader's dynamic `import()` is unaffected (the rule only flags static `import` statements by default). Static imports would bundle the package into the public BSL build via TypeScript's module resolution, defeating the privacy split.

**`backend/src/__tests__/load-entitlement-provider.test.ts` (new)** — 7 unit tests for `isProPackageNotInstalled` covering: non-Error inputs, both recognized codes, the package-name anchor, transitive-dep `MODULE_NOT_FOUND`, `ERR_PACKAGE_PATH_NOT_EXPORTED`, and unrelated runtime errors.

## Test plan

- [x] `cd backend && npx tsc --noEmit` clean
- [x] `npx eslint src` 0 errors (206 pre-existing warnings, none new)
- [x] Full backend suite: 91/91 files pass, 1665 passing tests, 5 pre-existing skips. The `database-metrics > handles 1000+ metrics` stress flake stayed green this run.
- [x] Code-reviewer: ship-ready after H1 (tighten predicate to require package name in message), M2 (update internal docs for transitional state), and M1/M3/L1/L2 polish — all folded in.
- [ ] **Recommended manual check before merge:** run `cd backend && npm run dev` locally without the private package installed; verify the dev server boots and license activation works through the in-tree LicenseService fallback. The dynamic-import path will be exercised once Phase 2b's Dockerfile change installs the package.

## Internal docs

`docs/internal/architecture/entitlement-provider.md` (gitignored) updated to document:
- The three binding states (Phase 1 initial, Phase 2 transitional, Phase 2 cleanup) in a state table.
- The single-image distribution decision and why dual images were rejected.
- The `isProPackageNotInstalled` discrimination logic.
- The ESLint guard.
- The TypeScript stub model.
- The `DatabaseAdapter` injection pattern.

## Out of scope

**Phase 2b (next PR):** Dockerfile change to install `@studio-saelix/sencho-pro` from GitHub Packages using `GITHUB_TOKEN` auth at build time. **Single image only** — the dual-image plan from the original ADR has been superseded; `saelix/sencho` remains the only image. `docker-publish.yml` gets a small change to pass the build secret.

**Cleanup PR (after Phase 2b is verified working in production):** remove `services/LicenseService.ts` from the public repo and switch the loader fallback from `LicenseService.getInstance()` to `new CommunityEntitlementProvider(...)`. The Community fallback still serves a purpose (local dev environments without GitHub Packages auth, future explicit Community-only builds).