### PR TITLE
fix(ci): tolerate empty inline blogPosts array in scaffold script

### DIFF
--- a/.github/scripts/scaffold-release-post.mjs
+++ b/.github/scripts/scaffold-release-post.mjs
@@ -284,16 +284,18 @@ function updateIndex(websiteRoot, exportName, fileBase) {
   lines.splice(lastImportIdx + 1, 0, importLine)
 
   const joined = lines.join('\n')
-  const arrayRegex = /(export const blogPosts: BlogPost\[\] = \[)([\s\S]*?)(\n\])/
+  // The closing capture tolerates both multi-line (`,\n]`) and empty inline
+  // (`[]`) array shapes. Empty inline is the bootstrap state of a fresh
+  // sencho-website repo before any release post has been written.
+  const arrayRegex = /(export const blogPosts: BlogPost\[\] = \[)([\s\S]*?)(\s*\])/
   const m = joined.match(arrayRegex)
   if (!m) throw new Error('Could not locate blogPosts array in index.ts')
   const before = joined.slice(0, m.index)
   const arrOpen = m[1]
   const arrBody = m[2]
-  const arrClose = m[3]
   const after = joined.slice(m.index + m[0].length)
-  const newBody = `${arrBody.replace(/\s*$/u, '')}\n  ${exportName},`
-  return `${before}${arrOpen}${newBody}${arrClose}${after}`
+  const trimmedBody = arrBody.replace(/\s*$/u, '')
+  return `${before}${arrOpen}${trimmedBody}\n  ${exportName},\n]${after}`
 }
 
 function updateMeta(websiteRoot, slug, title, description, date) {


### PR DESCRIPTION
## Summary

The release blog scaffold script (`.github/scripts/scaffold-release-post.mjs`) has been failing on every tag push. Root cause is in `updateIndex()` at line 287: the regex matching the website's `blogPosts` array requires a literal `\n]` as the closing pattern. The website repo bootstraps the array as an empty inline literal (`= []`), which has no newline before the bracket, so the regex never matches.

This was first observed on the v0.67.0 release (run [25257619433](https://github.com/Studio-Saelix/sencho/actions/runs/25257619433)).

## Fix

- Change the closing capture from `(\n\])` to `(\s*\])` so both empty inline and multi-line shapes match.
- Always emit `\n  ${exportName},\n]` regardless of input shape, so the result is always a clean multi-line array even when the input was inline.
- Drop the unused `arrClose` capture variable; the close is now hard-coded.

## Test plan

- [x] Dry-run against the current website state with v0.67.0:
  - Input: `export const blogPosts: BlogPost[] = []`
  - Output: `export const blogPosts: BlogPost[] = [\n  v0_67_0Release,\n]`
- [x] Manually traced three shapes (empty inline, multi-line empty, populated multi-line); all produce identical clean output.
- [x] Code review: no behavior drift on populated arrays; one latent footgun flagged for future inline-object posts (current pattern uses variable references, so safe).

## Notes

The dry-run also surfaced two pre-existing strategy concerns that are out of scope for this fix and deserve their own design call:

1. **Bootstrap roll-up:** with no prior anchor, the script rolls up all 150 historical versions into one post. Generated title becomes `Sencho v0.67.0: **ci:** add release-please automated vers..., **ci:** automated versioning with release..., and 689 more` and description quality is similarly poor. Recommend either seeding the website with a manual anchor post for one of the existing release versions, or adding a bootstrap-cap behind a flag.
2. After this fix lands, re-firing the workflow against `v0.67.0` via `workflow_dispatch` will succeed mechanically but produce a low-quality post per (1). Defer the v0.67.0 catch-up post until the strategy concern is resolved.