### PR TITLE
fix(ci): disable CLA Assistant PR auto-lock so release-please can comment

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -27,3 +27,7 @@ jobs:
           path-to-document: 'https://github.com/studio-saelix/sencho/blob/main/CLA.md'
           branch: 'main'
           allowlist: 'AnsoCode,dependabot[bot],greenkeeper[bot],github-actions[bot],release-please[bot],sencho-quartermaster[bot]'
+          # Default true locks merged PR conversations, which blocks
+          # release-please from commenting "included in vX.Y.Z" on the
+          # release PR. Signatures live in signatures/version1/cla.json.
+          lock-pullrequest-aftermerge: false


### PR DESCRIPTION
## Summary
- The `contributor-assistant/github-action` step in `.github/workflows/cla.yml` defaults `lock-pullrequest-aftermerge: true`, which locks every merged PR conversation a few seconds after merge.
- That lock blocks the release-please workflow from posting its post-release "included in vX.Y.Z" comment back on the merged release PR. Release-please then fails with `Unable to create comment because issue is locked.` on every release (observed on 0.67.1, 0.68.0, and 0.69.0).
- Set the input to `false` explicitly. The CLA flow itself is unchanged: signatures still write to `signatures/version1/cla.json`, the allowlist and pinned action SHA are unchanged, and the workflow's `permissions:` block already covers what the action needs.

## Why the lock is unnecessary
- CLA signatures persist in an in-repo file (`signatures/version1/cla.json`) that branch protection already governs.
- Locking the conversation thread on a closed PR adds no protection to that file. It only suppresses post-merge comments and reactions.

## Evidence the lock was the cause
Run timeline for PR #888 (release 0.68.0):

- `01:50:39` PR merged
- `01:50:42` release-please workflow starts
- `01:50:47` CLA Assistant logs `Locking the Pull Request to safe guard the Pull Request CLA Signatures` and `successfully locked the pull request 888`
- `01:50:50` release-please calls `POST .../issues/888/comments` and gets `Unable to create comment because issue is locked.`

Same pattern on #885 and #889. Confirmed via `gh api repos/.../issues/<n>` that every recent merged PR (release and non-release) shows `locked: true`.

## Test plan
- [ ] After merge, open and merge a trivial PR off `main` and confirm the merged PR returns `locked: false` from `gh api repos/Studio-Saelix/sencho/issues/<n> --jq .locked`.
- [ ] On the next release-please release PR merge, confirm the Release Please workflow run finishes green and posts its "included in vX.Y.Z" comment on the merged release PR.
- [ ] Confirm a CLA signing flow on a fresh contributor PR still works end to end (signature appended to `signatures/version1/cla.json`, status check turns green).

## Notes
- Optional cleanup not included here: previously locked release PRs (#885, #888, #889) can be unlocked manually with `gh api -X DELETE repos/Studio-Saelix/sencho/issues/<n>/lock` if you want their changelog comments to land on a re-run. Purely cosmetic.