### PR TITLE
fix(frontend): remove unused MockWS constructor param

### DIFF
--- a/frontend/src/components/EditorLayout/hooks/useContainerStats.test.ts
+++ b/frontend/src/components/EditorLayout/hooks/useContainerStats.test.ts
@@ -12,7 +12,7 @@ class MockWS {
   readyState = 1;
   send = vi.fn();
   close = vi.fn();
-  constructor(_url: string) { MockWS.instances.push(this); }
+  constructor() { MockWS.instances.push(this); }
   static reset() { MockWS.instances = []; }
 }
 

--- a/frontend/src/components/EditorLayout/hooks/useNotifications.test.ts
+++ b/frontend/src/components/EditorLayout/hooks/useNotifications.test.ts
@@ -27,7 +27,7 @@ class MockWS {
   readyState = 1; // OPEN
   send = vi.fn();
   close = vi.fn();
-  constructor(_url: string) { MockWS.instances.push(this); }
+  constructor() { MockWS.instances.push(this); }
   static reset() { MockWS.instances = []; }
 }
 


### PR DESCRIPTION
## Summary
- Drops the unused `_url: string` parameter from the test-only `MockWS` class constructors in `useNotifications.test.ts` and `useContainerStats.test.ts`.
- Unblocks the Frontend (Build, Lint) job, which was failing with `'_url' is defined but never used` from `@typescript-eslint/no-unused-vars`. The project's ESLint config does not configure `argsIgnorePattern: '^_'`, so the underscore prefix is not honored.
- The mock is installed via `vi.stubGlobal('WebSocket', MockWS)` at runtime, so dropping the declared parameter is safe; JS still allows callers to pass `new WebSocket(url)`.

## Test plan
- [x] `npm run lint` reports 0 errors.
- [x] `npx vitest run` for both affected test files: 11/11 pass.
- [x] `npx tsc -b --noEmit` clean.