### PR TITLE
fix(ci): create posts dir before writing scaffold output

### DIFF
--- a/.github/scripts/scaffold-release-post.mjs
+++ b/.github/scripts/scaffold-release-post.mjs
@@ -8,7 +8,7 @@
 // workflow commits it directly to website main. No PR is created or required.
 
 import { execFileSync } from 'node:child_process'
-import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs'
+import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync } from 'node:fs'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -387,6 +387,7 @@ function main() {
       console.log(newMeta)
     }
   } else {
+    mkdirSync(dirname(postPath), { recursive: true })
     writeFileSync(postPath, post, 'utf8')
     writeFileSync(indexPath, newIndex, 'utf8')
     if (newMeta) writeFileSync(metaPath, newMeta, 'utf8')


### PR DESCRIPTION
## Summary

- `scaffold-release-post.mjs` called `writeFileSync` directly on the output path without ensuring the parent directory existed
- A freshly cloned website repo does not have `src/data/blog/posts/` pre-created, so the write fails with `ENOENT`
- Fix: add `mkdirSync(dirname(postPath), { recursive: true })` before the first `writeFileSync`; the call is idempotent if the directory already exists

## Test plan

- [ ] Re-run the `Release Blog Scaffold` workflow against tag `v0.69.2` once merged; the `Run scaffold script` step should succeed and produce a commit to the website repo
- [ ] Confirm `mkdirSync` is a no-op when the posts dir already exists (subsequent runs)