### PR TITLE
refactor(frontend): tighten Resources Hub header and relocate Scan history

### DIFF
--- a/frontend/src/components/ResourcesView.tsx
+++ b/frontend/src/components/ResourcesView.tsx
@@ -671,32 +671,6 @@ export default function ResourcesView() {
     return (
         <div className="p-6 h-full overflow-auto text-foreground flex flex-col gap-6 animate-in fade-in-0 duration-300">
 
-            {/* Header */}
-            <div className="flex items-center gap-3">
-                <HardDrive className="w-5 h-5 text-muted-foreground" />
-                <h1 className="text-xl font-medium tracking-tight">Resources Hub</h1>
-                {activeNode?.type === 'remote' && (
-                    <span className="text-sm text-muted-foreground">· {activeNode.name}</span>
-                )}
-                {trivy.available && isPaid && (
-                    <Button
-                        variant="outline"
-                        size="sm"
-                        className="ml-auto border-border"
-                        onClick={() => {
-                            window.dispatchEvent(new CustomEvent<SenchoNavigateDetail>(SENCHO_NAVIGATE_EVENT, {
-                                detail: { view: 'security-history' },
-                            }));
-                        }}
-                        title="View completed vulnerability scans and compare them"
-                        aria-label="Open scan history"
-                    >
-                        <History className="w-4 h-4 mr-2" strokeWidth={1.5} />
-                        Scan history
-                    </Button>
-                )}
-            </div>
-
             {/* Reclaim hero */}
             {usage && isAdmin && (
                 <ReclaimHero
@@ -791,7 +765,7 @@ export default function ResourcesView() {
                 defaultValue="images"
                 className="flex-1 flex flex-col w-full rounded-lg border bg-card shadow-card-bevel overflow-hidden min-h-[400px] animate-in fade-in-0 slide-in-from-bottom-2 duration-300 delay-150"
             >
-                <div className="px-4 pt-3 pb-2">
+                <div className="px-4 pt-3 pb-2 flex items-center justify-between gap-3">
                     <TabsList className="grid grid-cols-4 w-full md:w-[680px] h-9 gap-1 p-0">
                         <TabsHighlight className="rounded-md bg-glass-highlight" transition={springs.snappy}>
                             {(['images', 'volumes', 'networks'] as const).map(tab => (
@@ -813,6 +787,23 @@ export default function ResourcesView() {
                             </TabsHighlightItem>
                         </TabsHighlight>
                     </TabsList>
+                    {trivy.available && isPaid && (
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            className="border-border"
+                            onClick={() => {
+                                window.dispatchEvent(new CustomEvent<SenchoNavigateDetail>(SENCHO_NAVIGATE_EVENT, {
+                                    detail: { view: 'security-history' },
+                                }));
+                            }}
+                            title="View completed vulnerability scans and compare them"
+                            aria-label="Open scan history"
+                        >
+                            <History className="w-4 h-4 mr-2" strokeWidth={1.5} />
+                            Scan history
+                        </Button>
+                    )}
                 </div>
 
                 <ScrollArea className="flex-1 bg-background relative text-sm">


### PR DESCRIPTION
## Summary
- Removes the page-title row from Resources Hub (HardDrive icon + 'Resources Hub' heading + remote-node indicator). The Reclaim hero now leads the page.
- Relocates the Scan history button to the far right of the secondary navigation bar (Images / Volumes / Networks / Unmanaged), vertically centered against the tabs.
- Tier guard on the Scan history button (trivy availability + paid) is unchanged. Lazy-loaded SecurityHistoryView overlay is unchanged.

## Test plan
- [x] cd frontend && npx tsc -b --noEmit passes
- [x] Visited Resources Hub: page title + icon gone; Reclaim hero unchanged in placement and content
- [x] Scan history button rendered on the same row as the tabs, right-aligned, vertically centered (verified visually after temporarily relaxing the tier guard for the screenshot, then reverting)
- [x] Clicking the button opens the existing scan-history overlay
- [x] Code reviewed; one mobile-viewport observation noted (TabsList md:w-[680px] vs full-width on narrow screens) - acceptable given desktop-first layout elsewhere on this view
- [x] Dev servers stopped after validation

## Notes
The active node is still surfaced through the global node selector chip in the top chrome, so the inline ' · nodeName' indicator inside the removed header was redundant.