### PR TITLE
fix(frontend): align sidebar brand box with top nav chrome

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -25,7 +25,7 @@ export function totpNow(secret: string): string {
 }
 
 /** Selector for the dashboard - only present in EditorLayout, not on login/setup pages */
-const DASHBOARD_INDICATOR = 'img[alt="Sencho Logo"]';
+const DASHBOARD_INDICATOR = 'img[src*="sencho-logo"]';
 
 /** Returns true if the current page is the first-run setup screen */
 async function isSetupPage(page: Page): Promise<boolean> {

--- a/frontend/src/components/sidebar/SidebarBrand.tsx
+++ b/frontend/src/components/sidebar/SidebarBrand.tsx
@@ -4,17 +4,17 @@ interface SidebarBrandProps {
 
 export function SidebarBrand({ isDarkMode }: SidebarBrandProps) {
   return (
-    <div className="flex items-center gap-2 px-4 py-1.5 border-b border-glass-border">
+    <div className="flex items-center justify-center gap-3 px-4 h-14 border-b border-glass-border">
       <img
         src={isDarkMode ? '/sencho-logo-dark.png' : '/sencho-logo-light.png'}
-        alt="Sencho Logo"
-        className="w-7 h-7 shrink-0"
+        alt=""
+        className="w-9 h-9 shrink-0"
       />
-      <div className="flex flex-col leading-none">
-        <span className="font-mono text-[10px] leading-3 tracking-[0.18em] uppercase text-stat-subtitle">
-          SENCHO · v{__APP_VERSION__}
+      <div className="flex items-baseline gap-1.5">
+        <span className="font-display italic text-[28px] leading-none text-foreground">Sencho</span>
+        <span className="font-mono text-[10px] tracking-[0.18em] uppercase text-stat-subtitle">
+          v{__APP_VERSION__}
         </span>
-        <span className="font-display italic text-[22px] leading-none text-foreground mt-0.5">Sencho</span>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Match the TopBar's 56px height so the bottom border of the brand box meets the bottom border under the nav, removing a 7px seam.
- Drop the duplicate uppercase "SENCHO" label; the italic wordmark "Sencho" now stands alone with `v{version}` baseline-aligned next to it.
- Center the brand row, enlarge the logo (28 → 36px) and wordmark (22 → 28px), and mark the logo `alt=""` since the wordmark already names the brand.
- Update the Playwright dashboard sentinel from `img[alt="Sencho Logo"]` to `img[src*="sencho-logo"]` so the now-decorative logo no longer breaks `loginAs()`.

## Test plan
- [x] `npx tsc -b --noEmit` passes
- [x] Manual visual check: brand box bottom and TopBar bottom both at y=56 (delta 0px)
- [x] Brand row horizontally centered (38px slack on both sides at default sidebar width)
- [x] Only one "Sencho" wordmark rendered in the brand box
- [x] Light and dark themes both render the correct logo asset
- [x] E2E sentinel now keys off logo `src` (unique to the authenticated sidebar; not present on login/setup screens), unblocking the suite

## Notes
The decorative `alt=""` change is correct accessibility (the adjacent wordmark already names the brand), so the test was adjusted rather than the markup. A follow-up could replace the asset-path sentinel with a dedicated `data-testid` on the layout shell, but that is out of scope for this PR.