### PR TITLE
fix: add CodeQL barrier model for sanitizeForLog against log injection

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,2 @@
+data_extensions:
+  - .github/codeql/extensions/safeLog.model.yml

--- a/.github/codeql/extensions/safeLog.model.yml
+++ b/.github/codeql/extensions/safeLog.model.yml
@@ -1,0 +1,6 @@
+extensions:
+  - addsTo:
+      pack: codeql/javascript-all
+      extensible: barrierModel
+    data:
+      - ["backend/src/utils/safeLog", "Member[sanitizeForLog].ReturnValue", "log-injection"]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
+          config-file: .github/codeql/codeql-config.yml
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2


### PR DESCRIPTION
## Summary

Adds a CodeQL data extension model that marks `sanitizeForLog()` as a log-injection taint barrier. The sanitizer already strips CR, LF, and ASCII control characters before logging, but CodeQL did not recognize the custom wrapper, causing false-positive alerts at all 5 call sites in `stacks.ts` and `ComposeService.ts`.

- `.github/codeql/extensions/safeLog.model.yml` - barrier model for `log-injection`
- `.github/codeql/codeql-config.yml` - references the model extension
- `.github/workflows/codeql.yml` - updated to load the config

Once merged, the next CodeQL scan will recognize `sanitizeForLog()` as a sanitizer and auto-resolve the 5 open alerts (246-250). Future call sites will be recognized automatically.

## Test plan

- [x] `npx tsc --noEmit` in backend reports zero errors (no code changes)
- [x] CodeQL config file format verified against the JavaScript barrier model spec