### PR TITLE
docs: split Features by capability and tighten nav

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -94,67 +94,97 @@
             "group": "Features",
             "pages": [
               "features/overview",
-              "features/dashboard",
-              "features/global-search",
-              "features/sidebar",
-              "features/stack-management",
-              "features/stack-activity",
-              "features/editor",
-              "features/stack-file-explorer",
-              "features/deploy-progress",
-              "features/resources",
-              "features/app-store",
-              "features/global-observability",
-              "features/host-console",
-              "features/multi-node",
-              "features/pilot-agent",
-              "features/sencho-mesh",
-              "features/fleet-view",
-              "features/fleet-sync",
-              "features/blueprint-model",
-              "features/remote-updates",
-              "features/stack-labels",
-              "features/alerts-notifications",
-              "features/notification-routing",
-              "features/webhooks",
-              "features/git-sources",
-              "features/rbac",
-              "features/atomic-deployments",
-              "features/fleet-backups",
-              "features/audit-log",
-              "features/api-tokens",
-              "features/private-registries",
-              "features/vulnerability-scanning",
-              "features/deploy-enforcement",
-              "features/cve-suppressions",
-              "features/auto-update-policies",
-              "features/auto-heal-policies",
-              "features/scheduled-operations",
-              "features/sso",
-              "features/two-factor-authentication",
-              "features/licensing"
+              {
+                "group": "Stacks & Deployments",
+                "pages": [
+                  "features/stack-management",
+                  "features/stack-activity",
+                  "features/editor",
+                  "features/stack-file-explorer",
+                  "features/deploy-progress",
+                  "features/resources",
+                  "features/app-store",
+                  "features/atomic-deployments",
+                  "features/deploy-enforcement",
+                  "features/blueprint-model",
+                  "features/git-sources",
+                  "features/stack-labels"
+                ]
+              },
+              {
+                "group": "Observability",
+                "pages": [
+                  "features/dashboard",
+                  "features/global-search",
+                  "features/global-observability",
+                  "features/alerts-notifications",
+                  "features/notification-routing",
+                  "features/audit-log"
+                ]
+              },
+              {
+                "group": "Fleet & Multi-Node",
+                "pages": [
+                  "features/multi-node",
+                  "features/pilot-agent",
+                  "features/sencho-mesh",
+                  "features/fleet-view",
+                  "features/fleet-sync",
+                  "features/fleet-backups",
+                  "features/remote-updates",
+                  "features/scheduled-operations"
+                ]
+              },
+              {
+                "group": "Security & Identity",
+                "pages": [
+                  "features/two-factor-authentication",
+                  "features/rbac",
+                  "features/sso",
+                  "features/api-tokens",
+                  "features/vulnerability-scanning",
+                  "features/cve-suppressions",
+                  "features/private-registries"
+                ]
+              },
+              {
+                "group": "Automation",
+                "pages": [
+                  "features/auto-update-policies",
+                  "features/auto-heal-policies",
+                  "features/webhooks"
+                ]
+              },
+              {
+                "group": "Platform",
+                "pages": [
+                  "features/sidebar",
+                  "features/host-console"
+                ]
+              }
             ]
           },
           {
             "group": "Reference",
             "pages": [
-              "security",
-              "features/node-compatibility",
               "reference/settings",
-              "reference/contact",
-              "reference/security-advisories"
+              "features/licensing",
+              "features/node-compatibility",
+              "security",
+              "reference/security-advisories",
+              "reference/contact"
             ]
           },
           {
             "group": "Operations",
             "pages": [
-              "operations/troubleshooting",
-              "operations/backup",
-              "operations/upgrade",
               "operations/self-hosting",
+              "operations/upgrade",
+              "operations/backup",
+              "operations/troubleshooting",
+              "operations/verifying-images",
               "operations/trivy-setup",
-              "operations/two-factor-admin",
-              "operations/verifying-images"
+              "operations/two-factor-admin"
             ]
           }
         ]


### PR DESCRIPTION
## Summary

- **Features sidebar:** subdivide the 40-page flat list into six capability subgroups (Stacks & Deployments, Observability, Fleet & Multi-Node, Security & Identity, Automation, Platform). `features/overview` stays at the top of the group as a landing page.
- **Reference group:** add `features/licensing`, reorder so look-up entries (Settings, Licensing, Node Compatibility) lead and Contact lands last.
- **Operations group:** reorder by lifecycle (Self-Hosting -> Upgrade -> Backup -> Troubleshooting -> Verifying Images -> Trivy Setup -> 2FA Admin).

## Why capability-based, not tier-based

The first instinct was Core / Skipper / Admiral subgroups, which would map to the commercial story. The blocker: ~10 of the 41 features are mixed-tier (RBAC, SSO, alerts, vulnerability-scanning, fleet-view, fleet-backups, remote-updates, editor, file-explorer, scheduled-operations). Each forces an awkward placement choice and obscures the fact that the entry-level capability is available on a lower tier. Capability subgroups sidestep that entirely. Tier discovery already lives in per-page badges and on the licensing page, so no information is lost.

## Notes

- Nav-only change. No `.mdx` files were moved, renamed, or rewritten -- every page keeps its current URL.
- Page totals match before/after (56 in the Documentation tab, no duplicates, no dropped pages).
- API Reference tab and Getting Started group untouched.

## Test plan

- [x] `docs.json` parses as valid JSON.
- [x] `mintlify dev` from `docs/` renders the new structure: 6 collapsible Features subgroups, `features/overview` at top of Features (not nested), Reference shows 6 items, Operations shows 7 items in lifecycle order.
- [x] Spot-check that previously-existing URLs still resolve: `/features/licensing`, `/features/node-compatibility`, `/security`, `/features/rbac`, `/features/auto-heal-policies`.
- [x] Per-page tier badges still render (e.g. open `/features/atomic-deployments` and confirm the "Skipper or Admiral" note is intact).