### PR TITLE
feat(app-store): show inline port-conflict message on deploy sheet

### DIFF
--- a/docs/features/app-store.mdx
+++ b/docs/features/app-store.mdx
@@ -46,8 +46,6 @@ When deploying to a remote node, a badge at the top of the sheet shows the targe
 
 The **Essentials** tab has a single field (the stack name) plus a hint that the template's recommended ports, volumes, and environment variables will be used as-is. Click **Deploy {template}** to ship it in one click. For anything more nuanced, switch to **Advanced**.
 
-If any of the template's default ports are already in use, the hint is replaced by a port-conflict warning that lists each conflicting port and the application using it. Switch to **Advanced** to remap the host port before deploying.
-
 ### Stack name
 
 Pre-filled with the template name in lowercase. You can change it; the same [naming rules](/features/stack-management#creating-a-stack) apply (lowercase, hyphens, no spaces).
@@ -60,10 +58,10 @@ The **Advanced** tab exposes every knob the template declares: port mappings, vo
 
 For each exposed port, the sheet shows an editable **host port** field (left side) and the fixed **container port** (right side). Edit the host port to avoid conflicts with other services on the same machine. Ports must be in the valid range (1 to 65535); invalid values are highlighted and block deployment.
 
-If a host port is already in use by a running container, an amber **"in use by `<stack>`"** message appears inline next to the port, alongside a pulsating warning dot. If the application is managed by Sencho, the stack name is shown; otherwise the indicator reads "in use by an external app".
+If a host port is already in use by a running container, a pulsating warning dot appears next to the port. Hover over the dot to see which application is using the port. If the application is managed by Sencho, the stack name is shown; otherwise the indicator reads "used by an external app".
 
 <Frame>
-  <img src="/images/app-store/app-store-port-conflict.png" alt="Port conflict indicator: an inline amber message names the stack already using the port, next to a pulsating warning dot" />
+  <img src="/images/app-store/app-store-port-conflict.png" alt="Port conflict indicator showing port 8080 is used by heimdall" />
 </Frame>
 
 ### Volumes

--- a/docs/features/app-store.mdx
+++ b/docs/features/app-store.mdx
@@ -46,6 +46,8 @@ When deploying to a remote node, a badge at the top of the sheet shows the targe
 
 The **Essentials** tab has a single field (the stack name) plus a hint that the template's recommended ports, volumes, and environment variables will be used as-is. Click **Deploy {template}** to ship it in one click. For anything more nuanced, switch to **Advanced**.
 
+If any of the template's default ports are already in use, the hint is replaced by a port-conflict warning that lists each conflicting port and the application using it. Switch to **Advanced** to remap the host port before deploying.
+
 ### Stack name
 
 Pre-filled with the template name in lowercase. You can change it; the same [naming rules](/features/stack-management#creating-a-stack) apply (lowercase, hyphens, no spaces).
@@ -58,10 +60,10 @@ The **Advanced** tab exposes every knob the template declares: port mappings, vo
 
 For each exposed port, the sheet shows an editable **host port** field (left side) and the fixed **container port** (right side). Edit the host port to avoid conflicts with other services on the same machine. Ports must be in the valid range (1 to 65535); invalid values are highlighted and block deployment.
 
-If a host port is already in use by a running container, a pulsating warning dot appears next to the port. Hover over the dot to see which application is using the port. If the application is managed by Sencho, the stack name is shown; otherwise the indicator reads "used by an external app".
+If a host port is already in use by a running container, an amber **"in use by `<stack>`"** message appears inline next to the port, alongside a pulsating warning dot. If the application is managed by Sencho, the stack name is shown; otherwise the indicator reads "in use by an external app".
 
 <Frame>
-  <img src="/images/app-store/app-store-port-conflict.png" alt="Port conflict indicator showing port 8080 is used by heimdall" />
+  <img src="/images/app-store/app-store-port-conflict.png" alt="Port conflict indicator: an inline amber message names the stack already using the port, next to a pulsating warning dot" />
 </Frame>
 
 ### Volumes

--- a/frontend/src/components/AppStoreView.tsx
+++ b/frontend/src/components/AppStoreView.tsx
@@ -13,7 +13,6 @@ import { apiFetch } from '@/lib/api';
 import { useDeployFeedback } from '@/context/DeployFeedbackContext';
 import { useNodes } from '@/context/NodeContext';
 import { useAuth } from '@/context/AuthContext';
-import { CursorProvider, CursorContainer, Cursor, CursorFollow } from '@/components/animate-ui/primitives/animate/cursor';
 import { CategorySidebar } from '@/components/appstore/CategorySidebar';
 import { FeaturedHero } from '@/components/appstore/FeaturedHero';
 import { TemplateTile } from '@/components/appstore/TemplateTile';
@@ -252,6 +251,22 @@ export function AppStoreView({ onDeploySuccess }: AppStoreViewProps) {
         return [...base].sort((a, b) => (b.stars ?? 0) - (a.stars ?? 0));
     }, [filtered, featuredTemplate]);
 
+    const essentialsConflicts = useMemo(() => {
+        if (!selectedTemplate?.ports) return [];
+        const seen = new Set<string>();
+        const conflicts: Array<{ host: string; info: PortInUseInfo }> = [];
+        for (const p of selectedTemplate.ports) {
+            const parts = p.split(':');
+            if (parts.length < 2) continue;
+            const host = portVars[p] || parts[0];
+            if (!host || seen.has(host)) continue;
+            seen.add(host);
+            const info = portsInUse[host];
+            if (info) conflicts.push({ host, info });
+        }
+        return conflicts;
+    }, [selectedTemplate, portVars, portsInUse]);
+
     return (
         <div className="flex flex-col h-full gap-5">
             <div className="flex items-center gap-3">
@@ -427,10 +442,30 @@ export function AppStoreView({ onDeploySuccess }: AppStoreViewProps) {
                                     </p>
                                 </div>
 
-                                <div className="mt-3 rounded-md border border-border/60 bg-muted/20 px-3 py-2.5 text-xs text-stat-subtitle">
-                                    Deploy with defaults: the template's recommended ports, volumes, and environment variables.
-                                    Use the Advanced tab to customize.
-                                </div>
+                                {essentialsConflicts.length > 0 ? (
+                                    <div role="status" aria-live="polite" className="mt-3 relative overflow-hidden rounded-md border border-warning/30 bg-warning/8 pl-4 pr-3 py-2.5">
+                                        <span className="absolute inset-y-0 left-0 w-[3px] bg-warning/70 animate-pulse" aria-hidden />
+                                        <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-warning">
+                                            Port conflict
+                                        </div>
+                                        <ul className="mt-1 space-y-0.5 text-xs leading-snug text-stat-value">
+                                            {essentialsConflicts.map(({ host, info }) => (
+                                                <li key={host}>
+                                                    Port <span className="font-mono">{host}</span> is in use by{' '}
+                                                    <span className="text-brand">{info.stack ?? 'an external app'}</span>.
+                                                </li>
+                                            ))}
+                                        </ul>
+                                        <p className="mt-1.5 text-xs text-stat-subtitle">
+                                            Switch to the Advanced tab to remap.
+                                        </p>
+                                    </div>
+                                ) : (
+                                    <div className="mt-3 rounded-md border border-border/60 bg-muted/20 px-3 py-2.5 text-xs text-stat-subtitle">
+                                        Deploy with defaults: the template's recommended ports, volumes, and environment variables.
+                                        Use the Advanced tab to customize.
+                                    </div>
+                                )}
                             </SheetSection>
                         )}
 
@@ -454,28 +489,15 @@ export function AppStoreView({ onDeploySuccess }: AppStoreViewProps) {
                                                             }}
                                                             className={cn('w-24 text-center font-mono', hostPort && !isValidPort(hostPort) && 'border-destructive')}
                                                         />
-                                                        {conflict ? (
-                                                            <CursorProvider>
-                                                                <CursorContainer className="inline-flex items-center gap-2">
-                                                                    <span className="text-muted-foreground font-mono">: {parts[1]}</span>
-                                                                    <span className="w-2 h-2 rounded-full bg-warning animate-pulse" />
-                                                                </CursorContainer>
-                                                                <Cursor>
-                                                                    <div className="h-2 w-2 rounded-full bg-brand" />
-                                                                </Cursor>
-                                                                <CursorFollow side="bottom" sideOffset={4} align="center" transition={{ stiffness: 400, damping: 40, bounce: 0 }}>
-                                                                    <div className="rounded-md border border-card-border bg-popover/95 backdrop-blur-[10px] backdrop-saturate-[1.15] px-2.5 py-1.5 shadow-md">
-                                                                        <span className="font-mono tabular-nums text-xs text-stat-value">
-                                                                            {conflict.stack !== null
-                                                                                ? <>Port {hostPort} used by <span className="text-brand">{conflict.stack}</span></>
-                                                                                : <>Port {hostPort} used by an external app</>
-                                                                            }
-                                                                        </span>
-                                                                    </div>
-                                                                </CursorFollow>
-                                                            </CursorProvider>
-                                                        ) : (
-                                                            <span className="text-muted-foreground font-mono">: {parts[1]}</span>
+                                                        <span className="text-muted-foreground font-mono">: {parts[1]}</span>
+                                                        {conflict && (
+                                                            <>
+                                                                <span className="text-xs text-warning font-mono">
+                                                                    in use by{' '}
+                                                                    <span className="text-brand">{conflict.stack ?? 'an external app'}</span>
+                                                                </span>
+                                                                <span className="w-2 h-2 rounded-full bg-warning animate-pulse" aria-hidden />
+                                                            </>
                                                         )}
                                                     </div>
                                                 );


### PR DESCRIPTION
## Summary

The App Store deploy sheet previously hid port-conflict information behind a hover tooltip on the Advanced tab, and showed nothing at all on the Essentials tab. Users could click **Deploy** without realising a default port collided with another running stack. This PR makes conflicts visible at first glance on both tabs.

- **Advanced tab.** The cursor-following tooltip is gone. Each port row now reads `[input] : <containerPort> in use by <stack> ●` inline, with the pulsating amber dot retained as the live-data indicator.
- **Essentials tab.** A new amber **Port conflict** rail appears whenever any of the template's default ports are already bound. It lists each conflicting port and the application using it, and points the user at the Advanced tab to remap. The rail replaces the calm "Deploy with defaults" hint while conflicts exist; its left accent pulses to echo the live-data signal. When the user remaps the port in Advanced, the Essentials rail clears automatically.

No backend or API changes. The existing `/api/ports/in-use` endpoint and `PortInUseInfo` shape are unchanged.

User-facing docs covering this UI change live on PR #966 (`docs/v1-refresh`, commit `0b9e93d`) to avoid a merge conflict with the rolling docs refresh on that branch.

## Test plan

- [ ] On a node where a stack already binds (for example) port 7878, open the App Store and click a template whose default host port is 7878.
- [ ] Confirm the Essentials tab shows a "PORT CONFLICT" rail listing the conflicting port and the owning stack name, with the "Switch to the Advanced tab to remap" hint.
- [ ] Switch to Advanced and confirm the port row reads `[7878] : 7878/tcp in use by <stack> ●` with no hover required.
- [ ] Edit the host port to a free value (e.g. 19999) and confirm both the Advanced inline message and the Essentials rail disappear.
- [ ] Switch back to Essentials and confirm the calm "Deploy with defaults" hint returns.
- [ ] Pick a template with no port conflict and confirm Essentials shows only the calm hint, and Advanced shows only the colon and container port.

## Notes

- TypeScript and ESLint pass with no new warnings introduced. Tested manually in browser end-to-end with both conflicting and clean templates.
- A second commit on this branch (`4f0f63f`) reverts the docs hunk that originally rode along; the equivalent docs update is now on PR #966 so the rolling docs refresh and this UI change merge cleanly.
- The image `/images/app-store/app-store-port-conflict.png` still depicts the prior hover tooltip; it should be refreshed from production in a follow-up commit on PR #966.