### PR TITLE
fix(pilot): generate auth_jwt_secret on pilot-agent boot

### DIFF
--- a/backend/src/__tests__/pilot-agent-bootstrap-secret.test.ts
+++ b/backend/src/__tests__/pilot-agent-bootstrap-secret.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Regression guard for the task #1 fix: pilot-agent hosts never run the
+ * first-run setup wizard, so the wizard's `auth_jwt_secret` generation
+ * (routes/auth.ts) never fires. Without that secret, the agent's loopback
+ * auth helper (pilot/agent.ts::getLoopbackAuthHeader) returns null and the
+ * local Sencho rejects every forwarded request with 401.
+ *
+ * `bootstrap/startup.ts` now generates the secret on pilot-mode boot when
+ * missing, and re-uses the persisted value on subsequent boots. This test
+ * exercises both branches by importing the underlying logic directly rather
+ * than starting a full server (the server would also try to bind a port and
+ * spawn pilot infrastructure).
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { setupTestDb, cleanupTestDb } from './helpers/setupTestDb';
+
+let tmpDir: string;
+let DatabaseService: typeof import('../services/DatabaseService').DatabaseService;
+let ensurePilotJwtSecret: typeof import('../bootstrap/startup').ensurePilotJwtSecret;
+
+beforeAll(async () => {
+    tmpDir = await setupTestDb();
+    ({ DatabaseService } = await import('../services/DatabaseService'));
+    ({ ensurePilotJwtSecret } = await import('../bootstrap/startup'));
+});
+
+afterAll(() => {
+    cleanupTestDb(tmpDir);
+});
+
+beforeEach(() => {
+    delete process.env.SENCHO_MODE;
+});
+
+afterEach(() => {
+    delete process.env.SENCHO_MODE;
+});
+
+describe('pilot-agent bootstrap auth_jwt_secret', () => {
+    it('generates a secret on first pilot-mode boot when missing', () => {
+        const db = DatabaseService.getInstance();
+        // Wipe any existing secret to simulate a fresh pilot host.
+        db.updateGlobalSetting('auth_jwt_secret', '');
+        expect(db.getGlobalSettings().auth_jwt_secret).toBe('');
+
+        process.env.SENCHO_MODE = 'pilot';
+        const generated = ensurePilotJwtSecret();
+        expect(generated).toBe(true);
+
+        const after = db.getGlobalSettings().auth_jwt_secret;
+        expect(after).toBeTruthy();
+        expect(after.length).toBe(128); // 64 random bytes hex-encoded
+    });
+
+    it('does not regenerate on subsequent boots with a persisted secret', () => {
+        const db = DatabaseService.getInstance();
+        const seeded = 'a'.repeat(128);
+        db.updateGlobalSetting('auth_jwt_secret', seeded);
+
+        process.env.SENCHO_MODE = 'pilot';
+        const generated = ensurePilotJwtSecret();
+        expect(generated).toBe(false);
+        expect(db.getGlobalSettings().auth_jwt_secret).toBe(seeded);
+    });
+
+    it('does nothing in non-pilot mode (even if secret is missing)', () => {
+        const db = DatabaseService.getInstance();
+        db.updateGlobalSetting('auth_jwt_secret', '');
+
+        // Default: SENCHO_MODE unset — primary mode.
+        const generated = ensurePilotJwtSecret();
+        expect(generated).toBe(false);
+        // Still empty: primary mode goes through the setup wizard, not this
+        // pilot-only auto-init.
+        expect(db.getGlobalSettings().auth_jwt_secret).toBe('');
+    });
+});

--- a/backend/src/bootstrap/startup.ts
+++ b/backend/src/bootstrap/startup.ts
@@ -1,6 +1,8 @@
 import type { Server } from 'http';
+import crypto from 'crypto';
 import { FileSystemService } from '../services/FileSystemService';
 import { NodeRegistry } from '../services/NodeRegistry';
+import { DatabaseService } from '../services/DatabaseService';
 import { LicenseService } from '../services/LicenseService';
 import SelfUpdateService from '../services/SelfUpdateService';
 import { MonitorService } from '../services/MonitorService';
@@ -17,6 +19,29 @@ import { sweepStaleTempDirs as sweepStaleGitTempDirs } from '../services/GitSour
 import { PORT } from '../helpers/constants';
 
 /**
+ * Pilot-agent hosts never run the first-run setup wizard, so the wizard
+ * path that normally generates `auth_jwt_secret` (routes/auth.ts) never
+ * fires. Without that secret, the agent-side loopback auth helper
+ * (`pilot/agent.ts::getLoopbackAuthHeader`) cannot mint the
+ * `pilot_tunnel`-scoped JWT it injects on every forwarded HTTP/WS request,
+ * and the local Sencho's `authMiddleware` rejects every proxied call with
+ * 401 "Authentication required". Generate the secret here on first boot in
+ * pilot mode; subsequent boots reuse the persisted value. No-op outside
+ * pilot mode (the wizard owns the lifecycle there).
+ *
+ * Returns true when a fresh secret was written, false otherwise.
+ */
+export function ensurePilotJwtSecret(): boolean {
+  if (process.env.SENCHO_MODE !== 'pilot') return false;
+  const dbSvc = DatabaseService.getInstance();
+  if (dbSvc.getGlobalSettings().auth_jwt_secret) return false;
+  const generated = crypto.randomBytes(64).toString('hex');
+  dbSvc.updateGlobalSetting('auth_jwt_secret', generated);
+  console.log('[Startup] pilot-agent: generated local auth_jwt_secret');
+  return true;
+}
+
+/**
  * Run the startup sequence: stack-directory migration, service initialization,
  * background watchdogs, then bind the HTTP server. The caller passes the
  * already-constructed server so tests can import the module without binding a
@@ -31,6 +56,8 @@ export async function startServer(server: Server): Promise<void> {
   } catch (error) {
     console.error('Migration failed:', error);
   }
+
+  ensurePilotJwtSecret();
 
   // Initialize the license service before any tier-gated code can run.
   LicenseService.getInstance().initialize();


### PR DESCRIPTION
## Summary

Closes audit task #1.

PR #990 wired the agent's `onHttpReq`/`onWsOpen` to inject a `pilot_tunnel`-scoped JWT signed with the LOCAL `auth_jwt_secret` so the loopback Sencho's `authMiddleware` would accept the forwarded request. The fix relied on the secret existing — but pilot-agent hosts never run the first-run setup wizard (where `routes/auth.ts:90` generates the secret). The mint helper at `pilot/agent.ts:117-119` returned `null`, no `Authorization` header was attached, and the local Sencho returned 401 "Authentication required" — exactly matching `auth.ts:43` ("no token provided") rather than `auth.ts:151` ("invalid/expired token"). This was reproducible end-to-end on v0.74.1, .2, and .3 against `sencho-pilot-test`.

## What changed

- New `ensurePilotJwtSecret()` exported from `backend/src/bootstrap/startup.ts`. When `SENCHO_MODE === 'pilot'` and `global_settings.auth_jwt_secret` is empty, generates 64 random bytes (hex-encoded, matching the wizard's pattern in `routes/auth.ts:90`) and persists. Returns true on fresh write, false on no-op.
- Called early in `startServer()`, before `LicenseService.initialize()`. `LicenseService.initialize` only reads `system_state` (`instance_id`, `license_status`), never touches `global_settings.auth_jwt_secret`, so the placement is safe.
- Subsequent boots see the persisted secret and no-op. Outside pilot mode the function is a no-op since the wizard owns the lifecycle.
- Helper is exported so the regression test exercises the real function rather than maintaining a hand-mirrored copy (a code-review finding).

## Test plan

- [x] `npx tsc --noEmit` (clean)
- [x] New `backend/src/__tests__/pilot-agent-bootstrap-secret.test.ts`: 3 cases — first-boot generation, persisted-secret no-op, non-pilot-mode no-op
- [x] 152 tests pass across 14 files (pilot, mesh, proxy, auth, fleet)
- [ ] Manual end-to-end: deploy v0.74.4 to all nodes; switch to `sencho-pilot-test` in the central UI; create a stack; confirm 200 OK and the stack lands on the pilot host. Manual step left for the merger.

## Notes

- Pilot hosts now have an `auth_jwt_secret` in their local DB. It never leaves the host (no transport, no third-party access). Operator-owned, audit-OK.
- Together with PR #989 (proxy-side bridge dispatch), PR #990 (agent-side loopback auth), PR #992 (control-plane HTTP), and PR #994 (mesh-reachable diagnostic), the central → bridge → agent → local-Sencho path is functional end-to-end for pilot-agent nodes.