### PR TITLE
fix(mesh): proxy sidecar lifecycle to remote node's local docker

### DIFF
--- a/backend/src/__tests__/mesh-sidecar-lifecycle-remote.test.ts
+++ b/backend/src/__tests__/mesh-sidecar-lifecycle-remote.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Regression guard for the C-4 fix: MeshService sidecar lifecycle methods
+ * (spawn/stop/inspect) used DockerController.getInstance(nodeId), but
+ * NodeRegistry.getDocker explicitly throws for remote nodes by design.
+ * Sidecars must spawn on each node's LOCAL Docker daemon, so the central
+ * cannot drive remote spawns via Dockerode. The fix mirrors PR #992: the
+ * dispatcher routes local nodes to the existing Dockerode path and remote
+ * nodes to a new HTTP endpoint on the remote Sencho's mesh router that
+ * runs the same Dockerode logic against its own local daemon.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { setupTestDb, cleanupTestDb } from './helpers/setupTestDb';
+
+let tmpDir: string;
+let MeshService: typeof import('../services/MeshService').MeshService;
+let DatabaseService: typeof import('../services/DatabaseService').DatabaseService;
+let NodeRegistry: typeof import('../services/NodeRegistry').NodeRegistry;
+
+beforeAll(async () => {
+    tmpDir = await setupTestDb();
+    ({ MeshService } = await import('../services/MeshService'));
+    ({ DatabaseService } = await import('../services/DatabaseService'));
+    ({ NodeRegistry } = await import('../services/NodeRegistry'));
+});
+
+afterAll(() => {
+    vi.restoreAllMocks();
+    cleanupTestDb(tmpDir);
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('MeshService sidecar lifecycle dispatch (C-4 fix)', () => {
+    it('routes spawn for the local node to spawnLocalSidecar (no remote HTTP)', async () => {
+        const svc = MeshService.getInstance();
+        const localNodeId = DatabaseService.getInstance().getNodes()[0].id;
+
+        const localSpy = vi.spyOn(svc, 'spawnLocalSidecar').mockResolvedValue(undefined);
+        const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+        await svc.spawnSidecar(localNodeId);
+
+        expect(localSpy).toHaveBeenCalledWith(localNodeId);
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('routes spawn for a remote node to the local-sidecar HTTP endpoint with proxy headers', async () => {
+        const svc = MeshService.getInstance();
+        const db = DatabaseService.getInstance();
+        const remoteNodeId = db.addNode({
+            name: 'sidecar-remote-test',
+            type: 'remote',
+            mode: 'proxy',
+            compose_dir: '/tmp',
+            is_default: false,
+            api_url: 'https://remote.example.com:1852',
+            api_token: 'remote-tok',
+        });
+
+        vi.spyOn(NodeRegistry.getInstance(), 'getProxyTarget').mockReturnValue({
+            apiUrl: 'https://remote.example.com:1852',
+            apiToken: 'remote-tok',
+        });
+        const localSpy = vi.spyOn(svc, 'spawnLocalSidecar');
+        const fetchMock = vi.spyOn(globalThis, 'fetch')
+            .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200, headers: { 'content-type': 'application/json' } }));
+
+        await svc.spawnSidecar(remoteNodeId);
+
+        expect(localSpy).not.toHaveBeenCalled();
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const [url, init] = fetchMock.mock.calls[0];
+        expect(String(url)).toBe('https://remote.example.com:1852/api/mesh/local-sidecar/spawn');
+        expect((init as { method: string }).method).toBe('POST');
+        const headers = (init as { headers: Record<string, string> }).headers;
+        expect(headers['Authorization']).toBe('Bearer remote-tok');
+        expect(headers).toHaveProperty('x-sencho-tier');
+
+        db.deleteNode(remoteNodeId);
+    });
+
+    it('throws when spawn for a remote node has no active proxy target (e.g. pilot tunnel down)', async () => {
+        const svc = MeshService.getInstance();
+        const db = DatabaseService.getInstance();
+        const remoteNodeId = db.addNode({
+            name: 'sidecar-remote-down',
+            type: 'remote',
+            mode: 'pilot_agent',
+            compose_dir: '/tmp',
+            is_default: false,
+            api_url: '',
+            api_token: '',
+        });
+
+        vi.spyOn(NodeRegistry.getInstance(), 'getProxyTarget').mockReturnValue(null);
+
+        await expect(svc.spawnSidecar(remoteNodeId)).rejects.toThrow(/no active proxy target/);
+        db.deleteNode(remoteNodeId);
+    });
+
+    it('routes stop for a remote node to the local-sidecar HTTP endpoint', async () => {
+        const svc = MeshService.getInstance();
+        const db = DatabaseService.getInstance();
+        const remoteNodeId = db.addNode({
+            name: 'sidecar-remote-stop',
+            type: 'remote',
+            mode: 'proxy',
+            compose_dir: '/tmp',
+            is_default: false,
+            api_url: 'https://remote.example.com:1852',
+            api_token: 'remote-tok',
+        });
+
+        vi.spyOn(NodeRegistry.getInstance(), 'getProxyTarget').mockReturnValue({
+            apiUrl: 'https://remote.example.com:1852',
+            apiToken: 'remote-tok',
+        });
+        const fetchMock = vi.spyOn(globalThis, 'fetch')
+            .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200, headers: { 'content-type': 'application/json' } }));
+
+        await svc.stopSidecar(remoteNodeId);
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const [url, init] = fetchMock.mock.calls[0];
+        expect(String(url)).toBe('https://remote.example.com:1852/api/mesh/local-sidecar/stop');
+        expect((init as { method: string }).method).toBe('POST');
+
+        db.deleteNode(remoteNodeId);
+    });
+
+    it('isSidecarRunning for a remote node uses GET /local-sidecar/inspect and folds running:true into true', async () => {
+        const svc = MeshService.getInstance();
+        const db = DatabaseService.getInstance();
+        const remoteNodeId = db.addNode({
+            name: 'sidecar-remote-running',
+            type: 'remote',
+            mode: 'proxy',
+            compose_dir: '/tmp',
+            is_default: false,
+            api_url: 'https://remote.example.com:1852',
+            api_token: 'remote-tok',
+        });
+
+        vi.spyOn(NodeRegistry.getInstance(), 'getProxyTarget').mockReturnValue({
+            apiUrl: 'https://remote.example.com:1852',
+            apiToken: 'remote-tok',
+        });
+        const fetchMock = vi.spyOn(globalThis, 'fetch')
+            .mockResolvedValue(new Response(JSON.stringify({ running: true }), { status: 200, headers: { 'content-type': 'application/json' } }));
+
+        const out = await (svc as unknown as { isSidecarRunning: (n: number) => Promise<boolean> }).isSidecarRunning(remoteNodeId);
+
+        expect(out).toBe(true);
+        const [url, init] = fetchMock.mock.calls[0];
+        expect(String(url)).toBe('https://remote.example.com:1852/api/mesh/local-sidecar/inspect');
+        expect((init as { method: string }).method).toBe('GET');
+
+        db.deleteNode(remoteNodeId);
+    });
+
+    it('stopSidecar on an unknown nodeId is a silent no-op (no throw, no fetch)', async () => {
+        const svc = MeshService.getInstance();
+        const fetchSpy = vi.spyOn(globalThis, 'fetch');
+        const localSpy = vi.spyOn(svc, 'stopLocalSidecar');
+
+        await expect(svc.stopSidecar(999_999)).resolves.toBeUndefined();
+        expect(fetchSpy).not.toHaveBeenCalled();
+        expect(localSpy).not.toHaveBeenCalled();
+    });
+
+    it('isSidecarRunning for a remote node returns false when the inspect HTTP call returns non-2xx', async () => {
+        const svc = MeshService.getInstance();
+        const db = DatabaseService.getInstance();
+        const remoteNodeId = db.addNode({
+            name: 'sidecar-remote-inspect-fail',
+            type: 'remote',
+            mode: 'proxy',
+            compose_dir: '/tmp',
+            is_default: false,
+            api_url: 'https://remote.example.com:1852',
+            api_token: 'remote-tok',
+        });
+
+        vi.spyOn(NodeRegistry.getInstance(), 'getProxyTarget').mockReturnValue({
+            apiUrl: 'https://remote.example.com:1852',
+            apiToken: 'remote-tok',
+        });
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('boom', { status: 502 }));
+
+        const out = await (svc as unknown as { isSidecarRunning: (n: number) => Promise<boolean> }).isSidecarRunning(remoteNodeId);
+        expect(out).toBe(false);
+        db.deleteNode(remoteNodeId);
+    });
+});

--- a/backend/src/routes/mesh.ts
+++ b/backend/src/routes/mesh.ts
@@ -57,6 +57,55 @@ meshRouter.post('/nodes/:nodeId/disable', async (req: Request, res: Response): P
  * existing proxy chain (`NodeRegistry.getProxyTarget`) so it can build the
  * cross-fleet alias cache without violating the local-only Dockerode rule.
  */
+/**
+ * Sidecar lifecycle endpoints that always operate on the LOCAL Docker
+ * daemon. Central's MeshService HTTP-calls these against each remote node
+ * via the existing proxy chain so spawn/stop/inspect respect the
+ * "remote-Docker is not directly accessible" rule. Mirrors the
+ * `/local-services/:stackName` pattern from PR #992.
+ *
+ * `nodeId` in the request body is the FLEET-wide node id used to label and
+ * uniquely name the sidecar container. Each Sencho instance only ever sees
+ * its own assigned id, so there is no cross-node collision.
+ */
+meshRouter.post('/local-sidecar/spawn', async (req: Request, res: Response): Promise<void> => {
+    if (!requireAdmiral(req, res)) return;
+    if (!requireAdmin(req, res)) return;
+    const nodeId = NodeRegistry.getInstance().getDefaultNodeId();
+    try {
+        await MeshService.getInstance().spawnLocalSidecar(nodeId);
+        res.json({ ok: true });
+    } catch (err) {
+        console.warn('[mesh] /local-sidecar/spawn failed:', sanitizeForLog((err as Error).message));
+        res.status(500).json({ error: (err as Error).message });
+    }
+});
+
+meshRouter.post('/local-sidecar/stop', async (req: Request, res: Response): Promise<void> => {
+    if (!requireAdmiral(req, res)) return;
+    if (!requireAdmin(req, res)) return;
+    const nodeId = NodeRegistry.getInstance().getDefaultNodeId();
+    try {
+        await MeshService.getInstance().stopLocalSidecar(nodeId);
+        res.json({ ok: true });
+    } catch (err) {
+        console.warn('[mesh] /local-sidecar/stop failed:', sanitizeForLog((err as Error).message));
+        res.status(500).json({ error: (err as Error).message });
+    }
+});
+
+meshRouter.get('/local-sidecar/inspect', async (req: Request, res: Response): Promise<void> => {
+    if (!requireAdmiral(req, res)) return;
+    const nodeId = NodeRegistry.getInstance().getDefaultNodeId();
+    try {
+        const running = await MeshService.getInstance().isLocalSidecarRunning(nodeId);
+        res.json({ running });
+    } catch (err) {
+        console.warn('[mesh] /local-sidecar/inspect failed:', sanitizeForLog((err as Error).message));
+        res.status(500).json({ error: 'Failed to inspect sidecar' });
+    }
+});
+
 meshRouter.get('/local-services/:stackName', async (req: Request, res: Response): Promise<void> => {
     if (!requireAdmiral(req, res)) return;
     const stackName = req.params.stackName as string;

--- a/backend/src/services/MeshService.ts
+++ b/backend/src/services/MeshService.ts
@@ -450,11 +450,7 @@ export class MeshService extends EventEmitter {
         }
         try {
             const url = `${target.apiUrl.replace(/\/$/, '')}/api/mesh/local-services/${encodeURIComponent(stackName)}`;
-            const headers: Record<string, string> = {};
-            if (target.apiToken) headers['Authorization'] = `Bearer ${target.apiToken}`;
-            const proxyHeaders = LicenseService.getInstance().getProxyHeaders();
-            headers[PROXY_TIER_HEADER] = proxyHeaders.tier;
-            headers[PROXY_VARIANT_HEADER] = proxyHeaders.variant || '';
+            const headers = this.buildProxyFetchHeaders(target);
             const res = await fetch(url, { headers, signal: AbortSignal.timeout(5_000) });
             if (!res.ok) {
                 console.error(`[MeshService] inspectStackServices: HTTP ${res.status} from node ${nodeId} (${sanitizeForLog(node.name)})`);
@@ -466,6 +462,23 @@ export class MeshService extends EventEmitter {
             console.error('[MeshService] inspectStackServices remote unreachable:', sanitizeForLog((err as Error).message));
             return [];
         }
+    }
+
+    /**
+     * Header shape for central-to-remote HTTP fetches that go directly to a
+     * resolved proxy target (bypassing the central's own proxy chain).
+     * Bearer-attaches the persisted node_proxy token (proxy mode) or omits
+     * it (pilot-agent mode, where the bridge re-auths via the tunnel
+     * socket). Tier and variant headers are always set so the remote's
+     * `requireAdmiral` honors the central's license, not the remote's.
+     */
+    private buildProxyFetchHeaders(target: { apiUrl: string; apiToken: string }): Record<string, string> {
+        const headers: Record<string, string> = {};
+        if (target.apiToken) headers['Authorization'] = `Bearer ${target.apiToken}`;
+        const proxyHeaders = LicenseService.getInstance().getProxyHeaders();
+        headers[PROXY_TIER_HEADER] = proxyHeaders.tier;
+        headers[PROXY_VARIANT_HEADER] = proxyHeaders.variant || '';
+        return headers;
     }
 
     // --- Resolution + forwarding ---
@@ -755,26 +768,39 @@ export class MeshService extends EventEmitter {
     public async getStatus(): Promise<MeshNodeStatus[]> {
         const db = DatabaseService.getInstance();
         const nodes = db.getNodes();
-        const out: MeshNodeStatus[] = [];
-        for (const node of nodes) {
-            const optedInStacks = db.listMeshStacks(node.id).map((s) => s.stack_name);
-            out.push({
-                nodeId: node.id,
-                nodeName: node.name,
-                enabled: db.getNodeMeshEnabled(node.id),
-                sidecarRunning: await this.isSidecarRunning(node.id),
-                pilotConnected: this.isMeshReachable(node.id),
-                optedInStacks,
-                activeStreamCount: Array.from(this.activeStreams.values()).length,
-            });
-        }
-        return out;
+        // After C-4, sidecar inspection on remote nodes is an HTTP fetch
+        // with a 30 s budget. Sequentially awaiting per node would let one
+        // unreachable remote stall the whole status fetch; the UI polls
+        // this on every Routing-tab open and on every refresh.
+        const sidecarStates = await Promise.all(nodes.map((n) =>
+            this.isSidecarRunning(n.id).catch(() => false),
+        ));
+        const activeStreamCount = this.activeStreams.size;
+        return nodes.map((node, i) => ({
+            nodeId: node.id,
+            nodeName: node.name,
+            enabled: db.getNodeMeshEnabled(node.id),
+            sidecarRunning: sidecarStates[i],
+            pilotConnected: this.isMeshReachable(node.id),
+            optedInStacks: db.listMeshStacks(node.id).map((s) => s.stack_name),
+            activeStreamCount,
+        }));
     }
 
-    // --- Sidecar lifecycle (best-effort; real spawn happens on local node) ---
+    // --- Sidecar lifecycle ---
+    //
+    // Each node's sidecar must run on that node's local Docker daemon.
+    // `NodeRegistry.getDocker` throws for any remote node by design (its
+    // Docker daemon is not directly accessible; all requests are proxied
+    // via HTTP), so the central cannot spawn/stop/inspect a remote node's
+    // sidecar via Dockerode. Public methods dispatch to either the local
+    // Dockerode path or an HTTP call to the remote node's
+    // `/api/mesh/local-sidecar/*` endpoints, which run the same local
+    // Dockerode logic on the remote's own MeshService. Mirrors the
+    // dispatch shape introduced for `inspectStackServices` in PR #992.
 
-    public async spawnSidecar(nodeId: number): Promise<void> {
-        const docker = DockerController.getInstance(nodeId).getDocker();
+    public async spawnLocalSidecar(nodeId: number): Promise<void> {
+        const docker = DockerController.getInstance().getDocker();
         const name = `${SIDECAR_CONTAINER_PREFIX}${nodeId}`;
         try {
             const existing = docker.getContainer(name);
@@ -817,8 +843,8 @@ export class MeshService extends EventEmitter {
         }
     }
 
-    public async stopSidecar(nodeId: number): Promise<void> {
-        const docker = DockerController.getInstance(nodeId).getDocker();
+    public async stopLocalSidecar(nodeId: number): Promise<void> {
+        const docker = DockerController.getInstance().getDocker();
         const name = `${SIDECAR_CONTAINER_PREFIX}${nodeId}`;
         try {
             const c = docker.getContainer(name);
@@ -831,14 +857,65 @@ export class MeshService extends EventEmitter {
         } catch { /* ignore */ }
     }
 
-    private async isSidecarRunning(nodeId: number): Promise<boolean> {
+    public async isLocalSidecarRunning(nodeId: number): Promise<boolean> {
         try {
-            const docker = DockerController.getInstance(nodeId).getDocker();
+            const docker = DockerController.getInstance().getDocker();
             const info = await docker.getContainer(`${SIDECAR_CONTAINER_PREFIX}${nodeId}`).inspect();
             return !!info.State?.Running;
         } catch {
             return false;
         }
+    }
+
+    public async spawnSidecar(nodeId: number): Promise<void> {
+        const node = DatabaseService.getInstance().getNode(nodeId);
+        if (!node) throw new Error(`Node ${nodeId} not found`);
+        if (node.type !== 'remote') return this.spawnLocalSidecar(nodeId);
+        await this.callRemoteSidecarLifecycle(nodeId, 'spawn');
+    }
+
+    public async stopSidecar(nodeId: number): Promise<void> {
+        const node = DatabaseService.getInstance().getNode(nodeId);
+        if (!node) return;
+        if (node.type !== 'remote') return this.stopLocalSidecar(nodeId);
+        await this.callRemoteSidecarLifecycle(nodeId, 'stop');
+    }
+
+    private async isSidecarRunning(nodeId: number): Promise<boolean> {
+        const node = DatabaseService.getInstance().getNode(nodeId);
+        if (!node) return false;
+        if (node.type !== 'remote') return this.isLocalSidecarRunning(nodeId);
+        const result = await this.callRemoteSidecarLifecycle(nodeId, 'inspect');
+        return result?.running === true;
+    }
+
+    /**
+     * HTTP-call the remote node's own `/api/mesh/local-sidecar/{action}`
+     * endpoint. The remote's MeshService runs the lifecycle action against
+     * its own local Docker daemon (where the sidecar must actually run).
+     * For inspect, the remote returns `{ running: boolean }` so the central
+     * can fold the result back into `getStatus`. Spawn/stop return `{ ok: true }`.
+     */
+    private async callRemoteSidecarLifecycle(
+        nodeId: number,
+        action: 'spawn' | 'stop' | 'inspect',
+    ): Promise<{ ok?: boolean; running?: boolean } | null> {
+        const target = NodeRegistry.getInstance().getProxyTarget(nodeId);
+        if (!target) {
+            const node = DatabaseService.getInstance().getNode(nodeId);
+            const name = node ? sanitizeForLog(node.name) : String(nodeId);
+            throw new Error(`Cannot reach node ${name}: no active proxy target`);
+        }
+        const url = `${target.apiUrl.replace(/\/$/, '')}/api/mesh/local-sidecar/${action}`;
+        const method = action === 'inspect' ? 'GET' : 'POST';
+        const headers = this.buildProxyFetchHeaders(target);
+        const res = await fetch(url, { method, headers, signal: AbortSignal.timeout(30_000) });
+        if (!res.ok) {
+            if (action === 'inspect') return { running: false };
+            const body = await res.text().catch(() => '');
+            throw new Error(`remote sidecar ${action} failed: HTTP ${res.status} ${body.slice(0, 200)}`);
+        }
+        return await res.json() as { ok?: boolean; running?: boolean };
     }
 
     public mintSidecarToken(nodeId: number): string {


### PR DESCRIPTION
## Summary

Closes audit finding **C-4** (critical, sibling to C-3).

`MeshService.spawnSidecar`, `stopSidecar`, and `isSidecarRunning` all opened with `DockerController.getInstance(nodeId).getDocker()`. `NodeRegistry.getDocker` explicitly throws for any node with `type: 'remote'` — exactly the same anti-pattern PR #992 fixed for `inspectStackServices`, just on a different surface that PR #992 did not touch. Cross-node sidecar lifecycle failed with:

```
POST /api/mesh/nodes/14/sidecar/restart
=> 500 Node "sencho-pilot-test" is a remote Distributed API node...
```

Discovered live on 2026-05-08 against v0.74.4 while running PR 0 verification.

## What changed

- **Split each lifecycle method** into a `*LocalSidecar(nodeId)` (always Dockerode against the local daemon) plus a dispatcher that routes local-type nodes to the local helper and remote-type nodes through a new HTTP endpoint on the target Sencho's mesh router.
- **Three new routes** under `/api/mesh/local-sidecar/`:
  - `POST /spawn` — creates and starts the sidecar container against this Sencho's own Docker daemon
  - `POST /stop` — stops and removes it
  - `GET /inspect` — returns `{ running: boolean }`
  Spawn/stop are gated by `requireAdmiral` + `requireAdmin`; inspect by `requireAdmiral` only. nodeId is always derived from `getDefaultNodeId()` so there's no caller-supplied id (no spoofing surface).
- **`callRemoteSidecarLifecycle`** dispatcher in MeshService HTTP-fetches the remote endpoint via the URL resolved by `NodeRegistry.getProxyTarget`, with the persisted node_proxy Bearer token and license tier headers.

### Code review side improvements

- **Extracted `buildProxyFetchHeaders` helper.** PR #992's review previously flagged this as a follow-up when a third site appeared. Third site is now here, so extracted; both `inspectStackServices` and the sidecar dispatcher use it.
- **Parallelized `getStatus` sidecar inspection** with `Promise.all`. Each remote inspect is now an HTTP fetch with a 30 s budget; sequential await would have let one unreachable remote stall the whole status fetch (the Routing tab polls this on every open).

## Test plan

- [x] `npx tsc --noEmit` (clean)
- [x] New `backend/src/__tests__/mesh-sidecar-lifecycle-remote.test.ts`: 7 cases covering local dispatch (no fetch), remote spawn (URL + headers), remote stop, remote inspect mapping, missing proxy target throws, non-2xx inspect → false, unknown nodeId stop is a silent no-op
- [x] 144 tests pass across 12 files (mesh + pilot + proxy + auth + nodes + fleet)
- [ ] Manual end-to-end: with this PR + a published `saelix/sencho-mesh:<tag>` image (see C-5), spawn a sidecar on a pilot-agent peer via the central UI, confirm the container appears on the remote host with the right env vars and labels.

## Notes

- Together with PR #989/#990/#992/#994/#997, this resolves the central-side architecture for cross-node mesh control. **C-5 remains the final gating blocker:** the hardcoded `saelix/sencho-mesh:latest` image returns 404 from Docker on a fresh install. Until C-5 lands (publish the image, or add `docker pull` with auth handling, or demote mesh to 1.1 behind `SENCHO_EXPERIMENTAL`), no sidecars will spawn anywhere regardless of routing fixes.
- `mintSidecarToken` continues to sign with the local `auth_jwt_secret`. Now that PR #997 bootstraps that secret on pilot-agent hosts, both proxy-mode and pilot-agent remotes can mint valid sidecar tokens.