### PR TITLE
fix(mesh): bind every alias port on every node, not just local-owned

### DIFF
--- a/backend/src/__tests__/mesh-service.test.ts
+++ b/backend/src/__tests__/mesh-service.test.ts
@@ -79,6 +79,57 @@ describe('MeshService.optInStack', () => {
             .rejects.toThrow(/invalid stack name/);
         expect(db.isMeshStackEnabled(localNodeId, '../../etc/passwd')).toBe(false);
     });
+
+    it('forwarder binds every alias port across the fleet, not just local-owned ports', async () => {
+        const svc = MeshService.getInstance();
+        const db = DatabaseService.getInstance();
+        const localNodeId = db.getNodes()[0].id;
+        const remoteNodeId = db.addNode({
+            name: 'remote-pilot', type: 'remote', mode: 'pilot_agent',
+            compose_dir: '/tmp', is_default: false, api_url: '', api_token: '',
+        });
+
+        // Seed local- and remote-owned aliases directly into
+        // aliasByPort so we exercise syncForwarderListeners without a
+        // live remote Sencho. The model: every meshed node binds every
+        // alias port because meshed containers' extra_hosts:host-gateway
+        // entries land on the SOURCE node's gateway, so the source node
+        // is where the inbound TCP connection is intercepted.
+        const aliasByPort = (svc as unknown as { aliasByPort: Map<number, unknown> }).aliasByPort;
+        aliasByPort.set(9000, {
+            host: 'echo.local-stack.Local.sencho',
+            nodeId: localNodeId, nodeName: 'Local',
+            stackName: 'local-stack', serviceName: 'echo', port: 9000,
+        });
+        aliasByPort.set(9001, {
+            host: 'echo.remote-stack.remote-pilot.sencho',
+            nodeId: remoteNodeId, nodeName: 'remote-pilot',
+            stackName: 'remote-stack', serviceName: 'echo', port: 9001,
+        });
+
+        // Stub the forwarder so the test never touches a real net.Server.
+        const listened: number[] = [];
+        const fwd = (svc as unknown as {
+            forwarder: { listen: (p: number) => Promise<void>; unlisten: (p: number) => Promise<void>; getListenerPorts: () => number[] };
+        }).forwarder;
+        const realListen = fwd.listen.bind(fwd);
+        const realUnlisten = fwd.unlisten.bind(fwd);
+        const realGetListenerPorts = fwd.getListenerPorts.bind(fwd);
+        fwd.listen = async (p: number) => { listened.push(p); };
+        fwd.unlisten = async () => { /* no-op */ };
+        fwd.getListenerPorts = () => [...listened];
+
+        try {
+            await (svc as unknown as { syncForwarderListeners: () => Promise<void> }).syncForwarderListeners();
+            expect(listened.sort()).toEqual([9000, 9001]);
+        } finally {
+            fwd.listen = realListen;
+            fwd.unlisten = realUnlisten;
+            fwd.getListenerPorts = realGetListenerPorts;
+            aliasByPort.clear();
+            db.deleteNode(remoteNodeId);
+        }
+    });
 });
 
 describe('MeshService activity log', () => {

--- a/backend/src/services/MeshService.ts
+++ b/backend/src/services/MeshService.ts
@@ -188,18 +188,24 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
     }
 
     /**
-     * Bind the forwarder's listeners to the local-owned alias ports and
-     * release any listeners no longer in the alias set. Called from
+     * Bind the forwarder's listeners to every alias port across the fleet
+     * and release any listeners no longer in the alias set. Called from
      * `start`, after each `refreshAliasCache` tick, and after every
-     * opt-in / opt-out / disable on the local node so the bound port set
-     * follows the DB state.
+     * opt-in / opt-out / disable so the bound port set follows the DB
+     * state.
+     *
+     * Every meshed node binds every alias port — not just ports it owns —
+     * because meshed containers' `extra_hosts: <alias>:host-gateway`
+     * entries resolve to the SOURCE node's gateway, so the source node is
+     * where the inbound TCP connection lands. `handleAccept` then
+     * dispatches to the same-node fast path or the cross-node bridge based
+     * on the resolved alias's owner. Fleet-wide port collisions are
+     * blocked at opt-in time (`optInStack` checks `aliasByPort`), so
+     * binding every alias port is unambiguous.
      */
     private async syncForwarderListeners(): Promise<void> {
         const localNodeId = NodeRegistry.getInstance().getDefaultNodeId();
-        const wantPorts = new Set<number>();
-        for (const alias of this.aliasByPort.values()) {
-            if (alias.nodeId === localNodeId) wantPorts.add(alias.port);
-        }
+        const wantPorts = new Set<number>(this.aliasByPort.keys());
         const havePorts = new Set(this.forwarder.getListenerPorts());
         for (const port of havePorts) {
             if (!wantPorts.has(port)) {


### PR DESCRIPTION
## Summary

`MeshService.syncForwarderListeners` filtered the bind set to ports owned by the local node. That broke cross-node mesh routing end to end. The architecture documented at `docs/internal/architecture/mesh.md` (data flow step 3) is explicit: every meshed node binds every alias port because meshed containers' `extra_hosts: <alias>:host-gateway` entries resolve to the **source** node's gateway.

## Bug

Meshed container on Local connecting to `echo.audit-mesh-pilot.sencho-pilot-test.sencho:9001`:

1. `getaddrinfo` resolves the alias to `host-gateway`, which on Linux Docker is the host's bridge interface IP — **the source's**, not the target's.
2. TCP connection lands on Local's host network at port 9001.
3. With the local-owned filter in place, Local's `MeshForwarder` only bound 9000 (its own alias). 9001 had no listener. Connection refused. Cross-node mesh dead.

`handleAccept` already dispatched correctly (`target.nodeId === localNodeId` → same-node fast path; otherwise → `openCrossNode` via `PilotTunnelManager.getBridge`). The bug was just in the bind set.

## Fix

`MeshService.ts:200-202`: drop the `if (alias.nodeId === localNodeId)` filter. `wantPorts` now includes every alias port from `aliasByPort`. The fleet-wide opt-in port-collision check (`optInStack`) keeps the bind set unambiguous.

Comment block above `syncForwarderListeners` updated to document the model.

## Test

New vitest case in `mesh-service.test.ts`:
- Seed `aliasByPort` with one local-owned and one remote-owned alias
- Stub the forwarder so we never touch a real `net.Server`
- Call `syncForwarderListeners` and assert both ports were requested

## Discovery

Ran the PR 0 protocol on v0.75.0 against Local + sencho-pilot-test (after PR #1000, #1001, #1003 all merged). Local's diagnostic showed `forwarderListening: true, listenerCount: 1` — only its own port. The remote alias was registered but unreachable from any meshed container on Local. Architecture doc + the original sidecar's `Forwarder.listen(port)` model both confirm the correct behavior.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (0 errors, 233 unchanged pre-existing warnings)
- [x] 167 tests pass across 13 mesh / pilot / proxy / auth / nodes / fleet files
- [ ] Manual end-to-end on a real two-node setup with this PR deployed: docker exec into a prober on each side, `nc echo.<otherStack>.<otherNode>.sencho <port>`. Both directions should print the banner. Manual step left for the merger after deploy.

## Notes

- Strictly speaking this is a Phase A bug; the filter was introduced in PR #1000. Both Phase A (central → pilot) and Phase B (pilot → central, pilot ↔ pilot via relay) need this fix to function end to end.
- No protocol or API change. Pure semantics fix in the bind dispatcher.