### PR TITLE
fix(fleet): drop tier gate from stack and container list endpoints

### DIFF
--- a/backend/src/__tests__/fleet.test.ts
+++ b/backend/src/__tests__/fleet.test.ts
@@ -205,6 +205,22 @@ describe('Fleet tier gating', () => {
       .set('Authorization', authHeader);
     expect(res.body.code).not.toBe('PAID_REQUIRED');
   });
+
+  it('GET /api/fleet/node/:nodeId/stacks is accessible on community tier', async () => {
+    mockTier('community');
+    const res = await request(app)
+      .get('/api/fleet/node/1/stacks')
+      .set('Authorization', authHeader);
+    expect(res.body.code).not.toBe('PAID_REQUIRED');
+  });
+
+  it('GET /api/fleet/node/:nodeId/stacks/:stackName/containers is accessible on community tier', async () => {
+    mockTier('community');
+    const res = await request(app)
+      .get('/api/fleet/node/1/stacks/db-compose/containers')
+      .set('Authorization', authHeader);
+    expect(res.body.code).not.toBe('PAID_REQUIRED');
+  });
 });
 
 // ─── Update Endpoint Input Validation ───

--- a/backend/src/routes/fleet.ts
+++ b/backend/src/routes/fleet.ts
@@ -595,8 +595,6 @@ fleetRouter.get('/configuration', authMiddleware, async (req: Request, res: Resp
 });
 
 fleetRouter.get('/node/:nodeId/stacks', authMiddleware, async (req: Request, res: Response): Promise<void> => {
-  if (!requirePaid(req, res)) return;
-
   try {
     const nodeId = parseIntParam(req, res, 'nodeId', 'node ID');
     if (nodeId === null) return;
@@ -635,8 +633,6 @@ fleetRouter.get('/node/:nodeId/stacks', authMiddleware, async (req: Request, res
 });
 
 fleetRouter.get('/node/:nodeId/stacks/:stackName/containers', authMiddleware, async (req: Request, res: Response): Promise<void> => {
-  if (!requirePaid(req, res)) return;
-
   try {
     const nodeId = parseIntParam(req, res, 'nodeId', 'node ID');
     if (nodeId === null) return;

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1888,7 +1888,7 @@ paths:
       operationId: getFleetNodeStacks
       tags: [Fleet]
       summary: List stacks on a fleet node
-      description: Returns stack names from a specific fleet node. Requires Skipper or Admiral license.
+      description: Returns stack names from a specific fleet node.
       parameters:
         - name: nodeId
           in: path
@@ -1928,7 +1928,7 @@ paths:
       operationId: getFleetNodeStackContainers
       tags: [Fleet]
       summary: List containers in a fleet node stack
-      description: Returns containers for a specific stack on a specific fleet node. Requires Skipper or Admiral license.
+      description: Returns containers for a specific stack on a specific fleet node.
       parameters:
         - name: nodeId
           in: path


### PR DESCRIPTION
## Summary

- Community-tier users saw "Failed to load containers for {stackName}" when expanding a stack card in the Fleet Overview drilldown. The Fleet view, node-card expand, and stack list were all reachable on Community (per PR #930), but two read-only metadata endpoints in `backend/src/routes/fleet.ts` kept their `requirePaid` gate, so expanding any stack card 403'd.
- Drop `requirePaid` from `GET /node/:nodeId/stacks` and `GET /node/:nodeId/stacks/:stackName/containers`. Both handlers stay behind `authMiddleware`, validate inputs, and proxy to the per-node `api_token` for remote nodes. Paid mutations (bulk update, scheduled snapshots, label bulk actions, Fleet Actions cards) keep their gates in `routes/fleetActions.ts`.
- Add two positive Community-tier assertions to the existing "Fleet tier gating" suite in `backend/src/__tests__/fleet.test.ts`.
- Clear the stale "Requires Skipper or Admiral license" line from the matching OpenAPI descriptions.

## Test plan

- [x] `cd backend && npx tsc --noEmit` — clean
- [x] `cd backend && npm test -- fleet.test.ts` — 48/48 pass (incl. the two new Community-tier tests)
- [x] Tested manually in browser: signed in, opened Fleet > Overview, expanded the local node card, expanded a stack — container list rendered, network tab shows `GET /api/fleet/node/1/stacks/{stack}/containers => 200`
- [x] Confirmed pre-fix repro: same endpoint returned 403 on a Community-tier instance running v0.76.0

## Notes

This patches an oversight in PR #930, which opened most of the Fleet Overview to Community but left these two reads gated. No frontend change is needed — `NodeCard.tsx` and `NodeCardStackList.tsx` already render unconditionally for any tier; the only failure was the backend 403.