### PR TITLE
fix(mesh): apply D-1 pushed override on pilot deploys via file-presence fallback

### DIFF
--- a/backend/src/__tests__/mesh-service.test.ts
+++ b/backend/src/__tests__/mesh-service.test.ts
@@ -622,6 +622,47 @@ describe('MeshService.ensureStackOverride (BUG-1 fix)', () => {
             && /orphaned-stack/.test(e.message),
         )).toBe(true);
     });
+
+    it('returns a pushed override file on pilot nodes where isMeshStackEnabled is always false', async () => {
+        const svc = MeshService.getInstance();
+        const db = DatabaseService.getInstance();
+        const localNodeId = db.getNodes()[0].id;
+
+        // Simulate the pilot scenario: no mesh_stacks row (isMeshStackEnabled → false),
+        // but the override file already exists on disk, pushed by central via D-1.
+        const dataDir = process.env.DATA_DIR as string;
+        const overrideDir = path.join(dataDir, 'mesh', 'overrides', String(localNodeId));
+        fsSync.mkdirSync(overrideDir, { recursive: true });
+        const overrideFile = path.join(overrideDir, 'pilot-stack.override.yml');
+        fsSync.writeFileSync(overrideFile, [
+            'services:',
+            '  echo:',
+            '    networks:',
+            '      - sencho_mesh',
+            '    extra_hosts:',
+            '      - echo.pilot-stack.pilot.sencho:172.30.0.2',
+            'networks:',
+            '  sencho_mesh:',
+            '    external: true',
+        ].join('\n'), 'utf8');
+
+        // No mesh_stacks row → isMeshStackEnabled returns false.
+        const result = await svc.ensureStackOverride(localNodeId, 'pilot-stack');
+        expect(result).toBe(overrideFile);
+
+        // Cleanup.
+        fsSync.unlinkSync(overrideFile);
+    });
+
+    it('returns null for pilot nodes when no pushed override file exists', async () => {
+        const svc = MeshService.getInstance();
+        const db = DatabaseService.getInstance();
+        const localNodeId = db.getNodes()[0].id;
+
+        // No mesh_stacks row, no file on disk.
+        const result = await svc.ensureStackOverride(localNodeId, 'no-such-stack');
+        expect(result).toBeNull();
+    });
 });
 
 describe('MeshService tunnel-up regen (BUG-2)', () => {

--- a/backend/src/services/MeshService.ts
+++ b/backend/src/services/MeshService.ts
@@ -592,13 +592,26 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
     public async ensureStackOverride(nodeId: number, stackName: string): Promise<string | null> {
         if (!isValidStackName(stackName)) return null;
         const db = DatabaseService.getInstance();
-        if (!db.isMeshStackEnabled(nodeId, stackName)) return null;
+        const dir = this.overrideDirFor(nodeId);
+        if (!db.isMeshStackEnabled(nodeId, stackName)) {
+            // Pilot nodes intentionally have no mesh_stacks rows (opt-in state
+            // lives on central per the C-3 design). Use file-presence as the
+            // fallback: if central pushed an override via applyLocalOverride, return
+            // that path so ComposeService picks it up on the next deploy.
+            const file = path.resolve(dir, `${path.basename(stackName)}.override.yml`);
+            if (!isPathWithinBase(file, dir)) return null;
+            try {
+                await fs.access(file);
+                return file;
+            } catch {
+                return null;
+            }
+        }
         if (!this.senchoIp) return null;
 
         const aliases: MeshAlias[] = Array.from(this.aliasCache.values()).map((a) => ({ host: a.host }));
         const serviceNames = await this.getDeclaredStackServiceNames(stackName, nodeId);
 
-        const dir = this.overrideDirFor(nodeId);
         await fs.mkdir(dir, { recursive: true });
         // path.basename mirrors the applyLocalOverride pattern (and is
         // the form CodeQL's path-injection model recognizes).
@@ -705,7 +718,7 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
     private async removeStackOverride(nodeId: number, stackName: string): Promise<void> {
         if (!isValidStackName(stackName)) return;
         const dir = this.overrideDirFor(nodeId);
-        const file = path.resolve(dir, `${stackName}.override.yml`);
+        const file = path.resolve(dir, `${path.basename(stackName)}.override.yml`);
         if (!isPathWithinBase(file, dir)) return;
         try { await fs.unlink(file); } catch { /* ignore not-exist */ }
     }


### PR DESCRIPTION
## Summary

- **Pilot deploy fix (D-1 consume-side gap)**: `ensureStackOverride` returned null on pilot nodes because `isMeshStackEnabled` always returns false there by design (opt-in state lives on central per the C-3 architecture). Added a file-presence fallback: if the DB gate fails but an override file already exists on disk (pushed by central via `applyLocalOverride`), that path is returned so `ComposeService` picks it up on the next deploy. This closes the gap where central pushed a correct override to the pilot but redeploying the pilot stack did not apply it.
- **`removeStackOverride` alignment**: aligns the private helper to use `path.basename` consistently with all other override-path construction sites (defense-in-depth, no behavior change on central nodes where this path runs).

## Context

The two earlier commits on this branch (`3f6c4d1`, `2bbbd56`) were squash-merged into main as PR #1017. This PR contains only the one new commit on top of that merge.

## Test plan

- [ ] `cd backend && npx tsc --noEmit` passes with no errors
- [ ] `cd backend && npx vitest run src/__tests__/mesh-service.test.ts src/__tests__/mesh-compose-override.test.ts` passes (including the two new pilot-fallback tests)
- [ ] On production fleet: after image update, trigger a redeploy of `audit-mesh-pilot` on `sencho-pilot-test`; confirm the prober joins `sencho_mesh` and `/etc/hosts` contains both alias entries
- [ ] Reverse mesh probe (`nc -v -w 5 echo.audit-mesh-prod.Local.sencho 9000` from `audit-mesh-pilot-prober-1`) succeeds with `route.resolve.ok` in the activity log