### PR TITLE
fix(mesh): push alias port map to pilot so reverse-direction forwarder binds listeners

### DIFF
--- a/backend/src/__tests__/mesh-service.test.ts
+++ b/backend/src/__tests__/mesh-service.test.ts
@@ -622,6 +622,47 @@ describe('MeshService.ensureStackOverride (BUG-1 fix)', () => {
             && /orphaned-stack/.test(e.message),
         )).toBe(true);
     });
+
+    it('returns a pushed override file on pilot nodes where isMeshStackEnabled is always false', async () => {
+        const svc = MeshService.getInstance();
+        const db = DatabaseService.getInstance();
+        const localNodeId = db.getNodes()[0].id;
+
+        // Simulate the pilot scenario: no mesh_stacks row (isMeshStackEnabled → false),
+        // but the override file already exists on disk, pushed by central via D-1.
+        const dataDir = process.env.DATA_DIR as string;
+        const overrideDir = path.join(dataDir, 'mesh', 'overrides', String(localNodeId));
+        fsSync.mkdirSync(overrideDir, { recursive: true });
+        const overrideFile = path.join(overrideDir, 'pilot-stack.override.yml');
+        fsSync.writeFileSync(overrideFile, [
+            'services:',
+            '  echo:',
+            '    networks:',
+            '      - sencho_mesh',
+            '    extra_hosts:',
+            '      - echo.pilot-stack.pilot.sencho:172.30.0.2',
+            'networks:',
+            '  sencho_mesh:',
+            '    external: true',
+        ].join('\n'), 'utf8');
+
+        // No mesh_stacks row → isMeshStackEnabled returns false.
+        const result = await svc.ensureStackOverride(localNodeId, 'pilot-stack');
+        expect(result).toBe(overrideFile);
+
+        // Cleanup.
+        fsSync.unlinkSync(overrideFile);
+    });
+
+    it('returns null for pilot nodes when no pushed override file exists', async () => {
+        const svc = MeshService.getInstance();
+        const db = DatabaseService.getInstance();
+        const localNodeId = db.getNodes()[0].id;
+
+        // No mesh_stacks row, no file on disk.
+        const result = await svc.ensureStackOverride(localNodeId, 'no-such-stack');
+        expect(result).toBeNull();
+    });
 });
 
 describe('MeshService tunnel-up regen (BUG-2)', () => {

--- a/backend/src/routes/mesh.ts
+++ b/backend/src/routes/mesh.ts
@@ -1,7 +1,7 @@
 import { Router, type Request, type Response } from 'express';
 import { DatabaseService } from '../services/DatabaseService';
 import { NodeRegistry } from '../services/NodeRegistry';
-import { MeshError, MeshService, type MeshRegenSummary } from '../services/MeshService';
+import { MeshError, MeshService, type MeshGlobalAlias, type MeshRegenSummary } from '../services/MeshService';
 import { requireAdmin, requireAdmiral } from '../middleware/tierGates';
 import { sanitizeForLog } from '../utils/safeLog';
 import { isValidStackName } from '../utils/validation';
@@ -113,6 +113,20 @@ meshRouter.get('/local-services/:stackName', async (req: Request, res: Response)
 
 const MAX_ALIASES_PER_PUSH = 1024;
 
+function parsePortAlias(entry: unknown): MeshGlobalAlias | null {
+    const e = entry as Record<string, unknown>;
+    const { host, nodeId, nodeName, stackName, serviceName, port } = e ?? {};
+    if (
+        typeof host !== 'string' || host.length === 0 || host.length > 253 ||
+        typeof nodeId !== 'number' ||
+        typeof nodeName !== 'string' || nodeName.length === 0 ||
+        typeof stackName !== 'string' || stackName.length === 0 ||
+        typeof serviceName !== 'string' || serviceName.length === 0 ||
+        typeof port !== 'number' || !Number.isInteger(port) || port < 1 || port > 65535
+    ) return null;
+    return { host, nodeId, nodeName, stackName, serviceName, port };
+}
+
 /**
  * Accepts a fleet-wide alias list from central and writes a mesh override
  * for the named stack onto THIS Sencho's local DATA_DIR. The pilot looks
@@ -125,7 +139,7 @@ meshRouter.put('/local-override/:stackName', async (req: Request, res: Response)
     if (!requireAdmiral(req, res)) return;
     const stackName = req.params.stackName as string;
     if (!isValidStackName(stackName)) { res.status(400).json({ error: 'Invalid stack name' }); return; }
-    const body = req.body as { aliases?: unknown };
+    const body = req.body as { aliases?: unknown; portAliases?: unknown };
     if (!Array.isArray(body?.aliases)) { res.status(400).json({ error: 'Missing aliases array in body' }); return; }
     if (body.aliases.length > MAX_ALIASES_PER_PUSH) {
         res.status(413).json({ error: `Alias list exceeds ${MAX_ALIASES_PER_PUSH} entries` });
@@ -142,8 +156,20 @@ meshRouter.put('/local-override/:stackName', async (req: Request, res: Response)
         }
         aliases.push({ host });
     }
+    const portAliases: MeshGlobalAlias[] = [];
+    if (Array.isArray(body?.portAliases)) {
+        if (body.portAliases.length > MAX_ALIASES_PER_PUSH) {
+            res.status(413).json({ error: `portAliases list exceeds ${MAX_ALIASES_PER_PUSH} entries` });
+            return;
+        }
+        for (const entry of body.portAliases) {
+            const parsed = parsePortAlias(entry);
+            if (!parsed) { res.status(400).json({ error: 'Invalid portAliases entry' }); return; }
+            portAliases.push(parsed);
+        }
+    }
     try {
-        const written = await MeshService.getInstance().applyLocalOverride(stackName, aliases);
+        const written = await MeshService.getInstance().applyLocalOverride(stackName, aliases, portAliases);
         if (!written) { res.status(400).json({ error: 'Refused to write override (path validation failed)' }); return; }
         res.json({ ok: true, path: written });
     } catch (err) {

--- a/backend/src/services/MeshService.ts
+++ b/backend/src/services/MeshService.ts
@@ -174,6 +174,11 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
     private started = false;
     private aliasCache = new Map<string, MeshGlobalAlias>();
     private aliasByPort = new Map<number, MeshGlobalAlias>();
+    // Populated on pilot nodes via the D-1 override push. Central's
+    // db.listMeshStacks() is authoritative on central; pilots have no
+    // mesh_stacks rows (C-3 design), so the push payload carries the alias
+    // data they need to bind forwarder listeners for the reverse direction.
+    private pilotAliasOverlay = new Map<string, MeshGlobalAlias[]>();
     private activity: MeshActivityEvent[] = [];
     private activeStreams = new Map<number, ActiveStreamRecord>();
     private aliasRefreshTimer?: NodeJS.Timeout;
@@ -656,7 +661,11 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
      * network with its own subnet. Returns the absolute path on success
      * or null if path validation rejects the input.
      */
-    public async applyLocalOverride(stackName: string, aliases: MeshAlias[]): Promise<string | null> {
+    public async applyLocalOverride(
+        stackName: string,
+        aliases: MeshAlias[],
+        portAliases?: MeshGlobalAlias[],
+    ): Promise<string | null> {
         if (!isValidStackName(stackName)) return null;
         if (!this.senchoIp) {
             throw new MeshError(
@@ -699,6 +708,11 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
             senchoIp: this.senchoIp,
         });
         await fs.writeFile(file, yaml, 'utf8');
+        if (portAliases && portAliases.length > 0) {
+            this.pilotAliasOverlay.set(stackName, portAliases);
+            await this.refreshAliasCache();
+            await this.syncForwarderListeners();
+        }
         return file;
     }
 
@@ -713,6 +727,10 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
         const file = path.resolve(dir, `${path.basename(stackName)}.override.yml`);
         if (!isPathWithinBase(file, dir)) return;
         try { await fs.unlink(file); } catch { /* ignore not-exist */ }
+        if (this.pilotAliasOverlay.delete(stackName)) {
+            await this.refreshAliasCache();
+            await this.syncForwarderListeners();
+        }
     }
 
     private async removeStackOverride(nodeId: number, stackName: string): Promise<void> {
@@ -832,6 +850,16 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
                     next.set(host, alias);
                     if (!portMap.has(port)) portMap.set(port, alias);
                 }
+            }
+        }
+        // Merge pilot overlay. Invariant: on central, pilotAliasOverlay is
+        // always empty (DB is authoritative); on pilots, db.listMeshStacks()
+        // returns empty (C-3), so the two populations are mutually exclusive
+        // and the first-write-wins portMap policy is safe.
+        for (const overlayAliases of this.pilotAliasOverlay.values()) {
+            for (const alias of overlayAliases) {
+                next.set(alias.host, alias);
+                if (!portMap.has(alias.port)) portMap.set(alias.port, alias);
             }
         }
         this.aliasCache = next;
@@ -1036,12 +1064,13 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
             return;
         }
 
-        const aliases: MeshAlias[] = Array.from(this.aliasCache.values()).map((a) => ({ host: a.host }));
+        const portAliases: MeshGlobalAlias[] = Array.from(this.aliasCache.values());
+        const aliases: MeshAlias[] = portAliases.map((a) => ({ host: a.host }));
         const res = await this.proxyFetch(
             nodeId,
             'PUT',
             `/api/mesh/local-override/${encodeURIComponent(stackName)}`,
-            { aliases },
+            { aliases, portAliases },
             5_000,
         );
         if (res.status === 404) {

--- a/backend/src/services/MeshService.ts
+++ b/backend/src/services/MeshService.ts
@@ -592,13 +592,26 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
     public async ensureStackOverride(nodeId: number, stackName: string): Promise<string | null> {
         if (!isValidStackName(stackName)) return null;
         const db = DatabaseService.getInstance();
-        if (!db.isMeshStackEnabled(nodeId, stackName)) return null;
+        const dir = this.overrideDirFor(nodeId);
+        if (!db.isMeshStackEnabled(nodeId, stackName)) {
+            // Pilot nodes intentionally have no mesh_stacks rows (opt-in state
+            // lives on central per the C-3 design). Use file-presence as the
+            // fallback: if central pushed an override via applyLocalOverride, return
+            // that path so ComposeService picks it up on the next deploy.
+            const file = path.resolve(dir, `${path.basename(stackName)}.override.yml`);
+            if (!isPathWithinBase(file, dir)) return null;
+            try {
+                await fs.access(file);
+                return file;
+            } catch {
+                return null;
+            }
+        }
         if (!this.senchoIp) return null;
 
         const aliases: MeshAlias[] = Array.from(this.aliasCache.values()).map((a) => ({ host: a.host }));
         const serviceNames = await this.getDeclaredStackServiceNames(stackName, nodeId);
 
-        const dir = this.overrideDirFor(nodeId);
         await fs.mkdir(dir, { recursive: true });
         // path.basename mirrors the applyLocalOverride pattern (and is
         // the form CodeQL's path-injection model recognizes).
@@ -705,7 +718,7 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
     private async removeStackOverride(nodeId: number, stackName: string): Promise<void> {
         if (!isValidStackName(stackName)) return;
         const dir = this.overrideDirFor(nodeId);
-        const file = path.resolve(dir, `${stackName}.override.yml`);
+        const file = path.resolve(dir, `${path.basename(stackName)}.override.yml`);
         if (!isPathWithinBase(file, dir)) return;
         try { await fs.unlink(file); } catch { /* ignore not-exist */ }
     }


### PR DESCRIPTION
## Summary

- **Root cause**: On pilot nodes, `db.listMeshStacks()` returns empty (C-3 design: opt-in state lives on central). `refreshAliasCache()` built an empty `aliasByPort` map from that empty result, so `syncForwarderListeners()` bound zero alias ports. Reverse-direction TCP connections from the pilot prober failed with connection refused at the OS level.
- **Fix**: Extend the D-1 override push (`PUT /api/mesh/local-override/:stackName`) payload to include the full `MeshGlobalAlias` records alongside the existing `aliases` host-string array. On the pilot, `applyLocalOverride()` stores these in a new `pilotAliasOverlay` map keyed by stack name, then immediately calls `refreshAliasCache()` + `syncForwarderListeners()` to bind the alias ports. `refreshAliasCache()` merges the overlay after the (empty) DB loop, making the two data sources mutually exclusive by the C-3 invariant. `removeLocalOverride()` clears the overlay entry and re-syncs on opt-out.
- **Validation**: `parsePortAlias()` helper in the route handler validates every field of each incoming entry; a single malformed entry aborts the request with 400 before any state is written.

## Context

Forward direction (central → pilot) worked because central's forwarder uses its own fully-populated `aliasByPort` to accept the connection, then dispatches a `tcp_open` frame to the pilot's agent, which resolves the target by Docker container labels. The pilot-side forwarder is not involved in the forward path. Reverse direction requires the pilot's forwarder to listen on the alias port so the prober can dial it.

## Test plan

- [ ] `cd backend && npx tsc --noEmit` passes with no errors
- [ ] `cd backend && npx vitest run src/__tests__/mesh-service.test.ts src/__tests__/mesh-compose-override.test.ts` passes (45 tests)
- [ ] After image update on pilot: push override from central triggers `syncForwarderListeners`; `netstat -lnt` inside `sencho-agent` shows the alias port listening on the `sencho_mesh` IP
- [ ] Reverse probe from `audit-mesh-pilot-prober-1` (`nc -v -w 5 echo.audit-mesh-prod.Local.sencho 9000`) succeeds with `route.resolve.ok` in the central activity log