### PR TITLE
fix(mesh): fix pilot handleAccept dispatch via enrollment token self-nodeId

### DIFF
--- a/backend/src/__tests__/mesh-service.test.ts
+++ b/backend/src/__tests__/mesh-service.test.ts
@@ -33,6 +33,7 @@ beforeEach(() => {
         senchoIp: string | null;
         meshSubnet: string;
         networkSetupError: string | null;
+        selfCentralNodeId: number | null;
     };
     svc.aliasCache = new Map();
     svc.aliasByPort = new Map();
@@ -43,6 +44,8 @@ beforeEach(() => {
     svc.senchoIp = '172.30.0.2';
     svc.meshSubnet = '172.30.0.0/24';
     svc.networkSetupError = null;
+    svc.selfCentralNodeId = null;
+    delete process.env.SENCHO_ENROLL_TOKEN;
     vi.restoreAllMocks();
 });
 
@@ -807,5 +810,97 @@ describe('MeshService.openCrossNode (BUG-4)', () => {
         } finally {
             vi.useRealTimers();
         }
+    });
+});
+
+describe('MeshService pilot handleAccept dispatch', () => {
+    function makeEnrollToken(nodeId: number): string {
+        const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+        const payload = Buffer.from(JSON.stringify({ scope: 'pilot_enroll', nodeId })).toString('base64url');
+        return `${header}.${payload}.fakesig`;
+    }
+
+    it('resolveSelfCentralNodeId extracts nodeId from SENCHO_ENROLL_TOKEN', () => {
+        process.env.SENCHO_ENROLL_TOKEN = makeEnrollToken(14);
+        const svc = MeshService.getInstance() as unknown as {
+            resolveSelfCentralNodeId: () => number;
+        };
+        expect(svc.resolveSelfCentralNodeId()).toBe(14);
+    });
+
+    it('resolveSelfCentralNodeId falls back to local default when token is absent', () => {
+        delete process.env.SENCHO_ENROLL_TOKEN;
+        const svc = MeshService.getInstance() as unknown as {
+            resolveSelfCentralNodeId: () => number;
+        };
+        const db = DatabaseService.getInstance();
+        const defaultId = db.getDefaultNode()?.id ?? 1;
+        expect(svc.resolveSelfCentralNodeId()).toBe(defaultId);
+    });
+
+    it('resolveSelfCentralNodeId falls back to local default for a malformed token', () => {
+        process.env.SENCHO_ENROLL_TOKEN = 'not.a.jwt';
+        const svc = MeshService.getInstance() as unknown as {
+            resolveSelfCentralNodeId: () => number;
+        };
+        const db = DatabaseService.getInstance();
+        const defaultId = db.getDefaultNode()?.id ?? 1;
+        expect(svc.resolveSelfCentralNodeId()).toBe(defaultId);
+    });
+
+    it('handleAccept routes same-node alias to openSameNode on a pilot', async () => {
+        const svc = MeshService.getInstance();
+        const internals = svc as unknown as {
+            selfCentralNodeId: number | null;
+            aliasByPort: Map<number, unknown>;
+            openSameNode: (t: MeshTarget, s: unknown) => Promise<void>;
+            openCrossNode: (t: MeshTarget, s: unknown) => void;
+        };
+        internals.selfCentralNodeId = 14;
+        internals.aliasByPort.set(9001, {
+            host: 'echo.audit-mesh-pilot.sencho-pilot-test.sencho',
+            nodeId: 14,
+            nodeName: 'sencho-pilot-test',
+            stackName: 'audit-mesh-pilot',
+            serviceName: 'echo',
+            port: 9001,
+        });
+
+        const openSame = vi.spyOn(internals, 'openSameNode').mockResolvedValue(undefined);
+        const openCross = vi.spyOn(internals, 'openCrossNode').mockImplementation(() => undefined);
+        const fakeSrc = { remoteAddress: '127.0.0.1', destroy: vi.fn() } as unknown as import('net').Socket;
+
+        await svc.handleAccept(9001, fakeSrc);
+
+        expect(openSame).toHaveBeenCalledOnce();
+        expect(openCross).not.toHaveBeenCalled();
+    });
+
+    it('handleAccept routes cross-node alias to openCrossNode on a pilot', async () => {
+        const svc = MeshService.getInstance();
+        const internals = svc as unknown as {
+            selfCentralNodeId: number | null;
+            aliasByPort: Map<number, unknown>;
+            openSameNode: (t: MeshTarget, s: unknown) => Promise<void>;
+            openCrossNode: (t: MeshTarget, s: unknown) => void;
+        };
+        internals.selfCentralNodeId = 14;
+        internals.aliasByPort.set(9000, {
+            host: 'echo.audit-mesh-prod.Local.sencho',
+            nodeId: 1,
+            nodeName: 'Local',
+            stackName: 'audit-mesh-prod',
+            serviceName: 'echo',
+            port: 9000,
+        });
+
+        const openSame = vi.spyOn(internals, 'openSameNode').mockResolvedValue(undefined);
+        const openCross = vi.spyOn(internals, 'openCrossNode').mockImplementation(() => undefined);
+        const fakeSrc = { remoteAddress: '127.0.0.1', destroy: vi.fn() } as unknown as import('net').Socket;
+
+        await svc.handleAccept(9000, fakeSrc);
+
+        expect(openCross).toHaveBeenCalledOnce();
+        expect(openSame).not.toHaveBeenCalled();
     });
 });

--- a/backend/src/services/MeshService.ts
+++ b/backend/src/services/MeshService.ts
@@ -189,6 +189,12 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
     private senchoIp: string | null = null;
     private meshSubnet: string = DEFAULT_MESH_SUBNET;
     private networkSetupError: string | null = null;
+    // On a pilot node, central's DB id for this node (e.g. 14). Used by
+    // handleAccept to decide same-node vs cross-node; the pilotAliasOverlay
+    // carries nodeIds from central's perspective, so comparing against the
+    // pilot's own local DB id (always 1) inverts dispatch. Null on central
+    // (fallback to getDefaultNodeId()). Populated from SENCHO_ENROLL_TOKEN.
+    private selfCentralNodeId: number | null = null;
 
     private constructor() {
         super();
@@ -199,6 +205,24 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
     public static getInstance(): MeshService {
         if (!MeshService.instance) MeshService.instance = new MeshService();
         return MeshService.instance;
+    }
+
+    private resolveSelfCentralNodeId(): number {
+        const tok = process.env.SENCHO_ENROLL_TOKEN;
+        if (tok) {
+            try {
+                // Extract payload only — signature verification not needed here;
+                // we only need the nodeId claim, not auth.
+                const [, b64] = tok.split('.');
+                const payload = JSON.parse(
+                    Buffer.from(b64, 'base64url').toString('utf8'),
+                ) as Record<string, unknown>;
+                if (typeof payload.nodeId === 'number') return payload.nodeId;
+            } catch {
+                // Malformed token; fall through to local default.
+            }
+        }
+        return NodeRegistry.getInstance().getDefaultNodeId();
     }
 
     public async start(): Promise<void> {
@@ -226,6 +250,8 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
                 });
             });
         });
+
+        this.selfCentralNodeId = this.resolveSelfCentralNodeId();
 
         await this.setupMeshNetwork();
         try {
@@ -259,7 +285,7 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
         const dataPlane = this.senchoIp ? 'ok' : `unavailable (${this.networkSetupError ?? 'unknown'})`;
         this.logActivity({
             source: 'mesh', level: this.senchoIp ? 'info' : 'warn', type: 'mesh.enable',
-            message: `MeshService started (data plane ${dataPlane})`,
+            message: `MeshService started (data plane ${dataPlane}, self nodeId ${this.selfCentralNodeId})`,
         });
     }
 
@@ -1208,8 +1234,8 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
             try { src.destroy(); } catch { /* ignore */ }
             return;
         }
-        const localNodeId = NodeRegistry.getInstance().getDefaultNodeId();
-        if (target.nodeId === localNodeId) {
+        const selfNodeId = this.selfCentralNodeId ?? NodeRegistry.getInstance().getDefaultNodeId();
+        if (target.nodeId === selfNodeId) {
             await this.openSameNode(target, src);
         } else {
             this.openCrossNode(target, src);


### PR DESCRIPTION
## Summary

- `handleAccept` on the pilot node compared `target.nodeId` (from `pilotAliasOverlay`, using central's DB ids) against `NodeRegistry.getDefaultNodeId()` which always returns `1` on a pilot. This inverted same-node vs cross-node dispatch for every alias the pilot knew about.
- Added `resolveSelfCentralNodeId()` that decodes the `nodeId` claim from `SENCHO_ENROLL_TOKEN` (the enrollment JWT is present on every pilot for its lifetime; we only need the payload, not signature verification). On central (env var absent), it falls back to `getDefaultNodeId()`.
- Cached in `selfCentralNodeId` at `start()`; `handleAccept` reads the cache instead of calling `getDefaultNodeId()` per connection.

**Before:** pilot-prober sending to `echo.audit-mesh-prod.Local.sencho:9000` hit `openSameNode` (no container on pilot, silent close, 0 bytes); pilot-prober sending to its own `echo.audit-mesh-pilot:9001` hit `openCrossNode` (tunnel loop through central).

**After:** cross-node alias routes through `openCrossNode` (reverse tunnel to central); same-node alias routes through `openSameNode` (local Dockerode dial). Closes BUG-3.

## Test plan

- [ ] 5 new unit tests: `resolveSelfCentralNodeId` extracts nodeId from enrollment token, falls back on absent/malformed token; `handleAccept` routes same-node alias to `openSameNode` and cross-node alias to `openCrossNode` on a simulated pilot (`selfCentralNodeId=14`).
- [ ] `tsc --noEmit` clean on backend.
- [ ] All 2005 existing tests pass.
- [ ] Validated manually: run banner probes from pilot-prober once deployed to v0.76.x fleet:
  - Forward: `docker exec audit-mesh-prod-prober-1 sh -c 'echo "" | nc -w 5 echo.audit-mesh-pilot.sencho-pilot-test.sencho 9001'` expects `PILOT-HELLO`
  - Reverse (coordinate with pilot host): `docker exec audit-mesh-pilot-prober-1 sh -c 'echo "" | nc -w 5 echo.audit-mesh-prod.Local.sencho 9000'` expects `PROD-HELLO`
  - `/api/mesh/activity?limit=10` expects `route.resolve.ok` for both directions