### PR TITLE
fix(mesh): proxy peer learns its central-namespace nodeId at tunnel upgrade

### DIFF
--- a/backend/src/__tests__/mesh-proxy-tunnel-handler.test.ts
+++ b/backend/src/__tests__/mesh-proxy-tunnel-handler.test.ts
@@ -38,7 +38,8 @@ interface ServerHandle {
 async function startServer(): Promise<ServerHandle> {
     const server = http.createServer();
     server.on('upgrade', (req, socket, head) => {
-        if (req.url === '/api/mesh/proxy-tunnel') {
+        const pathname = new URL(req.url ?? '/', 'http://localhost').pathname;
+        if (pathname === '/api/mesh/proxy-tunnel') {
             void handleMeshProxyTunnel(req, socket, head);
         } else {
             socket.destroy();
@@ -53,9 +54,9 @@ async function startServer(): Promise<ServerHandle> {
     };
 }
 
-function dialTunnel(port: number): Promise<WebSocket> {
+function dialTunnel(port: number, query: string = ''): Promise<WebSocket> {
     return new Promise((resolve, reject) => {
-        const ws = new WebSocket(`ws://127.0.0.1:${port}/api/mesh/proxy-tunnel`);
+        const ws = new WebSocket(`ws://127.0.0.1:${port}/api/mesh/proxy-tunnel${query}`);
         ws.once('open', () => resolve(ws));
         ws.once('error', reject);
     });
@@ -75,6 +76,7 @@ beforeEach(() => {
     delete process.env.SENCHO_MODE;
     // Defensive: clear any reverse dialer left over from a prior test.
     MeshService.getInstance().setReverseDialer(null);
+    MeshService.getInstance().setProxyTunnelSelfCentralNodeId(null);
 });
 
 describe('handleMeshProxyTunnel', () => {
@@ -146,6 +148,108 @@ describe('handleMeshProxyTunnel', () => {
             await new Promise((r) => setTimeout(r, 30));
         } finally {
             await srv.close();
+        }
+    });
+
+    it('installs the central-namespace nodeId from the ?nodeId= query param', async () => {
+        const srv = await startServer();
+        try {
+            const ws = await dialTunnel(srv.port, '?nodeId=14');
+            await new Promise((r) => setTimeout(r, 20));
+            expect((MeshService.getInstance() as unknown as { proxyTunnelSelfCentralNodeId: number | null }).proxyTunnelSelfCentralNodeId).toBe(14);
+
+            ws.close(1000, 'test cleanup');
+            await new Promise((r) => setTimeout(r, 30));
+            // Tunnel close clears the value.
+            expect((MeshService.getInstance() as unknown as { proxyTunnelSelfCentralNodeId: number | null }).proxyTunnelSelfCentralNodeId).toBeNull();
+        } finally {
+            await srv.close();
+        }
+    });
+
+    it('does not install or reject when the nodeId query param is missing (warns and proceeds)', async () => {
+        const srv = await startServer();
+        try {
+            const ws = await dialTunnel(srv.port);
+            await new Promise((r) => setTimeout(r, 20));
+            // Upgrade succeeded (reverse dialer installed), but no nodeId
+            // is recorded because central did not pass it.
+            const dialer = (MeshService.getInstance() as unknown as { reverseDialer: unknown }).reverseDialer;
+            expect(dialer).not.toBeNull();
+            expect((MeshService.getInstance() as unknown as { proxyTunnelSelfCentralNodeId: number | null }).proxyTunnelSelfCentralNodeId).toBeNull();
+
+            ws.close(1000, 'test cleanup');
+            await new Promise((r) => setTimeout(r, 30));
+        } finally {
+            await srv.close();
+        }
+    });
+
+    it('ignores malformed nodeId query params (non-numeric, zero, negative, decimal, leading zeros, exponent, whitespace)', async () => {
+        const srv = await startServer();
+        try {
+            // Strict regex rejects everything that is not a positive
+            // decimal integer with no leading zero. parseInt would have
+            // silently truncated `14.5` to `14`, accepted `00014`, etc.
+            const cases = [
+                '?nodeId=abc', '?nodeId=0', '?nodeId=-3',
+                '?nodeId=14.5', '?nodeId=00014', '?nodeId=1e2',
+                '?nodeId=%2014', '?nodeId=14abc', '?nodeId=',
+            ];
+            for (const bogus of cases) {
+                const ws = await dialTunnel(srv.port, bogus);
+                await new Promise((r) => setTimeout(r, 20));
+                expect((MeshService.getInstance() as unknown as { proxyTunnelSelfCentralNodeId: number | null }).proxyTunnelSelfCentralNodeId).toBeNull();
+                ws.close(1000, 'test cleanup');
+                await new Promise((r) => setTimeout(r, 30));
+            }
+        } finally {
+            await srv.close();
+        }
+    });
+
+    it('setProxyTunnelSelfCentralNodeId warns on a non-null overwrite to a different value', () => {
+        const svc = MeshService.getInstance();
+        const warns: string[] = [];
+        const origWarn = console.warn;
+        console.warn = (...args: unknown[]) => { warns.push(args.map(String).join(' ')); };
+        try {
+            svc.setProxyTunnelSelfCentralNodeId(14);
+            svc.setProxyTunnelSelfCentralNodeId(14); // same value: no warn
+            svc.setProxyTunnelSelfCentralNodeId(15); // different value: warn
+            svc.setProxyTunnelSelfCentralNodeId(null); // clear: no warn
+            svc.setProxyTunnelSelfCentralNodeId(20); // install after clear: no warn
+        } finally {
+            console.warn = origWarn;
+        }
+        const overwriteWarns = warns.filter((w) => w.includes('proxyTunnelSelfCentralNodeId overwritten'));
+        expect(overwriteWarns).toHaveLength(1);
+        expect(overwriteWarns[0]).toContain('14 -> 15');
+    });
+
+    it('a CAS-rejected reverse-dialer install does not leak the nodeId into MeshService', async () => {
+        const svc = MeshService.getInstance();
+        // Pre-seed the reverse-dialer slot so the handler's CAS install
+        // fails. The contract: the nodeId installer runs ONLY after the
+        // CAS install succeeds; a rejected upgrade must leave the
+        // identity slot unchanged.
+        const blockingDialer = { openMeshTcpStream: () => null };
+        svc.setReverseDialer(blockingDialer as unknown as Parameters<typeof svc.setReverseDialer>[0]);
+        try {
+            const srv = await startServer();
+            try {
+                const ws = new WebSocket(`ws://127.0.0.1:${srv.port}/api/mesh/proxy-tunnel?nodeId=14`);
+                const closeInfo = await new Promise<{ code: number }>((resolve, reject) => {
+                    ws.once('close', (code) => resolve({ code }));
+                    ws.once('error', reject);
+                });
+                expect(closeInfo.code).toBe(1013);
+                expect((svc as unknown as { proxyTunnelSelfCentralNodeId: number | null }).proxyTunnelSelfCentralNodeId).toBeNull();
+            } finally {
+                await srv.close();
+            }
+        } finally {
+            svc.setReverseDialer(null);
         }
     });
 

--- a/backend/src/__tests__/mesh-service.test.ts
+++ b/backend/src/__tests__/mesh-service.test.ts
@@ -34,6 +34,7 @@ beforeEach(() => {
         meshSubnet: string;
         networkSetupError: string | null;
         selfCentralNodeId: number | null;
+        proxyTunnelSelfCentralNodeId: number | null;
     };
     svc.aliasCache = new Map();
     svc.aliasByPort = new Map();
@@ -45,6 +46,7 @@ beforeEach(() => {
     svc.meshSubnet = '172.30.0.0/24';
     svc.networkSetupError = null;
     svc.selfCentralNodeId = null;
+    svc.proxyTunnelSelfCentralNodeId = null;
     delete process.env.SENCHO_ENROLL_TOKEN;
     vi.restoreAllMocks();
 });
@@ -902,5 +904,75 @@ describe('MeshService pilot handleAccept dispatch', () => {
 
         expect(openCross).toHaveBeenCalledOnce();
         expect(openSame).not.toHaveBeenCalled();
+    });
+
+    it('handleAccept on a proxy peer uses proxyTunnelSelfCentralNodeId to route cross-node aliases correctly (R1)', async () => {
+        // Repro for the R1 bug: a proxy peer receives an overlay carrying
+        // central-namespace nodeIds (e.g., Local = 1, this peer = 14). Pre-R1
+        // the peer had no selfCentralNodeId source, fell back to its local DB
+        // default (always 1), and falsely matched alias.nodeId=1 to its own
+        // selfNodeId=1 — dispatching cross-node aliases as same-node.
+        const svc = MeshService.getInstance();
+        const internals = svc as unknown as {
+            proxyTunnelSelfCentralNodeId: number | null;
+            selfCentralNodeId: number | null;
+            aliasByPort: Map<number, unknown>;
+            openSameNode: (t: MeshTarget, s: unknown) => Promise<void>;
+            openCrossNode: (t: MeshTarget, s: unknown) => void;
+        };
+        // Proxy peer: selfCentralNodeId is null (no SENCHO_ENROLL_TOKEN),
+        // the proxy-tunnel handler installed central's view of this peer.
+        internals.selfCentralNodeId = null;
+        svc.setProxyTunnelSelfCentralNodeId(14);
+        // Overlay alias for central's own stack (Local = nodeId 1 in
+        // central's namespace).
+        internals.aliasByPort.set(9000, {
+            host: 'echo.audit-mesh-central.Local.sencho',
+            nodeId: 1,
+            nodeName: 'Local',
+            stackName: 'audit-mesh-central',
+            serviceName: 'echo',
+            port: 9000,
+        });
+
+        const openSame = vi.spyOn(internals, 'openSameNode').mockResolvedValue(undefined);
+        const openCross = vi.spyOn(internals, 'openCrossNode').mockImplementation(() => undefined);
+        const fakeSrc = { remoteAddress: '127.0.0.1', destroy: vi.fn() } as unknown as import('net').Socket;
+
+        await svc.handleAccept(9000, fakeSrc);
+
+        expect(openCross).toHaveBeenCalledOnce();
+        expect(openSame).not.toHaveBeenCalled();
+    });
+
+    it('handleAccept on a proxy peer routes same-node aliases (matching the proxy-tunnel nodeId) to openSameNode', async () => {
+        const svc = MeshService.getInstance();
+        const internals = svc as unknown as {
+            proxyTunnelSelfCentralNodeId: number | null;
+            selfCentralNodeId: number | null;
+            aliasByPort: Map<number, unknown>;
+            openSameNode: (t: MeshTarget, s: unknown) => Promise<void>;
+            openCrossNode: (t: MeshTarget, s: unknown) => void;
+        };
+        internals.selfCentralNodeId = null;
+        svc.setProxyTunnelSelfCentralNodeId(14);
+        // Alias for a stack on this peer (nodeId 14 in central's namespace).
+        internals.aliasByPort.set(9002, {
+            host: 'echo.audit-mesh-proxy.sencho-test-03.sencho',
+            nodeId: 14,
+            nodeName: 'sencho-test-03',
+            stackName: 'audit-mesh-proxy',
+            serviceName: 'echo',
+            port: 9002,
+        });
+
+        const openSame = vi.spyOn(internals, 'openSameNode').mockResolvedValue(undefined);
+        const openCross = vi.spyOn(internals, 'openCrossNode').mockImplementation(() => undefined);
+        const fakeSrc = { remoteAddress: '127.0.0.1', destroy: vi.fn() } as unknown as import('net').Socket;
+
+        await svc.handleAccept(9002, fakeSrc);
+
+        expect(openSame).toHaveBeenCalledOnce();
+        expect(openCross).not.toHaveBeenCalled();
     });
 });

--- a/backend/src/services/MeshProxyTunnelDialer.ts
+++ b/backend/src/services/MeshProxyTunnelDialer.ts
@@ -186,7 +186,12 @@ export class MeshProxyTunnelDialer extends EventEmitter {
             console.log(`[MeshProxyDialer:diag] dialing node=${nodeId} url=${sanitizeForLog(target.apiUrl)}`.replace(/[\n\r]/g, ''));
         }
 
-        const wsUrl = httpUrlToWs(target.apiUrl) + '/api/mesh/proxy-tunnel';
+        // Pass the peer's nodeId in central's namespace as a query param so
+        // the remote MeshService can dispatch its own `handleAccept` correctly:
+        // overlay aliases carry central-namespace nodeIds, and without this
+        // the peer falls back to its local DB default (always 1) and treats
+        // cross-node aliases as same-node.
+        const wsUrl = httpUrlToWs(target.apiUrl) + `/api/mesh/proxy-tunnel?nodeId=${nodeId}`;
         let ws: WebSocket;
         try {
             ws = new WebSocket(wsUrl, {

--- a/backend/src/services/MeshService.ts
+++ b/backend/src/services/MeshService.ts
@@ -71,7 +71,8 @@ export type MeshActivityType =
     | 'mesh.override.preserved'
     | 'probe.ok' | 'probe.fail'
     | 'forwarder.listen' | 'forwarder.unlisten' | 'forwarder.error'
-    | 'proxy-tunnel.open.ok' | 'proxy-tunnel.open.fail' | 'proxy-tunnel.close';
+    | 'proxy-tunnel.open.ok' | 'proxy-tunnel.open.fail' | 'proxy-tunnel.close'
+    | 'mesh.proxy_tunnel.identify';
 
 export interface MeshActivityEvent {
     ts: number;
@@ -232,6 +233,14 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
     // pilot's own local DB id (always 1) inverts dispatch. Null on central
     // (fallback to getDefaultNodeId()). Populated from SENCHO_ENROLL_TOKEN.
     private selfCentralNodeId: number | null = null;
+    // On a proxy-mode peer, central's DB id for this node, communicated
+    // through the `?nodeId=` query param on the `/api/mesh/proxy-tunnel` WS
+    // upgrade. Same purpose as `selfCentralNodeId` but for proxy peers,
+    // where there is no SENCHO_ENROLL_TOKEN to read at boot. Takes
+    // precedence in `handleAccept`'s self-id resolution because the active
+    // upstream tunnel is the most authoritative source. Cleared on tunnel
+    // close.
+    private proxyTunnelSelfCentralNodeId: number | null = null;
 
     private constructor() {
         super();
@@ -1316,7 +1325,15 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
             try { src.destroy(); } catch { /* ignore */ }
             return;
         }
-        const selfNodeId = this.selfCentralNodeId ?? NodeRegistry.getInstance().getDefaultNodeId();
+        // Resolution order: active proxy-tunnel install > boot-time enroll
+        // token > local DB default. The proxy-tunnel value is the most
+        // authoritative when present because the upstream central just told
+        // this peer how it sees it; the enroll token covers pilot mode; the
+        // default-node fallback covers central itself.
+        const selfNodeId =
+            this.proxyTunnelSelfCentralNodeId
+            ?? this.selfCentralNodeId
+            ?? NodeRegistry.getInstance().getDefaultNodeId();
         if (target.nodeId === selfNodeId) {
             await this.openSameNode(target, src);
         } else {
@@ -1416,6 +1433,40 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
         }
         this.reverseDialer = dialer;
         return true;
+    }
+
+    /**
+     * Install (or clear) the central-namespace nodeId communicated by the
+     * upstream central at proxy-tunnel upgrade. Called by the proxy-tunnel
+     * WS handler; cleared on disconnect. Consumed by `handleAccept` to
+     * dispatch cross-node aliases correctly on proxy peers.
+     *
+     * The caller is implicitly single-tenant: it runs only after
+     * `setReverseDialer`'s CAS install succeeds (slot already guarded). A
+     * second non-null install while a different non-null value is present
+     * indicates a misconfigured deployment, so we warn loudly instead of
+     * silently overwriting.
+     */
+    public setProxyTunnelSelfCentralNodeId(nodeId: number | null): void {
+        if (
+            nodeId !== null
+            && this.proxyTunnelSelfCentralNodeId !== null
+            && this.proxyTunnelSelfCentralNodeId !== nodeId
+        ) {
+            console.warn(
+                `[MeshService] proxyTunnelSelfCentralNodeId overwritten ${this.proxyTunnelSelfCentralNodeId} -> ${nodeId}; concurrent proxy-tunnel install or misconfigured deployment`,
+            );
+        }
+        if (nodeId !== null && this.proxyTunnelSelfCentralNodeId !== nodeId) {
+            this.logActivity({
+                source: 'mesh', level: 'info', type: 'mesh.proxy_tunnel.identify',
+                message: `proxy-tunnel: this node is nodeId=${nodeId} in central's namespace`,
+            });
+        }
+        // Null-clear (tunnel teardown) is intentionally not logged: it
+        // would double the entries on every reconnect cycle without adding
+        // signal beyond the existing `proxy-tunnel.close` event.
+        this.proxyTunnelSelfCentralNodeId = nodeId;
     }
 
     private async dialMeshTcpStream(target: MeshTarget): Promise<MeshTcpStreamLike | null> {

--- a/backend/src/websocket/meshProxyTunnel.ts
+++ b/backend/src/websocket/meshProxyTunnel.ts
@@ -48,14 +48,38 @@ export async function handleMeshProxyTunnel(req: IncomingMessage, socket: Duplex
         return reject(socket, 404, 'Not Found');
     }
 
+    // Central appends `?nodeId=<central-namespace-id>` so this peer can tag
+    // its own MeshService with the right nodeId for `handleAccept` dispatch.
+    // The value is unsigned, but the Bearer credential at the upgrade has
+    // already proven the caller is the upstream central (auth + scope gate
+    // in `upgradeHandler.ts`); the query param's trust ceiling is the
+    // token's trust ceiling.
+    // Strict regex (no parseInt) so `?nodeId=14.5`, `?nodeId=00014`,
+    // `?nodeId=1e2`, leading whitespace, etc. are rejected rather than
+    // silently truncated.
+    let peerNodeId: number | null = null;
+    try {
+        const parsed = new URL(req.url ?? '/', `http://${req.headers.host || 'localhost'}`);
+        const raw = parsed.searchParams.get('nodeId');
+        if (raw != null && /^[1-9][0-9]*$/.test(raw)) {
+            const n = Number(raw);
+            if (Number.isSafeInteger(n)) peerNodeId = n;
+        }
+    } catch {
+        // Malformed URL; treat as missing param.
+    }
+    if (peerNodeId === null) {
+        console.warn('[MeshProxy] proxy-tunnel upgrade missing or malformed nodeId query param; reverse-direction mesh dispatch will be undefined until central upgrades');
+    }
+
     await new Promise<void>((resolve) => {
         wss.handleUpgrade(req, socket as Parameters<typeof wss.handleUpgrade>[1], head, (ws) => {
-            void attachSwitchboard(ws).finally(resolve);
+            void attachSwitchboard(ws, peerNodeId).finally(resolve);
         });
     });
 }
 
-async function attachSwitchboard(ws: WebSocket): Promise<void> {
+async function attachSwitchboard(ws: WebSocket, peerNodeId: number | null): Promise<void> {
     let switchboard: TcpStreamSwitchboard | null = null;
     let meshServiceCleanup: (() => void) | null = null;
 
@@ -87,8 +111,17 @@ async function attachSwitchboard(ws: WebSocket): Promise<void> {
             switchboard = null;
             return;
         }
+        // Install central's view of this peer's nodeId so handleAccept
+        // dispatches cross-node aliases correctly. Done after setReverseDialer
+        // succeeds so a CAS-rejected tunnel does not leak nodeId state.
+        if (peerNodeId !== null) {
+            meshService.setProxyTunnelSelfCentralNodeId(peerNodeId);
+        }
         meshServiceCleanup = () => {
             meshService.setReverseDialer(null, localDialer);
+            if (peerNodeId !== null) {
+                meshService.setProxyTunnelSelfCentralNodeId(null);
+            }
         };
     } catch (err) {
         if (isDebugEnabled()) {


### PR DESCRIPTION
## Summary

- Central appends `?nodeId=<central-namespace-id>` to the proxy-tunnel WS URL so proxy-mode peers can tag their own `MeshService` with the right nodeId for `handleAccept` dispatch.
- `handleAccept` self-id resolution priority: proxy-tunnel install > `SENCHO_ENROLL_TOKEN` (pilot mode) > `NodeRegistry.getDefaultNodeId()` (central). Proxy peers no longer fall through to their local DB default (always `1`) and falsely match cross-node aliases as same-node.
- Strict regex validates the query param: rejects decimals, leading zeros, exponent forms, whitespace, non-positive integers. Missing or malformed value logs a warn and proceeds (one-way tunnel still works until the other side ships).

## Why

Phase C (v0.77.0) shipped mesh over proxy-mode remotes. Live verification on a real fleet proved forward direction green but uncovered the reverse direction broken: each Sencho's local DB calls itself `nodeId=1`, so on a proxy peer the comparison `alias.nodeId === selfNodeId` collapsed to `1 === 1` for every alias central pushed for its own stacks. Reverse-direction probes hit `route.resolve.denied: cannot resolve container IP for echo.audit-mesh-central.Local.sencho`. The bidirectional-mesh claim in the architecture doc was aspirational until this fix.

## Changes

- `backend/src/services/MeshProxyTunnelDialer.ts` — append `?nodeId=${nodeId}` to the WS URL.
- `backend/src/websocket/meshProxyTunnel.ts` — strict-regex parse of the query param, install before reverse-dialer registration, clear on teardown alongside the existing CAS uninstall.
- `backend/src/services/MeshService.ts` — new private field `proxyTunnelSelfCentralNodeId`, public setter with non-null overwrite warn, new `mesh.proxy_tunnel.identify` activity type, updated `handleAccept` resolution order.

## Test plan

- [x] `npx vitest run mesh-proxy-tunnel-handler mesh-service` — 54 tests green.
- [x] `npx tsc --noEmit` clean.
- [x] `npx eslint` clean on touched files.
- [x] Code review feedback addressed (strict regex, overwrite warn, dedicated activity type, dropped test-only getter).
- [ ] Live verification on production fleet (Local + sencho-test-03 with audit-mesh stacks): reverse probe `docker exec audit-mesh-proxy-prober-1 sh -c 'sleep 4 | nc -w 5 echo.audit-mesh-central.Local.sencho 9000'` should deliver banner. Activity log on the proxy peer should show `route.dispatch cross-node` for the reverse probe (not `route.resolve.denied`).

## Notes

- Three pre-existing test flakes in `templates-deploy-rbac` and `filesystem-backup` are unrelated to mesh; they also fail on `main` at HEAD.
- F1 (empty-ports opt-in) and F2 (testUpstream uses ensureBridge) are queued as follow-up PRs.