### PR TITLE
fix(mesh): reject opt-in when every service has empty ports

### DIFF
--- a/backend/src/__tests__/mesh-service.test.ts
+++ b/backend/src/__tests__/mesh-service.test.ts
@@ -68,6 +68,26 @@ describe('MeshService.optInStack', () => {
             .rejects.toThrow(/port 5432 is already claimed/);
     });
 
+    it('rejects opt-in when every service declared empty ports (no routable target)', async () => {
+        const svc = MeshService.getInstance();
+        const db = DatabaseService.getInstance();
+        const localNodeId = db.getNodes()[0].id;
+
+        vi.spyOn(svc as unknown as { inspectStackServices: (n: number, s: string) => Promise<unknown> }, 'inspectStackServices')
+            .mockResolvedValue([
+                { service: 'web', ports: [] },
+                { service: 'db', ports: [] },
+            ]);
+        vi.spyOn(svc as unknown as { regenerateOverridesForNode: (n: number) => Promise<void> }, 'regenerateOverridesForNode')
+            .mockResolvedValue(undefined);
+
+        await expect(svc.optInStack(localNodeId, 'silent', 'tester'))
+            .rejects.toThrow(/no service ports to mesh/);
+        // Pre-fix this wrote a row with no aliases and the stack appeared
+        // "online but doesn't route". Verify the row was not written.
+        expect(db.isMeshStackEnabled(localNodeId, 'silent')).toBe(false);
+    });
+
     it('opt-out removes the row and the override', async () => {
         const svc = MeshService.getInstance();
         vi.spyOn(svc as unknown as { inspectStackServices: (n: number, s: string) => Promise<unknown> }, 'inspectStackServices')

--- a/backend/src/services/MeshService.ts
+++ b/backend/src/services/MeshService.ts
@@ -556,6 +556,12 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
 
         const newPorts = new Set<number>();
         for (const svc of services) for (const p of svc.ports) newPorts.add(p);
+        if (newPorts.size === 0) {
+            throw new MeshError(
+                'no_target',
+                `stack ${stackName} has no service ports to mesh (every service declared ports: [])`,
+            );
+        }
         if (newPorts.has(SENCHO_LISTEN_PORT)) {
             throw new MeshError(
                 'port_collision',


### PR DESCRIPTION
## Summary

- `MeshService.optInStack` now rejects with `no_target` when every service in the stack declared `ports: []`. Pre-fix, the empty `newPorts` Set sailed past collision checks, wrote a `mesh_stacks` row, and produced an empty-aliases override — the stack appeared online in the Routing tab but no traffic actually routed.
- Reuses the existing `MeshError('no_target', ...)` code so the frontend's error toast path is unchanged.

## Changes

- `backend/src/services/MeshService.ts` — 5-line check after building `newPorts`, before the `SENCHO_LISTEN_PORT` reservation guard.
- `backend/src/__tests__/mesh-service.test.ts` — one new test covering the empty-ports rejection and verifying no DB row is written.

## Test plan

- [x] `npx vitest run mesh-service` — 44 tests green.
- [x] `npx tsc --noEmit` clean.
- [x] `npx eslint` clean on touched files.

## Notes

Follow-up from the Phase C verification tracker. R1 (proxy peer dispatch namespace) and F2 (testUpstream uses ensureBridge) are queued as separate PRs.