### PR TITLE
fix(ui): close user dropdown after clicking menu actions

### DIFF
--- a/frontend/src/components/UserProfileDropdown.tsx
+++ b/frontend/src/components/UserProfileDropdown.tsx
@@ -52,6 +52,19 @@ export function UserProfileDropdown({ theme, setTheme, onOpenSettings }: UserPro
     const { logout, user, isAdmin } = useAuth();
     const { license } = useLicense();
     const [billingLoading, setBillingLoading] = useState(false);
+    const [open, setOpen] = useState(false);
+
+    const closeMenu = () => setOpen(false);
+
+    const handleOpenSettings = () => {
+        closeMenu();
+        onOpenSettings();
+    };
+
+    const handleLogout = () => {
+        closeMenu();
+        logout();
+    };
 
     const openBillingPortal = async () => {
         setBillingLoading(true);
@@ -67,6 +80,7 @@ export function UserProfileDropdown({ theme, setTheme, onOpenSettings }: UserPro
             toast.error('Failed to open billing portal.');
         } finally {
             setBillingLoading(false);
+            closeMenu();
         }
     };
 
@@ -75,7 +89,7 @@ export function UserProfileDropdown({ theme, setTheme, onOpenSettings }: UserPro
     const roleLabel = user?.role;
 
     return (
-        <Popover>
+        <Popover open={open} onOpenChange={setOpen}>
             <PopoverTrigger asChild>
                 <Button
                     variant="outline"
@@ -131,7 +145,7 @@ export function UserProfileDropdown({ theme, setTheme, onOpenSettings }: UserPro
 
                 {/* Navigation strip */}
                 <div className="border-t border-card-border/60">
-                    <MenuRow icon={Settings} label="Settings" onClick={onOpenSettings} />
+                    <MenuRow icon={Settings} label="Settings" onClick={handleOpenSettings} />
                     {showBilling ? (
                         <MenuRow
                             icon={CreditCard}
@@ -147,12 +161,14 @@ export function UserProfileDropdown({ theme, setTheme, onOpenSettings }: UserPro
                         label="Documentation"
                         href="https://docs.sencho.io"
                         external
+                        onClick={closeMenu}
                     />
                     <MenuRow
                         icon={MessageSquare}
                         label="Feedback"
                         href="https://github.com/studio-saelix/sencho/issues"
                         external
+                        onClick={closeMenu}
                     />
                 </div>
 
@@ -174,7 +190,7 @@ export function UserProfileDropdown({ theme, setTheme, onOpenSettings }: UserPro
                 <div className="border-t border-card-border/60">
                     <button
                         type="button"
-                        onClick={logout}
+                        onClick={handleLogout}
                         className="flex w-full items-center gap-2.5 px-[var(--density-row-x)] py-[var(--density-row-y)] text-left text-sm text-destructive transition-colors hover:bg-destructive/5 focus-visible:bg-destructive/5 focus-visible:outline-none"
                     >
                         <LogOut className="h-4 w-4" strokeWidth={1.5} />
@@ -235,6 +251,7 @@ function MenuRow({
                 href={href}
                 target={external ? '_blank' : undefined}
                 rel={external ? 'noopener noreferrer' : undefined}
+                onClick={onClick}
                 className={classes}
             >
                 {body}


### PR DESCRIPTION
## Summary

- Clicking Settings, Billing, Documentation, Feedback, or Log Out now dismisses the user-profile popover, matching standard menu UX.
- The Appearance theme toggle is intentionally excluded so users can preview themes without reopening the menu.
- Implemented by lifting the Radix Popover into controlled state and routing each action through a small `closeMenu()` helper. Billing closes in the `finally` block so the loading spinner stays visible during the API call.

## Test plan

- [x] Frontend typecheck (`npx tsc -b --noEmit`) passes
- [x] Manually verified in the browser:
  - Settings click closes menu, opens Settings
  - Documentation/Feedback link closes menu, opens link in new tab
  - Appearance theme toggle leaves menu open
  - Log Out closes menu, signs the user out
- [ ] Reviewer to spot-check Billing flow (active license required)

## Notes

Single-file change, scoped to `frontend/src/components/UserProfileDropdown.tsx`. Matches the existing controlled-popover pattern used in NotificationPanel, NodeSwitcher, NodeLabelPicker, FleetSnapshots, and the date picker.