### PR TITLE
fix(mesh): persist proxy-tunnel self-id across bridge teardown

### DIFF
--- a/backend/src/__tests__/mesh-proxy-tunnel-handler.test.ts
+++ b/backend/src/__tests__/mesh-proxy-tunnel-handler.test.ts
@@ -157,12 +157,91 @@ describe('handleMeshProxyTunnel', () => {
             const ws = await dialTunnel(srv.port, '?nodeId=14');
             await new Promise((r) => setTimeout(r, 20));
             expect((MeshService.getInstance() as unknown as { proxyTunnelSelfCentralNodeId: number | null }).proxyTunnelSelfCentralNodeId).toBe(14);
-
             ws.close(1000, 'test cleanup');
             await new Promise((r) => setTimeout(r, 30));
-            // Tunnel close clears the value.
-            expect((MeshService.getInstance() as unknown as { proxyTunnelSelfCentralNodeId: number | null }).proxyTunnelSelfCentralNodeId).toBeNull();
         } finally {
+            await srv.close();
+        }
+    });
+
+    it('the install persists across WS close (enrollment-stable, not per-bridge)', async () => {
+        // Null-clearing on teardown previously caused handleAccept to fall
+        // back to getDefaultNodeId() after idle close, misdispatching
+        // cross-fleet aliases to the same-node path.
+        const srv = await startServer();
+        try {
+            const ws = await dialTunnel(srv.port, '?nodeId=14');
+            await new Promise((r) => setTimeout(r, 20));
+            ws.close(1000, 'test cleanup');
+            await new Promise((r) => setTimeout(r, 30));
+            expect((MeshService.getInstance() as unknown as { proxyTunnelSelfCentralNodeId: number | null }).proxyTunnelSelfCentralNodeId).toBe(14);
+        } finally {
+            await srv.close();
+        }
+    });
+
+    it('re-opening the tunnel with the same nodeId is idempotent (no second identify event)', async () => {
+        const srv = await startServer();
+        const svc = MeshService.getInstance();
+        const identifyCount = () => svc.getActivity({ limit: 200 })
+            .filter((e) => e.type === 'mesh.proxy_tunnel.identify').length;
+        const waitForCount = async (atLeast: number, timeoutMs = 500): Promise<void> => {
+            const start = Date.now();
+            while (Date.now() - start < timeoutMs && identifyCount() < atLeast) {
+                await new Promise((r) => setTimeout(r, 5));
+            }
+        };
+        try {
+            const wsA = await dialTunnel(srv.port, '?nodeId=14');
+            // Snapshot after the first identify event has deterministically
+            // landed, so the race window between WS-open and async install
+            // can't make beforeCount=0 on a slow CI.
+            await waitForCount(1);
+            const beforeCount = identifyCount();
+            expect(beforeCount).toBeGreaterThanOrEqual(1);
+
+            wsA.close(1000, 'test cleanup');
+            await new Promise((r) => setTimeout(r, 30));
+
+            const wsB = await dialTunnel(srv.port, '?nodeId=14');
+            // Settle window for any (incorrect) second identify; small but
+            // deterministic because the assertion below is "no new event"
+            // and a longer wait wouldn't change the answer.
+            await new Promise((r) => setTimeout(r, 50));
+            expect((svc as unknown as { proxyTunnelSelfCentralNodeId: number | null }).proxyTunnelSelfCentralNodeId).toBe(14);
+            expect(identifyCount()).toBe(beforeCount);
+
+            wsB.close(1000, 'test cleanup');
+            await new Promise((r) => setTimeout(r, 30));
+        } finally {
+            await srv.close();
+        }
+    });
+
+    it('re-opening the tunnel with a different nodeId emits the overwrite warn (re-enrollment signal)', async () => {
+        const srv = await startServer();
+        const warns: string[] = [];
+        const origWarn = console.warn;
+        console.warn = (...args: unknown[]) => { warns.push(args.map(String).join(' ')); };
+        try {
+            const wsA = await dialTunnel(srv.port, '?nodeId=14');
+            await new Promise((r) => setTimeout(r, 20));
+            wsA.close(1000, 'test cleanup');
+            await new Promise((r) => setTimeout(r, 30));
+
+            const wsB = await dialTunnel(srv.port, '?nodeId=15');
+            await new Promise((r) => setTimeout(r, 20));
+            const svc = MeshService.getInstance();
+            expect((svc as unknown as { proxyTunnelSelfCentralNodeId: number | null }).proxyTunnelSelfCentralNodeId).toBe(15);
+
+            const overwriteWarns = warns.filter((w) => w.includes('proxyTunnelSelfCentralNodeId overwritten'));
+            expect(overwriteWarns.length).toBeGreaterThanOrEqual(1);
+            expect(overwriteWarns[overwriteWarns.length - 1]).toContain('14 -> 15');
+
+            wsB.close(1000, 'test cleanup');
+            await new Promise((r) => setTimeout(r, 30));
+        } finally {
+            console.warn = origWarn;
             await srv.close();
         }
     });

--- a/backend/src/websocket/meshProxyTunnel.ts
+++ b/backend/src/websocket/meshProxyTunnel.ts
@@ -114,14 +114,19 @@ async function attachSwitchboard(ws: WebSocket, peerNodeId: number | null): Prom
         // Install central's view of this peer's nodeId so handleAccept
         // dispatches cross-node aliases correctly. Done after setReverseDialer
         // succeeds so a CAS-rejected tunnel does not leak nodeId state.
+        //
+        // The install persists across bridge lifecycles: the peer's identity
+        // in central's namespace is stable for the enrollment, not per-WS.
+        // Null-clearing on teardown caused dispatch to fall back to
+        // getDefaultNodeId() after idle close, which collides with central's
+        // own nodeId for Local and misdispatches cross-fleet traffic to the
+        // same-node path. A subsequent install with a different nodeId
+        // (e.g. re-enrollment) is detected by the setter's overwrite-warn.
         if (peerNodeId !== null) {
             meshService.setProxyTunnelSelfCentralNodeId(peerNodeId);
         }
         meshServiceCleanup = () => {
             meshService.setReverseDialer(null, localDialer);
-            if (peerNodeId !== null) {
-                meshService.setProxyTunnelSelfCentralNodeId(null);
-            }
         };
     } catch (err) {
         if (isDebugEnabled()) {


### PR DESCRIPTION
## Summary

- Stop null-clearing `MeshService.proxyTunnelSelfCentralNodeId` on proxy-tunnel WS teardown. The peer's identity in central's namespace is enrollment-stable, not per-WS lifecycle.
- Update existing test assertion to expect persistence; add two new tests for the close-reopen lifecycle (same-id idempotent, different-id triggers overwrite warn).
- Update `docs/internal/architecture/mesh.md` to document the new lifecycle contract.

## Why

After PR #1055 shipped R1 (proxy peer learns its central-namespace nodeId from the proxy-tunnel WS `?nodeId=` query param) and we deployed v0.78.0, the reverse-direction probe still intermittently failed with the same v0.77.1 signature: TCP open + no banner, `route.resolve.denied: cannot resolve container IP` on the peer activity log.

Diagnosis: R1's install was scoped to the WS lifetime. The proxy-mode WS handler null-cleared `proxyTunnelSelfCentralNodeId` in the same cleanup callback that unregistered the reverse dialer. After an idle close (default 5 min, configurable via `SENCHO_MESH_PROXY_TUNNEL_IDLE_MS`), `handleAccept`'s self-id resolution fell back to `selfCentralNodeId ?? getDefaultNodeId()`. For proxy peers without `SENCHO_ENROLL_TOKEN`, `getDefaultNodeId()` returns `1` (the peer's own local DB id), which collided with central's nodeId for Local (=1 in the alias overlay), causing the comparison to take the same-node path and `openSameNode` to call `resolveContainerIp` for a stack that lives on a different node.

The peer's central-namespace nodeId only changes if the operator re-enrolls the peer with a different id. The setter already emits a `console.warn` overwrite signal when that happens. Persistence across bridge lifecycles is the correct contract.

## Test plan

- [x] `cd backend && npx tsc --noEmit` clean
- [x] `npx vitest run src/__tests__/mesh-proxy-tunnel-handler.test.ts` passes (12 tests, was 11 before; +1 from splitting the flipped assertion into its own block, +2 new lifecycle tests)
- [x] `npx vitest run src/__tests__/mesh-*.test.ts` passes (99 mesh tests)
- [x] Full backend suite passes (2167 tests; 1 pre-existing Windows EBUSY flake in `filesystem-backup.test.ts` unrelated to this change)
- [x] Symptom reproduced on v0.78.0 production fleet: reverse probe got TCP open + no banner after the first bridge idle close (workaround proves this is the cause: setting `SENCHO_MESH_PROXY_TUNNEL_IDLE_MS=0` kept the bridge warm and the reverse probe returned banner `CENTRAL-HELLO`). The fix removes the workaround dependency.
- [ ] Live verification with the fix deployed (next image build + fleet pull) still owed.

## Notes

- The `setReverseDialer(null, localDialer)` call on cleanup stays. The reverse-dialer slot IS per-WS (a new WS installs a new dialer) and must clear when the WS dies. Only the nodeId install changes.
- Re-enrollment to a different central nodeId (e.g., operator deletes node 5, re-adds as node 7) is handled by the existing setter `console.warn` overwrite signal. A regression test now exercises this path explicitly.
- A separate follow-up (R1-B) is to add a `route.resolve.ok`-equivalent activity event on inbound `tcp_open_reverse` so reverse-direction traffic shows up in `/api/mesh/activity` on central. Pure observability, no behavior change. Not included in this PR.