### PR TITLE
fix(security-ui): expose Community-tier scan surfaces per PR #930

### DIFF
--- a/frontend/src/components/EditorLayout/EditorView.tsx
+++ b/frontend/src/components/EditorLayout/EditorView.tsx
@@ -399,7 +399,7 @@ export function EditorView({
                                         </Button>
                                         {(() => {
                                             const canRollback = isPaid && backupInfo.exists;
-                                            const canScan = trivy.available && isAdmin && isPaid;
+                                            const canScan = trivy.available && isAdmin;
                                             const hasOverflowExtras = canRollback || canScan;
                                             return (
                                                 <DropdownMenu>

--- a/frontend/src/components/ResourcesView.tsx
+++ b/frontend/src/components/ResourcesView.tsx
@@ -732,7 +732,7 @@ export default function ResourcesView() {
                             </TabsHighlightItem>
                         </TabsHighlight>
                     </TabsList>
-                    {trivy.available && isPaid && (
+                    {trivy.available && (
                         <Button
                             variant="outline"
                             size="sm"
@@ -836,13 +836,11 @@ export default function ResourcesView() {
                                                                 >
                                                                     Scan (vulnerabilities)
                                                                 </DropdownMenuItem>
-                                                                {isPaid && (
-                                                                    <DropdownMenuItem
-                                                                        onClick={() => handleScanImage(img.RepoTags![0], { scanners: ['vuln', 'secret'] })}
-                                                                    >
-                                                                        Full scan (vulnerabilities + secrets)
-                                                                    </DropdownMenuItem>
-                                                                )}
+                                                                <DropdownMenuItem
+                                                                    onClick={() => handleScanImage(img.RepoTags![0], { scanners: ['vuln', 'secret'] })}
+                                                                >
+                                                                    Full scan (vulnerabilities + secrets)
+                                                                </DropdownMenuItem>
                                                             </DropdownMenuContent>
                                                         </DropdownMenu>
                                                     )}
@@ -1304,8 +1302,8 @@ export default function ResourcesView() {
                 onClose={() => setInspectScanId(null)}
                 onRescan={(imageRef) => { setInspectScanId(null); handleScanImage(imageRef, { force: true }); }}
                 canGenerateSbom={isPaid}
-                canCompare={isPaid}
-                canManageSuppressions={isPaid && isAdmin}
+                canCompare
+                canManageSuppressions={isAdmin}
             />
         </div>
     );

--- a/frontend/src/components/SecurityHistoryView.tsx
+++ b/frontend/src/components/SecurityHistoryView.tsx
@@ -157,12 +157,12 @@ export function SecurityHistoryView({ open, onClose }: SecurityHistoryViewProps)
       crumb={['Security', 'Scan history']}
       name="Scan history"
       meta={meta}
-      primaryAction={isPaid ? {
+      primaryAction={{
         label: `Compare (${selected.length}/2)`,
         icon: GitCompare,
         onClick: compareSelected,
         disabled: compareDisabled,
-      } : undefined}
+      }}
       secondaryActions={[{
         label: 'Refresh',
         icon: RefreshCw,
@@ -316,7 +316,7 @@ export function SecurityHistoryView({ open, onClose }: SecurityHistoryViewProps)
         onClose={() => setInspectScanId(null)}
         canGenerateSbom={isPaid}
         canCompare={false}
-        canManageSuppressions={isPaid && isAdmin}
+        canManageSuppressions={isAdmin}
       />
     </SystemSheet>
   );

--- a/frontend/src/components/__tests__/SecurityHistoryView.test.tsx
+++ b/frontend/src/components/__tests__/SecurityHistoryView.test.tsx
@@ -211,7 +211,7 @@ describe('SecurityHistoryView', () => {
     expect(mockedFetch).toHaveBeenCalledTimes(1);
   });
 
-  it('hides Compare button for community tier', async () => {
+  it('shows Compare button for community tier (scan compare is Community per PR #930)', async () => {
     licenseState.isPaid = false;
     mockedFetch.mockResolvedValue(
       listResponse([
@@ -226,6 +226,6 @@ describe('SecurityHistoryView', () => {
     await user.click(checkboxes[0]);
     await user.click(checkboxes[1]);
 
-    expect(screen.queryByRole('button', { name: /Compare/ })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Compare \(2\/2\)/ })).toBeEnabled();
   });
 });


### PR DESCRIPTION
## Summary

PR #930 opened the backend security routes (`/scan`, `/scan/stack`, `/suppressions/*`, `/misconfig-acks/*`, `/scans/*`, `/compare`) to Community admins, but several frontend `isPaid` gates were not flipped in the same pass. Result: the API would accept Community-tier requests, but the UI hid the triggers. This PR closes that gap.

## What flipped

| File | Change | Reason |
|---|---|---|
| `ResourcesView.tsx` | Scan history button `trivy.available && isPaid` → `trivy.available` | `/scans/*` is Community per PR #930 |
| `ResourcesView.tsx` | Full scan (vulnerabilities + secrets) menu item: drop `{isPaid && ...}` wrapper | `/scan` accepts the `secret` scanner for Community |
| `ResourcesView.tsx` | `canCompare={isPaid}` → `canCompare` | `/compare` is Community |
| `ResourcesView.tsx` | `canManageSuppressions={isPaid && isAdmin}` → `canManageSuppressions={isAdmin}` | suppression + ack endpoints are admin-only, no tier gate |
| `EditorLayout/EditorView.tsx` | `canScan = trivy.available && isAdmin && isPaid` → drop `isPaid` | `/scan/stack` is Community |
| `SecurityHistoryView.tsx` | `primaryAction={isPaid ? {...} : undefined}` → always render the Compare action | same as above |
| `SecurityHistoryView.tsx` | `canManageSuppressions={isPaid && isAdmin}` → `canManageSuppressions={isAdmin}` | same |

## What stays paid (unchanged)

- `canGenerateSbom={isPaid}` in both `ResourcesView` and `SecurityHistoryView` — SBOM endpoint stays `requirePaid` per PR #930.
- SARIF download in the scan drawer overflow — backend stays `requirePaid`.
- Scan Policies block in `Settings → Security` — backend stays `requirePaid`.
- Trivy auto-update toggle — stays `requireAdmiral`.

## Test plan

- [x] `cd frontend && npx tsc -b --noEmit` clean
- [x] `cd frontend && npm run lint` clean (no new warnings)
- [x] `cd frontend && npx vitest run` 238/238 passing, including the inverted Community-tier Compare-button assertion in `SecurityHistoryView.test.tsx`
- [x] `cd backend && npx vitest run` 2260/2260 passing for the changed paths (one pre-existing Windows-only EBUSY flake in `filesystem-backup.test.ts`, reproducible on `origin/main`, unrelated)
- [ ] Manual Community-license sweep recommended at review time:
  - Resources Hub → image row → shield icon → both "Scan (vulnerabilities)" and "Full scan (vulnerabilities + secrets)" appear
  - Resources Hub → "Scan history" button visible when Trivy is available
  - Scan history sheet → Compare primary action visible; ticking two scans enables it
  - Scan drawer → Compare in header, Suppress + Acknowledge on rows for admin
  - Stack overflow menu → "Scan config" visible for admin with Trivy
  - Settings → Security → SBOM/SARIF download buttons NOT visible, Scan Policies block NOT visible
  - App Store deploy sheet → auto-scan toggle visible when Trivy is available

## Notes

This is a UI-only follow-up; no backend, no schema, no test infrastructure changes. The diff is 4 files, +14/-16.