### PR TITLE
fix(mesh): peer-initiated callback bridge installs reverse dialer

### DIFF
--- a/backend/src/__tests__/peer-to-central-mesh-session-dialer.test.ts
+++ b/backend/src/__tests__/peer-to-central-mesh-session-dialer.test.ts
@@ -21,7 +21,7 @@
 import http from 'http';
 import type { AddressInfo } from 'net';
 import { WebSocketServer, type WebSocket as WsClient } from 'ws';
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { setupTestDb, cleanupTestDb } from './helpers/setupTestDb';
 
 let tmpDir: string;
@@ -236,6 +236,11 @@ describe('PeerToCentralMeshSessionDialer', () => {
             });
             switchboard = await PeerToCentralMeshSessionDialer.getInstance().ensureSession();
             expect(switchboard).not.toBeNull();
+            // The R1-A2 design puts a TcpStreamSwitchboard on the peer end of
+            // this WS, not a PilotTunnelBridge (which is central's role). A
+            // future regression that returns the wrong shape would surface
+            // here before the more abstract reverseDialer-installed check.
+            expect(switchboard).toBeInstanceOf(TcpStreamSwitchboardCtor);
             expect(PeerToCentralMeshSessionDialer.getInstance().hasSession()).toBe(true);
             // markUsed is called synchronously inside attachSwitchboard before
             // ensureSession resolves, so the DB row reflects it immediately.

--- a/backend/src/__tests__/peer-to-central-mesh-session-dialer.test.ts
+++ b/backend/src/__tests__/peer-to-central-mesh-session-dialer.test.ts
@@ -20,7 +20,7 @@
  */
 import http from 'http';
 import type { AddressInfo } from 'net';
-import { WebSocketServer } from 'ws';
+import { WebSocketServer, type WebSocket as WsClient } from 'ws';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { setupTestDb, cleanupTestDb } from './helpers/setupTestDb';
 
@@ -28,7 +28,8 @@ let tmpDir: string;
 let PeerToCentralMeshSessionDialer: typeof import('../services/PeerToCentralMeshSessionDialer').PeerToCentralMeshSessionDialer;
 let MeshCentralRegistry: typeof import('../services/MeshCentralRegistry').MeshCentralRegistry;
 let DatabaseService: typeof import('../services/DatabaseService').DatabaseService;
-let PilotTunnelBridge: typeof import('../services/PilotTunnelBridge').PilotTunnelBridge;
+let TcpStreamSwitchboardCtor: typeof import('../mesh/tcpStreamSwitchboard').TcpStreamSwitchboard;
+let MeshService: typeof import('../services/MeshService').MeshService;
 
 interface RejectingServer {
     server: http.Server;
@@ -79,7 +80,8 @@ beforeAll(async () => {
     ({ PeerToCentralMeshSessionDialer } = await import('../services/PeerToCentralMeshSessionDialer'));
     ({ MeshCentralRegistry } = await import('../services/MeshCentralRegistry'));
     ({ DatabaseService } = await import('../services/DatabaseService'));
-    ({ PilotTunnelBridge } = await import('../services/PilotTunnelBridge'));
+    ({ TcpStreamSwitchboard: TcpStreamSwitchboardCtor } = await import('../mesh/tcpStreamSwitchboard'));
+    ({ MeshService } = await import('../services/MeshService'));
 });
 
 afterAll(() => {
@@ -207,7 +209,7 @@ describe('PeerToCentralMeshSessionDialer', () => {
         }
     });
 
-    it('marks the row used on successful WS open', async () => {
+    it('marks the row used on successful WS open and installs a reverseDialer', async () => {
         const wss = new WebSocketServer({ noServer: true });
         const srv = http.createServer();
         srv.on('upgrade', (req, socket, head) => {
@@ -220,7 +222,10 @@ describe('PeerToCentralMeshSessionDialer', () => {
         await new Promise<void>((resolve) => srv.listen(0, '127.0.0.1', () => resolve()));
         const port = (srv.address() as AddressInfo).port;
         const url = `http://127.0.0.1:${port}`;
-        let bridge: InstanceType<typeof PilotTunnelBridge> | null = null;
+        // Start with a clean reverseDialer slot on the local MeshService so
+        // setReverseDialer's CAS swap succeeds inside attachSwitchboard.
+        MeshService.getInstance().setReverseDialer(null);
+        let switchboard: InstanceType<typeof TcpStreamSwitchboardCtor> | null = null;
         try {
             MeshCentralRegistry.getInstance().upsert({
                 centralInstanceId: 'inst-success',
@@ -229,14 +234,29 @@ describe('PeerToCentralMeshSessionDialer', () => {
                 jwtIssuedAt: 1,
                 jwtExpiresAt: 9999999999,
             });
-            bridge = await PeerToCentralMeshSessionDialer.getInstance().ensureSession();
-            expect(bridge).toBeInstanceOf(PilotTunnelBridge);
-            await vi.waitFor(() => {
-                expect(MeshCentralRegistry.getInstance().getActive()?.lastUsedAt ?? 0).toBeGreaterThan(0);
-            });
+            switchboard = await PeerToCentralMeshSessionDialer.getInstance().ensureSession();
+            expect(switchboard).not.toBeNull();
             expect(PeerToCentralMeshSessionDialer.getInstance().hasSession()).toBe(true);
+            // markUsed is called synchronously inside attachSwitchboard before
+            // ensureSession resolves, so the DB row reflects it immediately.
+            expect(MeshCentralRegistry.getInstance().getActive()?.lastUsedAt ?? 0).toBeGreaterThan(0);
+            // The R1-A2 wiring under test: MeshService.reverseDialer must be
+            // populated so MeshService.dialMeshTcpStream routes peer-side
+            // cross-fleet traffic through this callback bridge instead of
+            // falling through to PilotTunnelManager.ensureBridge(centralId),
+            // which has no record for central on a proxy peer.
+            const meshSvc = MeshService.getInstance() as unknown as { reverseDialer: unknown };
+            expect(meshSvc.reverseDialer).not.toBeNull();
         } finally {
-            try { bridge?.close(1000, 'test done'); } catch { /* ignore */ }
+            try { switchboard?.cleanup('test done'); } catch { /* ignore */ }
+            // The dialer owns the client-side WS and the switchboard doesn't
+            // close it on cleanup; tear it down explicitly so wss.close can
+            // resolve (it waits for all client connections to disconnect).
+            try {
+                const inst = PeerToCentralMeshSessionDialer.getInstance() as unknown as { currentWs: WsClient | null };
+                inst.currentWs?.close(1000, 'test done');
+            } catch { /* ignore */ }
+            MeshService.getInstance().setReverseDialer(null);
             await new Promise<void>((resolve) => wss.close(() => resolve()));
             await new Promise<void>((resolve) => srv.close(() => resolve()));
         }

--- a/backend/src/services/PeerToCentralMeshSessionDialer.ts
+++ b/backend/src/services/PeerToCentralMeshSessionDialer.ts
@@ -21,12 +21,27 @@
  */
 import { EventEmitter } from 'events';
 import WebSocket from 'ws';
-import { MAX_FRAME_SIZE_BYTES } from '../pilot/protocol';
+import {
+    MAX_FRAME_SIZE_BYTES,
+    decodeBinaryFrame,
+    decodeJsonFrame,
+    wsDataToBuffer,
+    wsDataToString,
+} from '../pilot/protocol';
 import { MeshCentralRegistry } from './MeshCentralRegistry';
-import { PilotTunnelBridge } from './PilotTunnelBridge';
+import {
+    attachTcpStreamSwitchboard,
+    resolveByComposeLabels,
+    type TcpStreamSwitchboard,
+    type ReverseTcpStreamHandle,
+} from '../mesh/tcpStreamSwitchboard';
 import { PilotMetrics } from './PilotMetrics';
 import { httpUrlToWs } from '../utils/wsUrl';
 import { sanitizeForLog } from '../utils/safeLog';
+
+interface CallbackReverseDialer {
+    openMeshTcpStream(target: { nodeId: number; stack: string; service: string; port: number }): ReverseTcpStreamHandle | null;
+}
 
 const HANDSHAKE_TIMEOUT_MS = 15_000;
 const RATE_LIMIT_WINDOW_MS = 60_000;
@@ -59,8 +74,9 @@ interface DialError extends Error {
 
 export class PeerToCentralMeshSessionDialer extends EventEmitter {
     private static instance: PeerToCentralMeshSessionDialer | null = null;
-    private currentSession: PilotTunnelBridge | null = null;
-    private inflight: Promise<PilotTunnelBridge | null> | null = null;
+    private currentSession: TcpStreamSwitchboard | null = null;
+    private currentWs: WebSocket | null = null;
+    private inflight: Promise<TcpStreamSwitchboard | null> | null = null;
     private recentDials: number[] = [];
     private endpointUnavailableUntil = 0;
 
@@ -73,7 +89,8 @@ export class PeerToCentralMeshSessionDialer extends EventEmitter {
 
     public static resetForTest(): void {
         if (this.instance) {
-            try { this.instance.currentSession?.close(1000, 'test reset'); } catch { /* ignore */ }
+            try { this.instance.currentSession?.cleanup('test reset'); } catch { /* ignore */ }
+            try { this.instance.currentWs?.close(1000, 'test reset'); } catch { /* ignore */ }
         }
         this.instance = null;
     }
@@ -82,7 +99,7 @@ export class PeerToCentralMeshSessionDialer extends EventEmitter {
         return this.currentSession !== null;
     }
 
-    public async ensureSession(): Promise<PilotTunnelBridge | null> {
+    public async ensureSession(): Promise<TcpStreamSwitchboard | null> {
         if (this.currentSession) return this.currentSession;
         if (Date.now() < this.endpointUnavailableUntil) return null;
         if (this.isRateLimited()) return null;
@@ -97,7 +114,7 @@ export class PeerToCentralMeshSessionDialer extends EventEmitter {
         return this.recentDials.length >= RATE_LIMIT_MAX;
     }
 
-    private async dial(): Promise<PilotTunnelBridge | null> {
+    private async dial(): Promise<TcpStreamSwitchboard | null> {
         const material = MeshCentralRegistry.getInstance().getActive();
         if (!material) return null;
         this.recentDials.push(Date.now());
@@ -115,25 +132,100 @@ export class PeerToCentralMeshSessionDialer extends EventEmitter {
             this.handleDialFailure(err, material.centralInstanceId);
             return null;
         }
-        return this.attachBridge(ws, material.centralInstanceId);
+        return this.attachSwitchboard(ws, material.centralInstanceId);
     }
 
-    private async attachBridge(ws: WebSocket, instanceId: string): Promise<PilotTunnelBridge | null> {
-        const bridge = new PilotTunnelBridge(0, ws);
+    /**
+     * Wire the peer-initiated callback WS into the local MeshService. The
+     * R1-A2 design puts the peer end of the bridge in TcpStreamSwitchboard
+     * mode (peer multiplexes streams; central side runs PilotTunnelBridge).
+     * Without this wiring the WS opens cleanly but MeshService.reverseDialer
+     * stays null, so MeshService.dialMeshTcpStream falls through to
+     * PilotTunnelManager.ensureBridge(centralNodeId), which has no record
+     * for central on a proxy-mode peer (peers do not enroll central) and
+     * fails with proxy-tunnel.open.fail reason=no_target. End state matches
+     * the v0.78.1 reverse-direction failure even though the callback bridge
+     * is alive.
+     *
+     * Wiring symmetric to the central-initiated handler at
+     * `meshProxyTunnel.ts:115-163`:
+     *   - attachTcpStreamSwitchboard with the same compose-label resolver
+     *   - SwitchboardReverseDialer that delegates to switchboard.openReverseStream
+     *   - setReverseDialer(localDialer, null) with CAS so a concurrent
+     *     central-initiated tunnel does not get silently overwritten
+     *   - ws.on('message') dispatches JSON/binary frames to the switchboard
+     *   - ws.on('close'/'error') tears down switchboard + clears reverseDialer
+     */
+    private async attachSwitchboard(ws: WebSocket, instanceId: string): Promise<TcpStreamSwitchboard | null> {
+        let switchboard: TcpStreamSwitchboard;
         try {
-            await bridge.start();
-        } catch {
-            try { bridge.close(1011, 'bridge start failed'); } catch { /* ignore */ }
+            switchboard = attachTcpStreamSwitchboard({
+                ws,
+                resolveTarget: resolveByComposeLabels,
+                logLabel: 'MeshCallback',
+            });
+        } catch (err) {
+            try { ws.close(1011, 'switchboard attach failed'); } catch { /* ignore */ }
+            PilotMetrics.increment('mesh_callback_dials_failed_total');
+            console.warn(`[PeerToCentralMeshSessionDialer] attach failed: ${sanitizeForLog((err as Error).message)}`);
+            return null;
+        }
+
+        const { MeshService } = await import('./MeshService');
+        const meshService = MeshService.getInstance();
+        const localDialer: CallbackReverseDialer = {
+            openMeshTcpStream(target) {
+                return switchboard.openReverseStream(target);
+            },
+        };
+        const installed = meshService.setReverseDialer(localDialer, null);
+        if (!installed) {
+            console.warn('[PeerToCentralMeshSessionDialer] reverse dialer already installed; rejecting concurrent callback bridge');
+            switchboard.cleanup('reverse dialer already installed');
+            try { ws.close(1013, 'reverse dialer already installed'); } catch { /* ignore */ }
             PilotMetrics.increment('mesh_callback_dials_failed_total');
             return null;
         }
-        bridge.once('closed', () => {
-            if (this.currentSession === bridge) this.currentSession = null;
+
+        const onMessage = (data: unknown, isBinary: boolean): void => {
+            try {
+                if (isBinary) {
+                    const buf = wsDataToBuffer(data);
+                    if (!buf) return;
+                    switchboard.handleBinaryFrame(decodeBinaryFrame(buf));
+                    return;
+                }
+                const text = wsDataToString(data);
+                if (text == null) return;
+                switchboard.handleJsonFrame(decodeJsonFrame(text));
+            } catch (err) {
+                console.warn(`[PeerToCentralMeshSessionDialer] malformed frame: ${sanitizeForLog((err as Error).message)}`);
+            }
+        };
+
+        let tornDown = false;
+        const teardown = (): void => {
+            if (tornDown) return;
+            tornDown = true;
+            ws.off('message', onMessage);
+            try { switchboard.cleanup('mesh callback bridge closed'); } catch { /* ignore */ }
+            meshService.setReverseDialer(null, localDialer);
+            if (this.currentSession === switchboard) this.currentSession = null;
+            if (this.currentWs === ws) this.currentWs = null;
+        };
+
+        ws.on('message', onMessage);
+        ws.once('close', teardown);
+        ws.once('error', (err) => {
+            console.warn(`[PeerToCentralMeshSessionDialer] ws error: ${sanitizeForLog(err.message)}`);
+            teardown();
         });
-        this.currentSession = bridge;
+
+        this.currentSession = switchboard;
+        this.currentWs = ws;
         PilotMetrics.increment('mesh_central_bootstraps_total');
         MeshCentralRegistry.getInstance().markUsed(instanceId);
-        return bridge;
+        return switchboard;
     }
 
     private awaitOpen(ws: WebSocket): Promise<void> {

--- a/backend/src/services/PeerToCentralMeshSessionDialer.ts
+++ b/backend/src/services/PeerToCentralMeshSessionDialer.ts
@@ -39,7 +39,7 @@ import { PilotMetrics } from './PilotMetrics';
 import { httpUrlToWs } from '../utils/wsUrl';
 import { sanitizeForLog } from '../utils/safeLog';
 
-interface CallbackReverseDialer {
+interface SwitchboardReverseDialer {
     openMeshTcpStream(target: { nodeId: number; stack: string; service: string; port: number }): ReverseTcpStreamHandle | null;
 }
 
@@ -173,7 +173,7 @@ export class PeerToCentralMeshSessionDialer extends EventEmitter {
 
         const { MeshService } = await import('./MeshService');
         const meshService = MeshService.getInstance();
-        const localDialer: CallbackReverseDialer = {
+        const localDialer: SwitchboardReverseDialer = {
             openMeshTcpStream(target) {
                 return switchboard.openReverseStream(target);
             },


### PR DESCRIPTION
## Summary

- The R1-A2 peer-initiated callback path opens the WS to central and persists `mesh_centrals` correctly, but the peer-side handler builds a `PilotTunnelBridge` (the central-role object) instead of a `TcpStreamSwitchboard` with a registered `reverseDialer`.
- Result: `MeshService.reverseDialer` stays null after `ensureSession`. `dialMeshTcpStream` falls through to `PilotTunnelManager.ensureBridge(target.nodeId)`, which calls `NodeRegistry.getProxyTarget` on the peer's local `nodes` table. Proxy peers do not enroll their central, so `getProxyTarget=null` and dispatch fails with `proxy-tunnel.open.fail reason=no_target` even though the callback bridge is up and healthy.
- Fix mirrors the wiring already present in the central-initiated handler at `meshProxyTunnel.ts:115-163`: attach a switchboard, register a `SwitchboardReverseDialer` via `setReverseDialer` (CAS-guarded), wire the WS message handler, and tear everything down on close.

## Symptom on production

Discovered during v0.81.1 live verification of the reverse direction (lazy-redemption path). Bridge idle-closed cleanly at 22:44:44Z. Peer's `centralCallback` diag showed `bridgeOpen: true`, `lastDialOkAt > 0`, `mesh_centrals.last_used_at` updated. The callback redemption succeeded in isolation. But the data dispatch never used it:

```
peer activity log (test-03), reverse probe at 23:05:04Z:
  route.dispatch        cross-node to echo.audit-mesh-central.Local.sencho on node 1
  proxy-tunnel.open.fail nodeId=1 reason=no_target  "no proxy target configured"
  tunnel.fail           "no mesh tunnel reachable for node 1"
```

The peer container's TCP open returned `(172.30.0.2:9000) open` then closed with no banner. Same end-state as the v0.78.1 reverse-direction break, even though R1-A2 implementation shipped in v0.81.0 and the v0.81.1 fix for the forward direction was unrelated.

## Root cause

Comparing the two peer-side WS handlers:

**Central-initiated** (`backend/src/websocket/meshProxyTunnel.ts:115-163`):
```ts
const switchboard = attachTcpStreamSwitchboard({ ws, resolveTarget: resolveByComposeLabels, ... });
const localDialer: SwitchboardReverseDialer = {
    openMeshTcpStream(target) { return switchboard.openReverseStream(target); },
};
meshService.setReverseDialer(localDialer, null);  // <-- DISPATCH WIRED
```

**Peer-initiated** (pre-fix `backend/src/services/PeerToCentralMeshSessionDialer.ts:121-137`):
```ts
const bridge = new PilotTunnelBridge(0, ws);     // <-- wrong role
await bridge.start();
this.currentSession = bridge;                     // <-- not wired to MeshService
```

The peer-initiated path put the wrong role object on the WS and never called `setReverseDialer`. The `currentSession` field was orphaned: nothing on the dispatch path knew about it.

## Fix shape

Replace the peer-side `PilotTunnelBridge` with the same wiring the central-initiated handler uses. The asymmetric protocol (central=PilotTunnelBridge, peer=TcpStreamSwitchboard) per the R1-A2 design doc is preserved on both directions of the WS handshake.

Concretely in `PeerToCentralMeshSessionDialer.attachSwitchboard` (renamed from `attachBridge`):

- `attachTcpStreamSwitchboard({ ws, resolveTarget: resolveByComposeLabels, logLabel: 'MeshCallback' })`
- `SwitchboardReverseDialer` delegating `openMeshTcpStream` to `switchboard.openReverseStream`
- `meshService.setReverseDialer(localDialer, null)` with CAS guard
- `ws.on('message', onMessage)` dispatching to `switchboard.handleJsonFrame` / `handleBinaryFrame`
- `ws.once('close'/'error', teardown)` clears switchboard, reverseDialer, and `currentSession` idempotently
- `currentWs` field stored alongside so `resetForTest` can close the WS (switchboard.cleanup does not)

`currentSession` field type changes from `PilotTunnelBridge | null` to `TcpStreamSwitchboard | null`. Callers (currently only `MeshService.openCrossNode`'s peer-recovery branch) use the return value only for truthiness; the change is binary-compatible.

## Why pre-merge testing missed this

The existing `peer-to-central-mesh-session-dialer.test.ts` "marks the row used on successful WS open" case asserted `expect(bridge).toBeInstanceOf(PilotTunnelBridge)`. That assertion was satisfied by the wrong object, which is precisely why it passed. The test never checked whether `MeshService.reverseDialer` was actually installed downstream, so the missing wiring was not visible from any unit test in the suite.

The integration tests in `mesh-bootstrap-integration.test.ts` stubbed the callback path at a higher level (via test doubles) and did not exercise the real `attachBridge` flow.

The fix updates the test to assert the new shape:

- return value is a `TcpStreamSwitchboard`
- `hasSession()` true
- `mesh_centrals.lastUsedAt` populated
- **`MeshService.reverseDialer` non-null** — the missing assertion that would have caught the regression

## Test plan

- [x] `cd backend && npx tsc --noEmit` clean
- [x] `cd backend && npx vitest run mesh` — 23 mesh test files, 170 tests green
- [x] `cd backend && npx vitest run` full backend suite — 2259/2268 green; only the pre-existing Windows EBUSY flake in `filesystem-backup.test.ts` fails (documented in the v0.81.1 PR handoff)
- [ ] After this ships, re-run the v0.81.x mesh verification runbook: Phase 4 reverse probe should return `CENTRAL-HELLO`, peer's activity log should show `route.dispatch` followed by `route.resolve.ok` (R1-B reverse event), no `proxy-tunnel.open.fail reason=no_target`

## Notes

Caught during the v0.81.1 live verification of the symmetric-callback path. Phases 0-3 passed cleanly; Phase 4 (lazy reverse redemption) surfaced this gap. v0.81.1's `openCrossNode` central-side regression fix was a separate concern and remains correct as shipped. Verification will resume after this lands and a patch release deploys.