### PR TITLE
fix(mesh): persist rotated handshake when peer bridge owns reverse-dialer slot

### DIFF
--- a/backend/src/__tests__/mesh-proxy-tunnel-first-frame.test.ts
+++ b/backend/src/__tests__/mesh-proxy-tunnel-first-frame.test.ts
@@ -184,4 +184,44 @@ describe('meshProxyTunnel first-frame state machine', () => {
             await srv.close();
         }
     });
+
+    it('persists mesh_handshake material even when reverse-dialer CAS rejects the bridge', async () => {
+        // Simulate a peer-initiated callback bridge that already owns the
+        // reverseDialer slot. Central's Trigger-2 dial then arrives with a
+        // rotated mesh_handshake frame; the CAS swap must refuse the new
+        // bridge, but the bootstrap material has to land on the peer
+        // anyway so subsequent peer-initiated callbacks authenticate with
+        // the rotated JWT.
+        MeshService.getInstance().setReverseDialer({
+            openMeshTcpStream: () => null,
+        });
+
+        const srv = await startServer();
+        try {
+            const ws = await dialTunnel(srv.port, '?nodeId=7');
+
+            const expiresAt = Math.floor(Date.now() / 1000) + 7200;
+            const closeInfo = new Promise<{ code: number }>((resolve) => {
+                ws.once('close', (code) => resolve({ code }));
+            });
+            ws.send(makeHandshakeFrame({
+                centralInstanceId: 'rotation-central-id',
+                centralApiUrl: 'https://central.example.test',
+                meshTunnelJwt: 'rotation.jwt.value',
+                jwtExpiresAt: expiresAt,
+            }));
+
+            const info = await closeInfo;
+            expect(info.code).toBe(1013);
+
+            const row = MeshCentralRegistry.getInstance().getActive();
+            expect(row).not.toBeNull();
+            expect(row?.centralInstanceId).toBe('rotation-central-id');
+            expect(row?.centralApiUrl).toBe('https://central.example.test');
+            expect(row?.callbackJwt).toBe('rotation.jwt.value');
+            expect(row?.jwtExpiresAt).toBe(expiresAt);
+        } finally {
+            await srv.close();
+        }
+    });
 });

--- a/backend/src/websocket/meshProxyTunnel.ts
+++ b/backend/src/websocket/meshProxyTunnel.ts
@@ -69,6 +69,17 @@ function isMeshHandshakeFrame(parsed: unknown): parsed is MeshHandshakeFrame {
  */
 const wss = new WebSocketServer({ noServer: true, maxPayload: MAX_FRAME_SIZE_BYTES });
 
+/**
+ * Upper bound on the pre-CAS first-frame wait inside attachSwitchboard.
+ * Sized to cover localhost-loopback RTT plus a slim margin for the
+ * central-side ms-scale gap between `ws.send(mesh_handshake)` and the
+ * registerProxyBridge throw + ws.close that follows on a refused dial.
+ * On a dial that carries no bootstrap, this is pure added latency
+ * before the reverse-dialer install; 30ms is well below operator
+ * perception and well above realistic localhost RTT.
+ */
+const FIRST_FRAME_WAIT_MS = 30;
+
 interface SwitchboardReverseDialer {
     openMeshTcpStream(target: { nodeId: number; stack: string; service: string; port: number }): ReverseTcpStreamHandle | null;
 }
@@ -115,60 +126,6 @@ export async function handleMeshProxyTunnel(req: IncomingMessage, socket: Duplex
 async function attachSwitchboard(ws: WebSocket, peerNodeId: number | null): Promise<void> {
     let switchboard: TcpStreamSwitchboard | null = null;
     let meshServiceCleanup: (() => void) | null = null;
-
-    try {
-        switchboard = attachTcpStreamSwitchboard({
-            ws,
-            resolveTarget: resolveByComposeLabels,
-            logLabel: 'MeshProxy',
-        });
-
-        // Register a reverse dialer so this side's MeshForwarder can dial
-        // cross-node aliases via `tcp_open_reverse` over the same WS. The
-        // CAS swap refuses to overwrite a dialer that another caller
-        // (a concurrent proxy-tunnel upgrade, or a pilot agent in a
-        // misconfigured deployment) has already installed.
-        const { MeshService } = await import('../services/MeshService');
-        const meshService = MeshService.getInstance();
-        const localSwitchboard = switchboard;
-        const localDialer: SwitchboardReverseDialer = {
-            openMeshTcpStream(target) {
-                return localSwitchboard.openReverseStream(target);
-            },
-        };
-        const installed = meshService.setReverseDialer(localDialer, null);
-        if (!installed) {
-            console.warn('[MeshProxy] reverse dialer already installed; rejecting concurrent tunnel');
-            try { ws.close(1013, 'reverse dialer already installed'); } catch { /* ignore */ }
-            switchboard.cleanup('reverse dialer already installed');
-            switchboard = null;
-            return;
-        }
-        // Install central's view of this peer's nodeId so handleAccept
-        // dispatches cross-node aliases correctly. Done after setReverseDialer
-        // succeeds so a CAS-rejected tunnel does not leak nodeId state.
-        //
-        // The install persists across bridge lifecycles: the peer's identity
-        // in central's namespace is stable for the enrollment, not per-WS.
-        // Null-clearing on teardown caused dispatch to fall back to
-        // getDefaultNodeId() after idle close, which collides with central's
-        // own nodeId for Local and misdispatches cross-fleet traffic to the
-        // same-node path. A subsequent install with a different nodeId
-        // (e.g. re-enrollment) is detected by the setter's overwrite-warn.
-        if (peerNodeId !== null) {
-            meshService.setProxyTunnelSelfCentralNodeId(peerNodeId);
-        }
-        meshServiceCleanup = () => {
-            meshService.setReverseDialer(null, localDialer);
-        };
-    } catch (err) {
-        if (isDebugEnabled()) {
-            console.warn('[MeshProxy:diag] failed to attach switchboard:', sanitizeForLog((err as Error).message));
-        }
-        try { ws.close(1011, 'switchboard attach failed'); } catch { /* ignore */ }
-        return;
-    }
-
     let phase: BootstrapPhase = 'awaiting';
 
     const onMessage = (data: unknown, isBinary: boolean): void => {
@@ -257,12 +214,84 @@ async function attachSwitchboard(ws: WebSocket, peerNodeId: number | null): Prom
         }
     };
 
-    ws.on('message', onMessage);
-    ws.once('close', teardown);
-    ws.once('error', (err) => {
-        if (isDebugEnabled()) {
-            console.warn('[MeshProxy:diag] ws error:', sanitizeForLog(err.message));
+    try {
+        switchboard = attachTcpStreamSwitchboard({
+            ws,
+            resolveTarget: resolveByComposeLabels,
+            logLabel: 'MeshProxy',
+        });
+
+        // Wire listeners synchronously so any first frame from central
+        // reaches onMessage even when the reverse-dialer CAS swap below
+        // refuses this bridge. Bootstrap material identifies central for
+        // the next peer-initiated callback and must persist independent
+        // of whether this particular WS becomes the active bridge.
+        ws.on('message', onMessage);
+        ws.once('close', teardown);
+        ws.once('error', (err) => {
+            if (isDebugEnabled()) {
+                console.warn('[MeshProxy:diag] ws error:', sanitizeForLog(err.message));
+            }
+            teardown();
+        });
+
+        // Register a reverse dialer so this side's MeshForwarder can dial
+        // cross-node aliases via `tcp_open_reverse` over the same WS. The
+        // CAS swap refuses to overwrite a dialer that another caller
+        // (a concurrent proxy-tunnel upgrade, or a pilot agent in a
+        // misconfigured deployment) has already installed.
+        const { MeshService } = await import('../services/MeshService');
+        const meshService = MeshService.getInstance();
+        const localSwitchboard = switchboard;
+        const localDialer: SwitchboardReverseDialer = {
+            openMeshTcpStream(target) {
+                return localSwitchboard.openReverseStream(target);
+            },
+        };
+        const installed = meshService.setReverseDialer(localDialer, null);
+        if (!installed) {
+            console.warn('[MeshProxy] reverse dialer already installed; rejecting concurrent tunnel');
+            // Hold the WS open briefly so any in-flight first frame can
+            // land in onMessage before we send the close. Central
+            // optionally sends a mesh_handshake as the first frame on
+            // Trigger 1 / Trigger 2 dials; that bootstrap material must
+            // persist via MeshCentralRegistry regardless of whether this
+            // WS becomes the active bridge. The wait resolves as soon as
+            // any 'message' arrives (the listener attached above runs
+            // synchronously on the event and updates the registry); the
+            // timeout bounds the close-latency overhead for refused
+            // dials that carry no bootstrap.
+            await new Promise<void>((resolve) => {
+                const onFirst = (): void => { clearTimeout(t); resolve(); };
+                const t = setTimeout(() => { ws.off('message', onFirst); resolve(); }, FIRST_FRAME_WAIT_MS);
+                ws.once('message', onFirst);
+            });
+            try { ws.close(1013, 'reverse dialer already installed'); } catch { /* ignore */ }
+            // teardown fires on the 'close' event and runs switchboard.cleanup.
+            return;
         }
-        teardown();
-    });
+        // Install central's view of this peer's nodeId so handleAccept
+        // dispatches cross-node aliases correctly. Done after setReverseDialer
+        // succeeds so a CAS-rejected tunnel does not leak nodeId state.
+        //
+        // The install persists across bridge lifecycles: the peer's identity
+        // in central's namespace is stable for the enrollment, not per-WS.
+        // Null-clearing on teardown caused dispatch to fall back to
+        // getDefaultNodeId() after idle close, which collides with central's
+        // own nodeId for Local and misdispatches cross-fleet traffic to the
+        // same-node path. A subsequent install with a different nodeId
+        // (e.g. re-enrollment) is detected by the setter's overwrite-warn.
+        if (peerNodeId !== null) {
+            meshService.setProxyTunnelSelfCentralNodeId(peerNodeId);
+        }
+        meshServiceCleanup = () => {
+            meshService.setReverseDialer(null, localDialer);
+        };
+    } catch (err) {
+        if (isDebugEnabled()) {
+            console.warn('[MeshProxy:diag] failed to attach switchboard:', sanitizeForLog((err as Error).message));
+        }
+        try { ws.close(1011, 'switchboard attach failed'); } catch { /* ignore */ }
+        return;
+    }
 }


### PR DESCRIPTION
## Summary

When the proxy-mode peer already has an open peer-initiated callback bridge to central, central's Trigger 2 dial (api_token rotation) used to deliver a fresh `mesh_handshake` frame on the wire but the peer's `/api/mesh/proxy-tunnel` handler closed the WS before its `'message'` listener had been attached, so the frame was unread and the peer's cached callback JWT stayed at the pre-rotation fingerprint. Without a central restart the next callback would 401 against the rotated token.

This PR restructures `attachSwitchboard` so the `'message'`, `'close'`, and `'error'` listeners are attached synchronously, before the async MeshService import and the reverse-dialer CAS swap. On the CAS-fail branch the WS is held open for up to 30ms (well above localhost RTT, well below operator perception) before sending the 1013 close, so any in-flight first frame lands in `onMessage` and the bootstrap material is persisted via `MeshCentralRegistry.upsert` regardless of whether this WS becomes the active bridge. Accepted dials are untouched: the success path runs no extra wait and the reverseDialer install timing is unchanged.

## Test plan

- [x] New regression test in `mesh-proxy-tunnel-first-frame.test.ts` pre-installs a stub reverse dialer (simulating a peer-initiated bridge owning the slot), dials a fresh tunnel, sends a `mesh_handshake` frame, and asserts the registry receives the rotated material before the 1013 close fires.
- [x] All existing mesh-proxy-tunnel and pilot-tunnel-manager suites pass unchanged (59 tests across the affected files).
- [x] Backend `tsc --noEmit` clean.
- [ ] Live production verification still owed: with the workstation's v0.81.2 central + sencho-test-03 peer (peer-initiated callback bridge active), rotate the api_token on nodeId=7 in Settings, watch central's mesh activity log for the `proxy-tunnel.open.ok bootstrapSent=true` -> `proxy-tunnel.open.fail reason=manager_rejected` sequence, then confirm the peer's `mesh_centrals.callback_jwt` reflects the rotated material without a central restart. Reachable next session.

## Notes

Scoped fix for F-R-1 from the mesh tracker. The structural alternative (have the dialer use `replaceOrRegisterProxyBridge` and tag bridge kind so a central-initiated dial cleanly supersedes a peer-initiated one) is intentionally out of scope and remains a separate follow-up; it does not preclude or duplicate this change. F-R-2 (misleading `manager_rejected` log wording), F-R-3 (unexplained pre-Save dial firing on token-field edit), and F-R-4 (in-memory `proxy_dials_failed` counter resetting on restart) also remain open as separate items.