### PR TITLE
fix(mesh): gate Trigger 2 re-bootstrap on actual api_token change

### DIFF
--- a/backend/src/__tests__/mesh-token-rotation-integration.test.ts
+++ b/backend/src/__tests__/mesh-token-rotation-integration.test.ts
@@ -174,4 +174,24 @@ describe('Trigger 2: api_token rotation forces re-bootstrap', () => {
         expect(closeSpy).not.toHaveBeenCalled();
         expect(ensureSpy).not.toHaveBeenCalled();
     });
+
+    it('does not fire when api_token in payload equals the current value', async () => {
+        const closeSpy = vi.spyOn(MeshProxyTunnelDialer.getInstance(), 'closeBridge');
+        const ensureSpy = vi.spyOn(MeshProxyTunnelDialer.getInstance(), 'ensureBridge')
+            .mockResolvedValue(null);
+        const nodeId = seedProxyNode(true);
+        const existingToken = DatabaseService.getInstance().getNode(nodeId)?.api_token;
+        expect(existingToken).toBeTruthy();
+
+        const res = await request(app)
+            .put(`/api/nodes/${nodeId}`)
+            .set('Authorization', authHeader)
+            .send({ name: `renamed-${uniqueSuffix()}`, api_token: existingToken });
+
+        expect(res.status).toBe(200);
+        await new Promise((r) => setImmediate(r));
+
+        expect(closeSpy).not.toHaveBeenCalled();
+        expect(ensureSpy).not.toHaveBeenCalled();
+    });
 });

--- a/backend/src/routes/nodes.ts
+++ b/backend/src/routes/nodes.ts
@@ -224,6 +224,11 @@ nodesRouter.put('/:id', async (req: Request, res: Response) => {
     const id = parseInt(nodeId);
     const updates = req.body;
 
+    const existingNode = DatabaseService.getInstance().getNode(id);
+    if (!existingNode) {
+      return res.status(404).json({ error: 'Node not found' });
+    }
+
     if (updates.api_url !== undefined && updates.api_url !== '') {
       const urlCheck = isValidRemoteUrl(updates.api_url);
       if (!urlCheck.valid) {
@@ -239,11 +244,15 @@ nodesRouter.put('/:id', async (req: Request, res: Response) => {
     // Trigger 2: if the api_token was rotated on a mesh-enabled proxy-mode
     // remote, close the existing callback bridge and re-dial. The next
     // ensureBridge mints a JWT with the fresh token fingerprint so the
-    // remote's tunnel auth gate accepts the upgrade.
-    if (typeof updates.api_token === 'string') {
-      const node = DatabaseService.getInstance().getNode(id);
+    // remote's tunnel auth gate accepts the upgrade. Gate on actual value
+    // change so a Save that only edits name / compose_dir does not cycle
+    // the bridge (the frontend sends the full formData on every Save).
+    const tokenChanged =
+      typeof updates.api_token === 'string' &&
+      updates.api_token !== existingNode.api_token;
+    if (tokenChanged) {
       const meshEnabled = DatabaseService.getInstance().getNodeMeshEnabled(id);
-      if (node && node.type === 'remote' && node.mode === 'proxy' && meshEnabled) {
+      if (existingNode.type === 'remote' && existingNode.mode === 'proxy' && meshEnabled) {
         MeshProxyTunnelDialer.getInstance().closeBridge(id, 'peer token rotated');
         void MeshProxyTunnelDialer.getInstance().ensureBridge(id).catch((err) => {
           console.warn(`[Mesh] proactive re-bootstrap on token rotation failed for node ${id}: ${(err as Error).message}`);


### PR DESCRIPTION
## Summary

- F-R-3 closure. The PUT `/api/nodes/:id` handler used to fire the mesh Trigger 2 bridge re-bootstrap (`closeBridge` + `ensureBridge`) on every Save that included `api_token` in the body, even when the token value was unchanged.
- The frontend Add/Edit Node modal sends the full `formData` on Save, so renames and `compose_dir` edits against a mesh-enabled proxy remote produced a wasted close + dial round-trip and a spurious `manager_rejected` entry in the activity log.
- Gate the re-bootstrap on a real value diff against the persisted token. The handler now loads the existing node first, returns 404 if missing (the handler previously lacked this guard), then compares `updates.api_token` to `existingNode.api_token` before deciding to cycle the bridge.
- The typing/blur hypothesis recorded in the mesh tracker is refuted by the code: the frontend modal has no `onBlur`/`useEffect`/`setTimeout` test triggers; all field inputs are plain `onChange` handlers that only update local React state. `runConnectionTest` fires only on explicit Save and hits the HTTP-only `/test` endpoint, not the mesh dialer. The Trigger-2-shaped dial seen in the 2026-05-17 verification came from the backend gate, not from a frontend auto-test.

## Test plan

- [x] `cd backend && npx tsc --noEmit` clean.
- [x] `cd backend && npm test -- mesh-token-rotation` reports 7 passing (3 trigger-1, 3 existing trigger-2, 1 new same-token regression).
- [ ] Manual UI validation deferred: requires a proxy-mode mesh-enabled fleet (the production sencho-test-03 setup), not available on the local dev box where port 1852 is occupied by a separate Sencho instance. Recommended manual recipe for whoever exercises this on the production fleet:
  1. Edit a proxy-mode mesh-enabled remote in Settings → Nodes, change only the Name field, click Save. Verify the backend log shows no `[Mesh] proactive re-bootstrap` line and `/api/mesh/activity` records no new `proxy-tunnel.open.*` event.
  2. Edit the same node, change the API Token to a different value, click Save. Verify the activity log shows the new `proxy-tunnel.open.*` event corresponding to the rotation.

## Notes

- Scope: token-change only. URL-change re-bootstrap and frontend payload tightening are out of scope per the planning discussion; the existing-bridge-with-stale-URL case is not what F-R-3 reported.
- The 404 add for non-existent nodes is incidental but load-bearing for the gate logic (the comparison needs the old token); kept in the same commit.
- One branch, one concern: branched off `main`, not off the F-R-2 branch.