### PR TITLE
fix(mesh): cascade override regen across all meshed nodes on opt-in/opt-out

### DIFF
--- a/backend/src/__tests__/mesh-service.test.ts
+++ b/backend/src/__tests__/mesh-service.test.ts
@@ -57,7 +57,7 @@ describe('MeshService.optInStack', () => {
 
         vi.spyOn(svc as unknown as { inspectStackServices: (n: number, s: string) => Promise<unknown> }, 'inspectStackServices')
             .mockResolvedValue([{ service: 'db', ports: [5432] }]);
-        vi.spyOn(svc as unknown as { regenerateOverridesForNode: (n: number) => Promise<void> }, 'regenerateOverridesForNode')
+        vi.spyOn(svc as unknown as { regenerateOverridesAcrossFleet: (n?: number, s?: string) => Promise<void> }, 'regenerateOverridesAcrossFleet')
             .mockResolvedValue(undefined);
 
         const db = DatabaseService.getInstance();
@@ -80,7 +80,7 @@ describe('MeshService.optInStack', () => {
                 { service: 'web', ports: [] },
                 { service: 'db', ports: [] },
             ]);
-        vi.spyOn(svc as unknown as { regenerateOverridesForNode: (n: number) => Promise<void> }, 'regenerateOverridesForNode')
+        vi.spyOn(svc as unknown as { regenerateOverridesAcrossFleet: (n?: number, s?: string) => Promise<void> }, 'regenerateOverridesAcrossFleet')
             .mockResolvedValue(undefined);
 
         await expect(svc.optInStack(localNodeId, 'silent', 'tester'))
@@ -94,7 +94,7 @@ describe('MeshService.optInStack', () => {
         const svc = MeshService.getInstance();
         vi.spyOn(svc as unknown as { inspectStackServices: (n: number, s: string) => Promise<unknown> }, 'inspectStackServices')
             .mockResolvedValue([{ service: 'db', ports: [5432] }]);
-        vi.spyOn(svc as unknown as { regenerateOverridesForNode: (n: number) => Promise<void> }, 'regenerateOverridesForNode')
+        vi.spyOn(svc as unknown as { regenerateOverridesAcrossFleet: (n?: number, s?: string) => Promise<void> }, 'regenerateOverridesAcrossFleet')
             .mockResolvedValue(undefined);
         vi.spyOn(svc as unknown as { removeStackOverride: (n: number, s: string) => Promise<void> }, 'removeStackOverride')
             .mockResolvedValue(undefined);
@@ -164,6 +164,63 @@ describe('MeshService.optInStack', () => {
             aliasByPort.clear();
             db.deleteNode(remoteNodeId);
         }
+    });
+
+    it('optInStack cascades override regen to every meshed node, not just the source node', async () => {
+        const svc = MeshService.getInstance();
+        const db = DatabaseService.getInstance();
+        const localNodeId = db.getNodes()[0].id;
+        const remoteNodeId = db.addNode({
+            name: 'remote-pilot', type: 'remote', mode: 'pilot_agent',
+            compose_dir: '/tmp', is_default: false, api_url: '', api_token: '',
+        });
+        db.insertMeshStack(remoteNodeId, 'remote-existing', 'setup');
+
+        vi.spyOn(svc as unknown as { inspectStackServices: (n: number, s: string) => Promise<unknown> }, 'inspectStackServices')
+            .mockResolvedValue([{ service: 'web', ports: [8080] }]);
+        const pushed: Array<{ nodeId: number; stackName: string }> = [];
+        vi.spyOn(svc, 'pushOverrideToNode').mockImplementation(async (nodeId, stackName) => {
+            pushed.push({ nodeId, stackName });
+        });
+        vi.spyOn(svc as unknown as { triggerRedeploy: (n: number, s: string, a: string) => void }, 'triggerRedeploy')
+            .mockImplementation(() => { /* noop */ });
+
+        await svc.optInStack(localNodeId, 'new-stack', 'tester');
+
+        expect(pushed).toContainEqual({ nodeId: localNodeId, stackName: 'new-stack' });
+        // Other meshed nodes' existing stacks must regenerate so they pick
+        // up the new alias entry.
+        expect(pushed).toContainEqual({ nodeId: remoteNodeId, stackName: 'remote-existing' });
+    });
+
+    it('optOutStack cascades override regen to every other meshed node', async () => {
+        const svc = MeshService.getInstance();
+        const db = DatabaseService.getInstance();
+        const localNodeId = db.getNodes()[0].id;
+        const remoteNodeId = db.addNode({
+            name: 'remote-pilot', type: 'remote', mode: 'pilot_agent',
+            compose_dir: '/tmp', is_default: false, api_url: '', api_token: '',
+        });
+        db.insertMeshStack(localNodeId, 'to-remove', 'setup');
+        db.insertMeshStack(remoteNodeId, 'remote-existing', 'setup');
+
+        const pushed: Array<{ nodeId: number; stackName: string }> = [];
+        vi.spyOn(svc, 'pushOverrideToNode').mockImplementation(async (nodeId, stackName) => {
+            pushed.push({ nodeId, stackName });
+        });
+        vi.spyOn(svc as unknown as { removeOverrideFromNode: (n: number, s: string) => Promise<void> }, 'removeOverrideFromNode')
+            .mockResolvedValue(undefined);
+        vi.spyOn(svc as unknown as { triggerRedeploy: (n: number, s: string, a: string) => void }, 'triggerRedeploy')
+            .mockImplementation(() => { /* noop */ });
+
+        await svc.optOutStack(localNodeId, 'to-remove', 'tester');
+
+        // Other meshed nodes' existing stacks must regenerate so they drop
+        // the removed alias entry.
+        expect(pushed).toContainEqual({ nodeId: remoteNodeId, stackName: 'remote-existing' });
+        // The removed row was deleted before the cascade ran, and its file
+        // was unlinked separately, so it must not appear in the cascade.
+        expect(pushed.find((p) => p.stackName === 'to-remove')).toBeUndefined();
     });
 });
 
@@ -439,7 +496,7 @@ describe('MeshService.optInStack guard rails (network setup)', () => {
         const svc = MeshService.getInstance();
         vi.spyOn(svc as unknown as { inspectStackServices: (n: number, s: string) => Promise<unknown> }, 'inspectStackServices')
             .mockResolvedValue([{ service: 'web', ports: [1852] }]);
-        vi.spyOn(svc as unknown as { regenerateOverridesForNode: (n: number) => Promise<void> }, 'regenerateOverridesForNode')
+        vi.spyOn(svc as unknown as { regenerateOverridesAcrossFleet: (n?: number, s?: string) => Promise<void> }, 'regenerateOverridesAcrossFleet')
             .mockResolvedValue(undefined);
 
         const db = DatabaseService.getInstance();
@@ -589,7 +646,7 @@ describe('MeshService.regenerateAllOverrides (F6: boot-time regen)', () => {
         const pushSpy = vi.spyOn(svc, 'pushOverrideToNode').mockResolvedValue(undefined);
         vi.spyOn(svc as unknown as { triggerRedeploy: (n: number, s: string, a: string) => void }, 'triggerRedeploy')
             .mockImplementation(() => { /* noop */ });
-        vi.spyOn(svc as unknown as { regenerateOverridesForNode: (n: number, skip?: string) => Promise<void> }, 'regenerateOverridesForNode')
+        vi.spyOn(svc as unknown as { regenerateOverridesAcrossFleet: (n?: number, skip?: string) => Promise<void> }, 'regenerateOverridesAcrossFleet')
             .mockResolvedValue(undefined);
 
         const [summary] = await Promise.all([

--- a/backend/src/services/MeshService.ts
+++ b/backend/src/services/MeshService.ts
@@ -675,11 +675,12 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
             await this.syncForwarderListeners();
             throw err;
         }
-        // Regenerate OTHER meshed stacks' overrides on the same node so
-        // they pick up the new alias entry. The just-opted-in stack was
-        // already pushed above; skip it to avoid a duplicate round-trip.
-        // Best-effort; per-stack failures are logged inside the helper.
-        await this.regenerateOverridesForNode(nodeId, stackName);
+        // Regenerate every other meshed stack's override across the fleet
+        // so they pick up the new alias entry. The just-opted-in stack was
+        // already pushed above; skip the (nodeId, stackName) tuple to
+        // avoid a duplicate round-trip. Best-effort; per-stack failures
+        // surface as forwarder.error activity events.
+        await this.regenerateOverridesAcrossFleet(nodeId, stackName);
         this.triggerRedeploy(nodeId, stackName, actor);
 
         this.logActivity({
@@ -704,7 +705,10 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
         await this.removeOverrideFromNode(nodeId, stackName);
         await this.refreshAliasCache();
         await this.syncForwarderListeners();
-        await this.regenerateOverridesForNode(nodeId);
+        // The opted-out row is already deleted, so listMeshStacks() will not
+        // include it. Walk the remaining fleet-wide rows so every other
+        // meshed stack regenerates its override without the dropped alias.
+        await this.regenerateOverridesAcrossFleet();
         this.triggerRedeploy(nodeId, stackName, actor);
 
         this.logActivity({
@@ -922,6 +926,41 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
                         await this.pushOverrideToNode(nodeId, s.stack_name);
                     } catch (err) {
                         console.warn('[MeshService] override push failed:', sanitizeForLog((err as Error).message));
+                    }
+                }),
+        );
+    }
+
+    /**
+     * Walk every `mesh_stacks` row across the fleet and re-push each override.
+     * Called from optInStack / optOutStack so a new or removed alias
+     * propagates to every meshed node's override file in one pass, not just
+     * the node whose row changed. Best-effort: per-stack failures emit a
+     * forwarder.error activity event and the other nodes still get
+     * regenerated. An offline remote node leaves stale overrides until the
+     * next opt-in / opt-out, the next tunnel reconnect, or a manual
+     * `POST /api/mesh/regen-overrides`.
+     */
+    private async regenerateOverridesAcrossFleet(
+        skipNodeId?: number,
+        skipStack?: string,
+    ): Promise<void> {
+        const db = DatabaseService.getInstance();
+        const stacks = db.listMeshStacks();
+        await Promise.allSettled(
+            stacks
+                .filter((s) => !(s.node_id === skipNodeId && s.stack_name === skipStack))
+                .map(async (s) => {
+                    try {
+                        await this.pushOverrideToNode(s.node_id, s.stack_name);
+                    } catch (err) {
+                        const message = sanitizeForLog((err as Error).message);
+                        this.logActivity({
+                            source: 'mesh', level: 'warn', type: 'forwarder.error',
+                            nodeId: s.node_id,
+                            message: `cascade override push failed for ${s.stack_name}: ${message}`,
+                            details: { stackName: s.stack_name },
+                        });
                     }
                 }),
         );


### PR DESCRIPTION
## Summary

- New `MeshService.regenerateOverridesAcrossFleet(skipNodeId?, skipStack?)` helper walks every `mesh_stacks` row across the fleet and re-pushes each override under `Promise.allSettled`, emitting `forwarder.error` activity events on per-stack failures.
- `optInStack` and `optOutStack` now call the new fleet-wide helper instead of `regenerateOverridesForNode` so a new or removed alias propagates to every meshed node's override file without a manual `POST /api/mesh/regen-overrides`.
- `regenerateOverridesForNode` stays as-is for the tunnel-up retry path, where a reconnecting pilot only needs its own stacks re-pushed.

## Why

Before this change, opting a stack into mesh on node A wrote the new alias entry only to node A's overrides. Any meshed stack on a sibling node kept a stale `extra_hosts` block until something else re-pushed its override. Confirmed during the 2026-05-17 production run: opting `audit-mesh-proxy` into mesh on a remote did not propagate the new alias to the central node's `audit-mesh-central.override.yml`. The operator had to manually call `POST /api/mesh/regen-overrides` and redeploy the affected stacks. Same gap on opt-out.

The cascade is best-effort. Per-stack failures land in `/api/mesh/activity` as `forwarder.error` events, matching the pattern in `regenerateAllOverrides`. An offline remote node leaves stale overrides until the next opt-in/opt-out, the next tunnel reconnect, or a manual rerun of the regen-overrides endpoint.

## Test plan

- [x] `cd backend && npx tsc --noEmit` (clean)
- [x] `cd backend && npx vitest run src/__tests__/mesh-service.test.ts` (52 passed, including two new cases asserting cross-node cascade for opt-in and opt-out)
- [x] Broader mesh + pilot suites: `mesh-service`, `mesh-bootstrap-integration`, `mesh-compose-override`, `mesh-forwarder`, `mesh-service-proactive-bootstrap-fanout`, `pilot-tunnel-manager-replace`, `pilot-tunnel-manager-ensure` (79 passed)
- [x] Code reviewed for reuse, quality, and efficiency; trims applied (test cleanup, naming, inline comments)
- [ ] Manual fleet probe (recommended post-merge against the production audit-mesh stacks):
  1. With at least two meshed nodes each carrying one meshed stack, opt a fresh stack into mesh on node B via the Routing tab.
  2. Inspect `<DATA_DIR>/mesh/overrides/<nodeA>/<existingStack>.override.yml`. Expect the new alias entry from node B present without any manual `regen-overrides` call.
  3. Check `/api/mesh/activity` for the affected window. Expect no `forwarder.error` entries on a healthy fleet; one per offline node if any.
  4. Opt the stack back out and confirm the alias is removed from node A's override.

## Notes

- Out of scope: bulk-redeploy concurrency (per-node serializer for the redeploy fan-out) stays as a separate follow-up. `triggerRedeploy` remains fire-and-forget at both call sites.
- No tier-gate changes; no architecture-map changes; no operator docs changes. The cascade is the implementation detail behind a behavior the user-facing copy already implies ("opting a stack into mesh propagates the alias to every meshed node").
- No frontend changes; this is a backend bug fix.