### PR TITLE
fix(stacks): prevent right-side clipping in Create Stack modal

### DIFF
--- a/frontend/src/components/EditorLayout/CreateStackDialog.tsx
+++ b/frontend/src/components/EditorLayout/CreateStackDialog.tsx
@@ -319,7 +319,7 @@ export function CreateStackDialog({ open, onOpenChange, onStackCreated, onStacks
 
             {createMode === 'git' && (
                 <div role="tabpanel" id={panelId('git')} aria-labelledby={tabId('git')}>
-                    <ScrollArea className="max-h-[60vh]">
+                    <ScrollArea block className="max-h-[60vh]">
                         <ModalBody>
                             <div className="space-y-2">
                                 <Label htmlFor="create-git-stack-name">Stack Name</Label>
@@ -387,7 +387,7 @@ export function CreateStackDialog({ open, onOpenChange, onStackCreated, onStacks
 
             {createMode === 'docker-run' && (
                 <div role="tabpanel" id={panelId('docker-run')} aria-labelledby={tabId('docker-run')}>
-                    <ScrollArea className="max-h-[60vh]">
+                    <ScrollArea block className="max-h-[60vh]">
                         <ModalBody>
                             <div className="space-y-2">
                                 <Label htmlFor="create-dr-stack-name">Stack Name</Label>
@@ -431,7 +431,7 @@ export function CreateStackDialog({ open, onOpenChange, onStackCreated, onStacks
                             {convertedYaml !== null && (
                                 <div className="space-y-2">
                                     <Label>compose.yaml preview</Label>
-                                    <ScrollArea className="max-h-[240px] rounded-md border border-card-border border-t-card-border-top bg-card shadow-card-bevel">
+                                    <ScrollArea block className="max-h-[240px] rounded-md border border-card-border border-t-card-border-top bg-card shadow-card-bevel">
                                         <pre className="px-3 py-2 text-xs font-mono whitespace-pre leading-relaxed">
                                             {convertedYaml}
                                         </pre>


### PR DESCRIPTION
## Summary
- In the **Create new stack** → **From Docker Run** tab, the converted `compose.yaml preview` silently clipped long YAML lines on the right of the modal with no horizontal scrollbar to recover the hidden text.
- Root cause: `<pre className="whitespace-pre">` inside a `<ScrollArea>` whose Radix viewport defaults to `overflow-x: hidden` with a `display: table` inner wrapper. The pre's intrinsic 665px width propagated up the chain via table sizing, pushing the form's `ModalBody` to 715px (masked only by the dialog's `overflow: hidden` clip).
- Fix: opt into the existing `block` prop on `frontend/src/components/ui/scroll-area.tsx` for the YAML preview ScrollArea and for both tab-panel form ScrollAreas. `block` overrides the Radix viewport child with `display: block; min-w-0` and renders a horizontal `<ScrollBar>` (Radix only mounts it when content actually overflows). Matches the established pattern already used by `VulnerabilityScanSheet`, `ScanComparisonSheet`, and `SecurityHistoryView`.

## Test plan
- [x] Open **Create Stack** → **From Docker Run**, paste a docker run command that produces a YAML line longer than the visible viewport (long env value + long volume path).
- [x] Click **Convert**. Confirm the YAML preview shows a horizontal scrollbar, the long line is fully reachable by scrolling right, and the modal's right border no longer hides content.
- [x] Switch to **From Git** tab. Confirm form layout is unchanged at the 576px modal width.
- [x] Switch to **Empty** tab. Confirm nothing changed.
- [x] `cd frontend && npx tsc -b --noEmit` clean.

## Notes
- DOM trace confirms the outer `block` props are load-bearing: without them, the inner pre's intrinsic width propagates up through Radix's table-display viewport child and pushes `ModalBody` to 715px even with the inner ScrollArea constrained.
- No behavior changes elsewhere; three single-token additions to one file.