### PR TITLE
refactor(mesh): route inspectStackServices through proxyFetch

### DIFF
--- a/backend/src/services/MeshService.ts
+++ b/backend/src/services/MeshService.ts
@@ -1180,19 +1180,14 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
         if (!node) return [];
         if (node.type !== 'remote') return this.inspectLocalStackServices(stackName);
 
-        const target = NodeRegistry.getInstance().getProxyTarget(nodeId);
-        if (!target) {
-            console.warn(`[MeshService] inspectStackServices: no proxy target for node ${nodeId} (${sanitizeForLog(node.name)})`);
-            return [];
-        }
         try {
-            const url = `${target.apiUrl.replace(/\/$/, '')}/api/mesh/local-services/${encodeURIComponent(stackName)}`;
-            const headers: Record<string, string> = {};
-            if (target.apiToken) headers['Authorization'] = `Bearer ${target.apiToken}`;
-            const proxyHeaders = LicenseService.getInstance().getProxyHeaders();
-            headers[PROXY_TIER_HEADER] = proxyHeaders.tier;
-            headers[PROXY_VARIANT_HEADER] = proxyHeaders.variant || '';
-            const res = await fetch(url, { headers, signal: AbortSignal.timeout(5_000) });
+            const res = await this.proxyFetch(
+                nodeId,
+                'GET',
+                `/api/mesh/local-services/${encodeURIComponent(stackName)}`,
+                undefined,
+                5_000,
+            );
             if (!res.ok) {
                 console.error(`[MeshService] inspectStackServices: HTTP ${res.status} from node ${nodeId} (${sanitizeForLog(node.name)})`);
                 return [];
@@ -1200,6 +1195,13 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
             const body = await res.json() as { services?: Array<{ service: string; ports: number[] }> };
             return body.services ?? [];
         } catch (err) {
+            // proxyFetch throws MeshError('push_failed') when getProxyTarget
+            // returns null (e.g. pilot tunnel offline). Treat the same as a
+            // non-OK response: empty list.
+            if (err instanceof MeshError && err.code === 'push_failed') {
+                console.warn(`[MeshService] inspectStackServices: no proxy target for node ${nodeId} (${sanitizeForLog(node.name)})`);
+                return [];
+            }
             console.error('[MeshService] inspectStackServices remote unreachable:', sanitizeForLog((err as Error).message));
             return [];
         }


### PR DESCRIPTION
## Summary

- Migrate the private `MeshService.inspectStackServices` to delegate to the existing `proxyFetch` helper. Drops the inline `Authorization` / `x-sencho-tier` / `x-sencho-variant` header construction and the standalone `NodeRegistry.getProxyTarget` call; both are now handled inside `proxyFetch` where every other remote-node HTTP call already goes through (`listStacksOnNode`, `pushOverrideToNode`, `triggerRemeshRedeploy`, `removeOverrideFromNode`).
- The catch arm gains a narrow `if (err instanceof MeshError && err.code === 'push_failed')` branch that converts the new throw from `proxyFetch` back into the existing warn + return `[]` contract that callers (`optInStack`, `refreshAliasCache`) rely on. Behavior on the wire is byte-identical: same URL, same GET, same three headers, same 5 s timeout.
- Drift risk closed: a future header added to `proxyFetch` (audit context, license fingerprint, request id) will now reach this code path automatically. Pattern matches `listStacksOnNode` verbatim.

## Test plan

- [x] `cd backend && npx tsc --noEmit` — clean.
- [x] `cd backend && npx vitest run mesh-inspect-remote mesh-list-stacks-remote mesh-service` — 65 tests pass across the four affected files. The wire-shape assertion (`mesh-inspect-remote` case 2 inspects URL + the three headers explicitly) is the equivalent of a live data-plane probe for this byte-identical refactor.
- [x] `cd backend && npm test` — 2275 pass, 1 pre-existing Windows SQLite handle teardown flake in `filesystem-backup.test.ts` (`EBUSY: resource busy or locked, unlink ... sencho.db`), unrelated to mesh (file imports zero mesh code).
- [x] Code reviewed and findings addressed; reviewer reports clean (no findings at any severity).
- [ ] Live data-plane smoke deliberately skipped: the only proxy-test fixture on this workstation is enrolled against the running production container, which carries the old code. A dev backend on a fresh data dir has no nodes enrolled, so `refreshAliasCache` -> `inspectStackServices` -> `proxyFetch` is unreachable without a docker rebuild. The unit tests cover the same wire bytes; behavior will be re-verified the next time the production fleet is exercised through normal usage.

## Notes

- Pure hygiene refactor: no schema change, no docs change, no architecture-map change, no tier-gate change, no user-visible change. Conventional prefix is `refactor:` so the release-please CHANGELOG line is informational only.
- Adjacent follow-ups intentionally kept off this branch: F-A9 (`MeshError 'no_target'` semantics) will retarget this new catch from `'push_failed'` to `'no_target'` when it lands; F4 (cascading override regen, #1079) and F5 (bulk-redeploy concurrency) stay on their own branches.