### PR TITLE
refactor(mesh): retarget proxyFetch null-target throw to no_target

### DIFF
--- a/backend/src/__tests__/mesh-list-stacks-remote.test.ts
+++ b/backend/src/__tests__/mesh-list-stacks-remote.test.ts
@@ -17,13 +17,14 @@ import { setupTestDb, cleanupTestDb } from './helpers/setupTestDb';
 
 let tmpDir: string;
 let MeshService: typeof import('../services/MeshService').MeshService;
+let MeshError: typeof import('../services/MeshService').MeshError;
 let DatabaseService: typeof import('../services/DatabaseService').DatabaseService;
 let NodeRegistry: typeof import('../services/NodeRegistry').NodeRegistry;
 let FileSystemService: typeof import('../services/FileSystemService').FileSystemService;
 
 beforeAll(async () => {
     tmpDir = await setupTestDb();
-    ({ MeshService } = await import('../services/MeshService'));
+    ({ MeshService, MeshError } = await import('../services/MeshService'));
     ({ DatabaseService } = await import('../services/DatabaseService'));
     ({ NodeRegistry } = await import('../services/NodeRegistry'));
     ({ FileSystemService } = await import('../services/FileSystemService'));
@@ -178,5 +179,65 @@ describe('MeshService.listStacksOnNode dispatch (F8)', () => {
         const out = await svc.listStacksOnNode(999_999);
         expect(out).toEqual([]);
         expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('catch arm swallows MeshError(no_target) and logs the no-proxy-target warning', async () => {
+        const svc = MeshService.getInstance();
+        const db = DatabaseService.getInstance();
+        const remoteNodeId = db.addNode({
+            name: 'list-stacks-no-target-code',
+            type: 'remote',
+            mode: 'pilot_agent',
+            compose_dir: '/tmp',
+            is_default: false,
+            api_url: '',
+            api_token: '',
+        });
+
+        vi.spyOn(NodeRegistry.getInstance(), 'getProxyTarget').mockReturnValue(null);
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        const out = await svc.listStacksOnNode(remoteNodeId);
+
+        expect(out).toEqual([]);
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(String(warnSpy.mock.calls[0][0])).toContain('no proxy target for node');
+        expect(errorSpy).not.toHaveBeenCalled();
+
+        db.deleteNode(remoteNodeId);
+    });
+
+    it('unexpected MeshError codes fall through to the remote-unreachable error path', async () => {
+        const svc = MeshService.getInstance();
+        const db = DatabaseService.getInstance();
+        const remoteNodeId = db.addNode({
+            name: 'list-stacks-push-failed-falls-through',
+            type: 'remote',
+            mode: 'proxy',
+            compose_dir: '/tmp',
+            is_default: false,
+            api_url: 'https://remote.example.com:1852',
+            api_token: 'remote-tok',
+        });
+
+        vi.spyOn(NodeRegistry.getInstance(), 'getProxyTarget').mockReturnValue({
+            apiUrl: 'https://remote.example.com:1852',
+            apiToken: 'remote-tok',
+        });
+        vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+            throw new MeshError('push_failed', 'simulated transport failure');
+        });
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        const out = await svc.listStacksOnNode(remoteNodeId);
+
+        expect(out).toEqual([]);
+        expect(warnSpy).not.toHaveBeenCalled();
+        expect(errorSpy).toHaveBeenCalledTimes(1);
+        expect(String(errorSpy.mock.calls[0][0])).toContain('remote unreachable');
+
+        db.deleteNode(remoteNodeId);
     });
 });

--- a/backend/src/services/MeshService.ts
+++ b/backend/src/services/MeshService.ts
@@ -1231,10 +1231,7 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
             if (!Array.isArray(body.stacks)) return [];
             return body.stacks.filter((s): s is string => typeof s === 'string');
         } catch (err) {
-            // proxyFetch throws MeshError('push_failed') when getProxyTarget
-            // returns null (e.g. pilot tunnel offline). Treat the same as a
-            // non-OK response: empty list.
-            if (err instanceof MeshError && err.code === 'push_failed') {
+            if (err instanceof MeshError && err.code === 'no_target') {
                 console.warn(`[MeshService] listStacksOnNode: no proxy target for node ${nodeId} (${sanitizeForLog(node.name)})`);
                 return [];
             }
@@ -1261,7 +1258,7 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
         timeoutMs: number,
     ): Promise<Response> {
         const target = NodeRegistry.getInstance().getProxyTarget(nodeId);
-        if (!target) throw new MeshError('push_failed', `no proxy target for node ${nodeId}`);
+        if (!target) throw new MeshError('no_target', `no proxy target for node ${nodeId}`);
         const url = `${target.apiUrl.replace(/\/$/, '')}${apiPath}`;
         const headers: Record<string, string> = {};
         if (body !== undefined) headers['Content-Type'] = 'application/json';


### PR DESCRIPTION
## Summary

`MeshService.proxyFetch` previously threw `MeshError('push_failed', ...)` when `NodeRegistry.getProxyTarget(nodeId)` returned null. That code semantically meant "we tried to push and the transport failed," but in this branch we never tried; we simply lacked a target. Callers had to special-case the code and carry a 3-line comment explaining the overload.

This PR retargets the throw to the existing `'no_target'` variant of `MeshErrorCode`. `listStacksOnNode`'s catch arm now matches `'no_target'` directly; the explanatory comment is gone since the code reads for itself.

`MeshError('push_failed', ...)` continues to signal real outbound push failures:
- `applyLocalOverride` (receiving node's mesh data plane is not yet ready)
- `pushOverrideToNode` (HTTP 404 from an outdated remote, non-OK HTTP response)

These sites are unchanged.

## Test plan

- [x] `cd backend && npx tsc --noEmit` clean
- [x] `npx vitest run src/__tests__/mesh-list-stacks-remote.test.ts` — 8/8 green (6 existing + 2 new cases pinning catch-arm semantics)
- [x] `npx vitest run src/__tests__/mesh-service.test.ts src/__tests__/mesh-inspect-remote.test.ts` — 56/56 green
- [x] Code reviewed; cosmetic test-name finding applied
- [ ] Manual mesh probe NOT required: wire shape unchanged, only the error label changes

## Notes

- Operator-visible behavior unchanged in the steady state.
- The rare "remote disappeared between opt-in start and override push" case now returns HTTP 400 with `code: 'no_target'` instead of 503; the response body carries the clear message `no proxy target for node N` so clients can disambiguate.
- PR #1082 (route inspectStackServices through proxyFetch) needs a rebase plus a one-line update to its catch arm before merging on top of this change.

## Gate parity

No tier/role/capability/flag gate touched. `git diff --cached --name-only | rg "(tierGates|requirePaid|requireAdmiral|isPaid|isAdmiral|PaidGate|AdmiralGate|CapabilityGate)"` returned empty.