### PR TITLE
fix(mesh): cascade opt-out when a stack is deleted (F-1 / F-14)

### DIFF
--- a/backend/src/__tests__/stack-delete-cascades-mesh-opt-out.test.ts
+++ b/backend/src/__tests__/stack-delete-cascades-mesh-opt-out.test.ts
@@ -1,0 +1,135 @@
+/** F-1 / F-14: DELETE /api/stacks/:stackName must cascade a mesh opt-out. */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import { setupTestDb, cleanupTestDb, loginAsTestAdmin } from './helpers/setupTestDb';
+
+let tmpDir: string;
+let app: import('express').Express;
+let DatabaseService: typeof import('../services/DatabaseService').DatabaseService;
+let MeshService: typeof import('../services/MeshService').MeshService;
+let ComposeService: typeof import('../services/ComposeService').ComposeService;
+let FileSystemService: typeof import('../services/FileSystemService').FileSystemService;
+let LicenseService: typeof import('../services/LicenseService').LicenseService;
+let adminCookie: string;
+
+beforeAll(async () => {
+    tmpDir = await setupTestDb();
+    ({ DatabaseService } = await import('../services/DatabaseService'));
+    ({ MeshService } = await import('../services/MeshService'));
+    ({ ComposeService } = await import('../services/ComposeService'));
+    ({ FileSystemService } = await import('../services/FileSystemService'));
+    ({ LicenseService } = await import('../services/LicenseService'));
+
+    vi.spyOn(LicenseService.getInstance(), 'getTier').mockReturnValue('paid');
+    vi.spyOn(LicenseService.getInstance(), 'getVariant').mockReturnValue('admiral');
+    vi.spyOn(LicenseService.getInstance(), 'getSeatLimits').mockReturnValue({ maxAdmins: null, maxViewers: null });
+
+    ({ app } = await import('../index'));
+    adminCookie = await loginAsTestAdmin(app);
+});
+
+afterAll(() => {
+    cleanupTestDb(tmpDir);
+});
+
+beforeEach(() => {
+    const db = DatabaseService.getInstance().getDb();
+    db.prepare('DELETE FROM mesh_stacks').run();
+
+    vi.restoreAllMocks();
+
+    vi.spyOn(LicenseService.getInstance(), 'getTier').mockReturnValue('paid');
+    vi.spyOn(LicenseService.getInstance(), 'getVariant').mockReturnValue('admiral');
+    vi.spyOn(LicenseService.getInstance(), 'getSeatLimits').mockReturnValue({ maxAdmins: null, maxViewers: null });
+
+    vi.spyOn(ComposeService.prototype, 'downStack').mockResolvedValue(undefined);
+    vi.spyOn(FileSystemService.prototype, 'deleteStack').mockResolvedValue(undefined);
+
+    // optInStack rejects when senchoIp is null; seed a placeholder.
+    const svc = MeshService.getInstance() as unknown as {
+        aliasCache: Map<string, unknown>;
+        aliasByPort: Map<number, unknown>;
+        activity: unknown[];
+        senchoIp: string | null;
+        networkSetupError: string | null;
+    };
+    svc.aliasCache = new Map();
+    svc.aliasByPort = new Map();
+    svc.activity = [];
+    svc.senchoIp = '172.30.0.2';
+    svc.networkSetupError = null;
+
+    // Stub only the leaf I/O; the real optInStack and optOutStack run so
+    // the cascade contract is exercised end-to-end.
+    const meshSvc = MeshService.getInstance();
+    vi.spyOn(meshSvc as unknown as { inspectStackServices: (n: number, s: string) => Promise<unknown> }, 'inspectStackServices')
+        .mockResolvedValue([{ service: 'web', ports: [8080] }]);
+    vi.spyOn(meshSvc as unknown as { pushOverrideToNode: (n: number, s: string) => Promise<void> }, 'pushOverrideToNode')
+        .mockResolvedValue(undefined);
+    vi.spyOn(meshSvc as unknown as { regenerateOverridesAcrossFleet: (n?: number, s?: string) => Promise<void> }, 'regenerateOverridesAcrossFleet')
+        .mockResolvedValue(undefined);
+    vi.spyOn(meshSvc as unknown as { syncForwarderListeners: () => Promise<void> }, 'syncForwarderListeners')
+        .mockResolvedValue(undefined);
+    vi.spyOn(meshSvc as unknown as { refreshAliasCache: () => Promise<void> }, 'refreshAliasCache')
+        .mockResolvedValue(undefined);
+    vi.spyOn(meshSvc as unknown as { triggerRedeploy: (n: number, s: string, a: string) => void }, 'triggerRedeploy')
+        .mockReturnValue(undefined);
+    vi.spyOn(meshSvc as unknown as { cascadeRecomposeAcrossFleet: (n?: number, s?: string, a?: string) => void }, 'cascadeRecomposeAcrossFleet')
+        .mockReturnValue(undefined);
+});
+
+describe('DELETE /api/stacks/:stackName mesh opt-out cascade (F-1 / F-14)', () => {
+    it('clears the mesh_stacks row and removes the override file when the deleted stack was opted in', async () => {
+        const db = DatabaseService.getInstance();
+        const localNodeId = db.getNodes()[0].id;
+        const svc = MeshService.getInstance();
+        const removeSpy = vi.spyOn(svc as unknown as { removeStackOverride: (n: number, s: string) => Promise<void> }, 'removeStackOverride')
+            .mockResolvedValue(undefined);
+
+        await svc.optInStack(localNodeId, 'api', 'tester');
+        expect(db.isMeshStackEnabled(localNodeId, 'api')).toBe(true);
+
+        const res = await request(app)
+            .delete('/api/stacks/api')
+            .set('Cookie', adminCookie);
+
+        expect(res.status).toBe(200);
+        expect(db.isMeshStackEnabled(localNodeId, 'api')).toBe(false);
+        expect(removeSpy).toHaveBeenCalledWith(localNodeId, 'api');
+    });
+
+    it('is a no-op when the deleted stack was never opted into the mesh', async () => {
+        const svc = MeshService.getInstance();
+        const removeSpy = vi.spyOn(svc as unknown as { removeStackOverride: (n: number, s: string) => Promise<void> }, 'removeStackOverride')
+            .mockResolvedValue(undefined);
+
+        const res = await request(app)
+            .delete('/api/stacks/never-meshed')
+            .set('Cookie', adminCookie);
+
+        expect(res.status).toBe(200);
+        // optOutStack short-circuits at isMeshStackEnabled === false, so the
+        // override removal is never invoked.
+        expect(removeSpy).not.toHaveBeenCalled();
+    });
+
+    it('still returns 200 and warns when the mesh cascade itself rejects', async () => {
+        const db = DatabaseService.getInstance();
+        const localNodeId = db.getNodes()[0].id;
+        const svc = MeshService.getInstance();
+
+        await svc.optInStack(localNodeId, 'api', 'tester');
+        vi.spyOn(svc, 'optOutStack').mockRejectedValue(new Error('simulated mesh failure'));
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+        const res = await request(app)
+            .delete('/api/stacks/api')
+            .set('Cookie', adminCookie);
+
+        expect(res.status).toBe(200);
+        const sawCascadeWarning = warnSpy.mock.calls.some(args =>
+            typeof args[0] === 'string' && args[0].includes('Mesh opt-out cascade failed')
+        );
+        expect(sawCascadeWarning).toBe(true);
+    });
+});

--- a/backend/src/routes/stacks.ts
+++ b/backend/src/routes/stacks.ts
@@ -6,6 +6,7 @@ import { FileSystemService } from '../services/FileSystemService';
 import { ComposeService, getComposeRollbackInfo } from '../services/ComposeService';
 import DockerController from '../services/DockerController';
 import { DatabaseService } from '../services/DatabaseService';
+import { MeshService } from '../services/MeshService';
 import { CacheService } from '../services/CacheService';
 import { UpdatePreviewService } from '../services/UpdatePreviewService';
 import { GitSourceService, GitSourceError, repoHost as gitRepoHost } from '../services/GitSourceService';
@@ -561,6 +562,24 @@ stacksRouter.delete('/:stackName', async (req: Request, res: Response) => {
     DatabaseService.getInstance().clearStackAutoUpdateSetting(req.nodeId, stackName);
     DatabaseService.getInstance().deleteRoleAssignmentsByResource('stack', stackName);
     DatabaseService.getInstance().deleteGitSource(stackName);
+
+    // Cascade a mesh opt-out so the mesh_stacks row, override file on disk,
+    // and derived aliases do not outlive the stack. optOutStack is idempotent
+    // (no-op when the stack was never opted in). Best-effort: a mesh cleanup
+    // failure must not regress the delete itself.
+    try {
+      await MeshService.getInstance().optOutStack(
+        req.nodeId,
+        stackName,
+        req.user?.username ?? 'system',
+      );
+    } catch (meshErr) {
+      console.warn(
+        '[Stacks] Mesh opt-out cascade failed for %s, continuing delete:',
+        sanitizeForLog(stackName),
+        meshErr,
+      );
+    }
 
     if (fsErr) throw fsErr;
 


### PR DESCRIPTION
## Summary

- `DELETE /api/stacks/:name` now invokes `MeshService.optOutStack` after the DB cleanup so a deleted stack does not leave behind a `mesh_stacks` row, an override file under `<DATA_DIR>/mesh/overrides/<nodeId>/`, or any derived aliases. Closes the F-1 / F-14 pair from the audit doc.
- The cascade is best-effort relative to the delete: a mesh failure warns through `console.warn` but never regresses the delete contract.
- `optOutStack` is idempotent (early return on `isMeshStackEnabled === false`) and already cascades override-regen plus recompose across the rest of the fleet, so peers' `/etc/hosts` drop the dropped alias automatically.
- New regression test `stack-delete-cascades-mesh-opt-out.test.ts` locks three contracts: cascade on delete, no-op on never-meshed, and 200 + warn when the cascade rejects.

## Why now

The mesh data-plane top blockers (F-0, F-3, F-8, F-9, F-17) are closed in 0.81.10. F-1 / F-14 is the first remaining item in the audit doc's "Significant bugs" list and the only one filed against the stack lifecycle rather than the data plane proper. The fix is a single new call site inside an existing handler; the dependency already exists, is idempotent, and already cascades across the fleet thanks to the F-8 work (PR #1090).

## Gate parity

Pre-commit grep against staged paths for `tierGates | requirePaid | requireAdmiral | isPaid | isAdmiral | PaidGate | AdmiralGate | CapabilityGate` returned empty. This fix touches no gate. The DELETE handler retains its existing `requirePermission('stack:delete', ...)` guard; `optOutStack` is a callee, not a new endpoint.

## Test plan

- [x] `cd backend && npx tsc --noEmit` (clean)
- [x] `cd backend && npm test` (2258 passing; one pre-existing Windows-only `EBUSY` flake on `filesystem-backup.test.ts` that reproduces unchanged in isolation, called out in the audit doc)
- [x] New `stack-delete-cascades-mesh-opt-out.test.ts` green in isolation (3/3)
- [x] Code review pass; comment trims applied
- [ ] Post-merge collaborative end-to-end on workstation central + the proxy peer: opt a local stack into mesh, delete it, confirm `optedInStacks` no longer lists it, the alias is gone, and the override file is removed from disk; then on a cross-node setup, confirm a previously-meshed peer's container is recomposed with the deleted alias dropped from `/etc/hosts`