### PR TITLE
fix(mesh): surface stopped-stack opt-ins on routing node cards (F-13 / F-12)

### DIFF
--- a/backend/src/__tests__/mesh-status-resolvability.test.ts
+++ b/backend/src/__tests__/mesh-status-resolvability.test.ts
@@ -1,0 +1,138 @@
+/**
+ * `MeshService.getStatus().optedInStacks[i].currentlyResolvable` contract.
+ *
+ * The Routing tab needs to distinguish two states for an opted-in stack:
+ *  - resolvable: the alias cache currently carries at least one alias for
+ *    `(nodeId, stackName)` (services are running and inspectable).
+ *  - suspended: the `mesh_stacks` row still exists, but the alias cache has
+ *    nothing for that pair (stack stopped, ports gone).
+ *
+ * Reading `this.aliasCache` directly keeps the new field aligned with what
+ * `/api/mesh/aliases` reports without paying an extra Dockerode / cross-node
+ * inspect on every status poll.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { setupTestDb, cleanupTestDb } from './helpers/setupTestDb';
+import { MeshService, type MeshGlobalAlias } from '../services/MeshService';
+import { DatabaseService } from '../services/DatabaseService';
+
+let tmpDir: string;
+beforeAll(async () => { tmpDir = await setupTestDb(); });
+afterAll(() => cleanupTestDb(tmpDir));
+
+function uniqueSuffix(): string {
+    return `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function seedProxyNode(meshEnabled: boolean): number {
+    const db = DatabaseService.getInstance();
+    const id = db.addNode({
+        name: `peer-resolv-${uniqueSuffix()}`,
+        type: 'remote',
+        mode: 'proxy',
+        api_url: `https://peer-${uniqueSuffix()}.example.com`,
+        api_token: `tok-${uniqueSuffix()}`,
+        compose_dir: '/tmp',
+        is_default: false,
+    });
+    if (meshEnabled) db.setNodeMeshEnabled(id, true);
+    return id;
+}
+
+function setAliasCache(entries: MeshGlobalAlias[]): void {
+    const svc = MeshService.getInstance() as unknown as {
+        aliasCache: Map<string, MeshGlobalAlias>;
+    };
+    svc.aliasCache = new Map(entries.map((a) => [a.host, a]));
+}
+
+beforeEach(() => {
+    DatabaseService.getInstance().getDb().prepare('DELETE FROM nodes WHERE is_default = 0').run();
+    DatabaseService.getInstance().getDb().prepare('DELETE FROM mesh_stacks').run();
+    setAliasCache([]);
+});
+
+describe('MeshService.getStatus optedInStacks.currentlyResolvable', () => {
+    it('reports currentlyResolvable=true when the alias cache has an alias for the stack', async () => {
+        const id = seedProxyNode(true);
+        const db = DatabaseService.getInstance();
+        db.insertMeshStack(id, 'whoami', 'admin');
+        setAliasCache([
+            { host: 'whoami.whoami.peer.sencho', nodeId: id, nodeName: 'peer', stackName: 'whoami', serviceName: 'whoami', port: 80 },
+        ]);
+
+        const statuses = await MeshService.getInstance().getStatus();
+        const entry = statuses.find((s) => s.nodeId === id);
+        expect(entry?.optedInStacks).toEqual([{ stackName: 'whoami', currentlyResolvable: true }]);
+    });
+
+    it('reports currentlyResolvable=false when the alias cache is empty for the stack', async () => {
+        const id = seedProxyNode(true);
+        DatabaseService.getInstance().insertMeshStack(id, 'whoami', 'admin');
+        setAliasCache([]);
+
+        const statuses = await MeshService.getInstance().getStatus();
+        const entry = statuses.find((s) => s.nodeId === id);
+        expect(entry?.optedInStacks).toEqual([{ stackName: 'whoami', currentlyResolvable: false }]);
+    });
+
+    it('handles a mix of resolvable and suspended opt-ins on the same node', async () => {
+        const id = seedProxyNode(true);
+        const db = DatabaseService.getInstance();
+        db.insertMeshStack(id, 'whoami', 'admin');
+        db.insertMeshStack(id, 'paperless', 'admin');
+        setAliasCache([
+            { host: 'whoami.whoami.peer.sencho', nodeId: id, nodeName: 'peer', stackName: 'whoami', serviceName: 'whoami', port: 80 },
+        ]);
+
+        const statuses = await MeshService.getInstance().getStatus();
+        const entry = statuses.find((s) => s.nodeId === id);
+        const byName = new Map(entry?.optedInStacks.map((s) => [s.stackName, s.currentlyResolvable]) ?? []);
+        expect(byName.get('whoami')).toBe(true);
+        expect(byName.get('paperless')).toBe(false);
+        expect(entry?.optedInStacks).toHaveLength(2);
+    });
+
+    it('returns an empty optedInStacks array for a node with no opt-ins (shape regression)', async () => {
+        const id = seedProxyNode(true);
+
+        const statuses = await MeshService.getInstance().getStatus();
+        const entry = statuses.find((s) => s.nodeId === id);
+        expect(entry?.optedInStacks).toEqual([]);
+    });
+
+    it('does not invent a phantom opt-in from a stale alias whose stack is not in mesh_stacks', async () => {
+        // Invariant: `optedInStacks` is derived from the persistent
+        // `mesh_stacks` table; the alias cache only adjusts the
+        // `currentlyResolvable` flag for existing rows. A stale alias entry
+        // (e.g. cached for a stack that was just deleted) must NOT surface as
+        // a phantom opt-in.
+        const id = seedProxyNode(true);
+        // No `insertMeshStack` call — node has no opt-ins.
+        setAliasCache([
+            { host: 'ghost.ghost.peer.sencho', nodeId: id, nodeName: 'peer', stackName: 'ghost', serviceName: 'ghost', port: 80 },
+        ]);
+
+        const statuses = await MeshService.getInstance().getStatus();
+        const entry = statuses.find((s) => s.nodeId === id);
+        expect(entry?.optedInStacks).toEqual([]);
+    });
+
+    it('scopes resolvability per node: an alias on node A does not make stack X resolvable on node B', async () => {
+        const idA = seedProxyNode(true);
+        const idB = seedProxyNode(true);
+        const db = DatabaseService.getInstance();
+        db.insertMeshStack(idA, 'shared', 'admin');
+        db.insertMeshStack(idB, 'shared', 'admin');
+        // Alias exists only for node A.
+        setAliasCache([
+            { host: 'shared.shared.peer-a.sencho', nodeId: idA, nodeName: 'peer-a', stackName: 'shared', serviceName: 'shared', port: 80 },
+        ]);
+
+        const statuses = await MeshService.getInstance().getStatus();
+        const a = statuses.find((s) => s.nodeId === idA);
+        const b = statuses.find((s) => s.nodeId === idB);
+        expect(a?.optedInStacks).toEqual([{ stackName: 'shared', currentlyResolvable: true }]);
+        expect(b?.optedInStacks).toEqual([{ stackName: 'shared', currentlyResolvable: false }]);
+    });
+});

--- a/backend/src/services/MeshService.ts
+++ b/backend/src/services/MeshService.ts
@@ -190,7 +190,18 @@ export interface MeshNodeStatus {
     reachableReason: string | null;
     /** Peer→central reverse path state. `not_applicable` for non-proxy peers. */
     reverseCallbackStatus: MeshReverseCallbackStatus;
-    optedInStacks: string[];
+    /**
+     * Stacks opted into the mesh on this node, with a per-stack resolvability
+     * flag. `currentlyResolvable` is `true` iff the alias cache currently
+     * carries at least one alias for that (nodeId, stackName) pair, i.e. the
+     * stack's services were inspectable and exposed at least one port the
+     * last time `refreshAliasCache()` ran (every 60 s on a timer, plus on
+     * opt-in / opt-out and pilot reconnect). A suspended opt-in (stack
+     * stopped, services not running) reports `currentlyResolvable: false` so
+     * the Routing tab can surface the asymmetry between the persistent
+     * registry and the live alias list.
+     */
+    optedInStacks: Array<{ stackName: string; currentlyResolvable: boolean }>;
     activeStreamCount: number;
 }
 
@@ -2131,6 +2142,15 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
         const localListening = this.isLocalForwarderActive();
         const ptm = PilotTunnelManager.getInstance();
         const dialer = MeshProxyTunnelDialer.getInstance();
+        // Precompute the (nodeId, stackName) pairs that currently have at least
+        // one alias in the cache. Reading the cache (refreshed every 60 s and
+        // on opt-in/opt-out) keeps the new `currentlyResolvable` field aligned
+        // with what `/api/mesh/aliases` reports, without paying the cost of a
+        // fresh Dockerode/cross-node inspect per status poll.
+        const resolvableKeys = new Set<string>();
+        for (const alias of this.aliasCache.values()) {
+            resolvableKeys.add(`${alias.nodeId}:${alias.stackName}`);
+        }
         return nodes.map((node) => {
             const reach = this.computeReachable(node, localNodeId);
             const meshEnabled = db.getNodeMeshEnabled(node.id);
@@ -2148,7 +2168,10 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
                 reachableMode: reach.mode,
                 reachableReason: reach.reason,
                 reverseCallbackStatus: this.computeReverseCallbackStatus(node, meshEnabled, dialer),
-                optedInStacks: db.listMeshStacks(node.id).map((s) => s.stack_name),
+                optedInStacks: db.listMeshStacks(node.id).map((s) => ({
+                    stackName: s.stack_name,
+                    currentlyResolvable: resolvableKeys.has(`${node.id}:${s.stack_name}`),
+                })),
                 activeStreamCount: this.activeStreams.size,
             };
         });

--- a/docs/features/sencho-mesh.mdx
+++ b/docs/features/sencho-mesh.mdx
@@ -180,6 +180,10 @@ A few things are deliberately out of scope for the first release:
     The stack is opted into the mesh but exposes no service ports that became aliases. The stack joins `sencho_mesh` (other meshed containers can talk to it directly by container name) but no fleet-wide hostname is published. To publish an alias, declare a port on a service in the stack's compose file and redeploy.
   </Accordion>
 
+  <Accordion title="A stack on the Routing tab shows a `suspended` pill">
+    The stack is opted into the mesh, but its services are not currently running, so there are no aliases to publish. The opt-in is sticky: when the stack starts again, its aliases reappear automatically on the next refresh (within roughly one minute) without needing a manual opt-out and re-opt-in. To clear the suspended state, start the stack from its **Overview** page. To remove the opt-in entirely, open the node card and use the opt-out action.
+  </Accordion>
+
   <Accordion title="Graph reflects a stale node state">
     The Routing tab polls `/mesh/status` and `/mesh/aliases` every 30 seconds while the browser tab is focused. To force an immediate refresh, leave and return to the Routing tab, or toggle any stack's mesh state to trigger an action-driven refresh. Polling pauses when the tab is hidden, so a long-dormant tab catches up on the first poll after it regains focus.
   </Accordion>

--- a/frontend/src/components/fleet/RoutingNodeCard.tsx
+++ b/frontend/src/components/fleet/RoutingNodeCard.tsx
@@ -25,6 +25,16 @@ export function RoutingNodeCard({
     const [testingAlias, setTestingAlias] = useState<string | null>(null);
 
     const nodeAliases = aliases.filter((a) => a.nodeId === status.nodeId);
+    const hasOptIns = status.optedInStacks.length > 0;
+    // Defensive de-dup: `/mesh/status` and `/mesh/aliases` are fetched
+    // separately, so a transient inconsistency between the two snapshots
+    // could otherwise render both a live alias row and a suspended row for
+    // the same stack. Drop suspended entries that the alias snapshot still
+    // covers; the alias row already represents the live state.
+    const stackNamesWithAliases = new Set(nodeAliases.map((a) => a.stackName));
+    const suspendedOptIns = status.optedInStacks.filter(
+        (s) => !s.currentlyResolvable && !stackNamesWithAliases.has(s.stackName),
+    );
 
     const toggleEnabled = async (next: boolean) => {
         setToggling(true);
@@ -122,7 +132,7 @@ export function RoutingNodeCard({
                 {status.enabled && (
                     <>
                         <div className="border-t border-card-border pt-2 space-y-1">
-                            {nodeAliases.length === 0 && (
+                            {!hasOptIns && nodeAliases.length === 0 && (
                                 <div className="text-[11px] text-stat-subtitle">No mesh services on this node yet.</div>
                             )}
                             {nodeAliases.map((a) => {
@@ -156,6 +166,25 @@ export function RoutingNodeCard({
                                     </div>
                                 );
                             })}
+                            {suspendedOptIns.map((s) => (
+                                <div
+                                    key={`suspended-${s.stackName}`}
+                                    className="flex items-center justify-between gap-2 rounded border border-card-border bg-card px-2 py-1.5"
+                                    title="Stack is opted into the mesh but has no running services. Aliases will publish when the stack starts."
+                                >
+                                    <span className="text-[11px] font-mono text-left truncate text-stat-subtitle">
+                                        {s.stackName}
+                                    </span>
+                                    <span className="shrink-0 px-1.5 py-0.5 rounded-sm border border-amber-500/40 bg-amber-500/10 text-[10px] leading-3 font-mono uppercase tracking-[0.18em] text-amber-600 dark:text-amber-400">
+                                        suspended
+                                    </span>
+                                </div>
+                            ))}
+                            {suspendedOptIns.length > 0 && (
+                                <div className="text-[11px] text-stat-subtitle pt-1">
+                                    Stack stopped, alias resumes when services start.
+                                </div>
+                            )}
                         </div>
                         <Button
                             variant="outline" size="sm" className="w-full"

--- a/frontend/src/lib/mesh-topology-layout.test.ts
+++ b/frontend/src/lib/mesh-topology-layout.test.ts
@@ -39,32 +39,54 @@ function makeAlias(over: Partial<MeshAlias> & Pick<MeshAlias, 'host' | 'nodeId'>
     };
 }
 
+function entries(...names: string[]): MeshNodeStatus['optedInStacks'] {
+    return names.map((stackName) => ({ stackName, currentlyResolvable: true }));
+}
+
 describe('stacksKey', () => {
     it('returns the same key for the same membership regardless of order', () => {
-        expect(stacksKey(['a', 'b', 'c'])).toBe(stacksKey(['c', 'a', 'b']));
+        expect(stacksKey(entries('a', 'b', 'c'))).toBe(stacksKey(entries('c', 'a', 'b')));
     });
 
     it('differs when membership differs even with the same count', () => {
-        expect(stacksKey(['a', 'b'])).not.toBe(stacksKey(['a', 'c']));
+        expect(stacksKey(entries('a', 'b'))).not.toBe(stacksKey(entries('a', 'c')));
     });
 
     it('returns empty string for empty list', () => {
         expect(stacksKey([])).toBe('');
     });
+
+    it('differs when a stack flips currentlyResolvable', () => {
+        const a = [{ stackName: 'svc', currentlyResolvable: true }];
+        const b = [{ stackName: 'svc', currentlyResolvable: false }];
+        expect(stacksKey(a)).not.toBe(stacksKey(b));
+    });
 });
 
 describe('meshNodeStateEqual', () => {
-    const base = makeNode({ nodeId: 1, nodeName: 'n', reachableMode: 'pilot', enabled: true, pilotConnected: true, optedInStacks: ['a', 'b'] });
+    const base = makeNode({ nodeId: 1, nodeName: 'n', reachableMode: 'pilot', enabled: true, pilotConnected: true, optedInStacks: entries('a', 'b') });
 
     it('returns true when scalar fields and stack membership match', () => {
         const a = { ...base };
-        const b = { ...base, optedInStacks: ['b', 'a'] };
+        const b = { ...base, optedInStacks: entries('b', 'a') };
         expect(meshNodeStateEqual(a, b)).toBe(true);
     });
 
     it('detects a stack swap that preserves the count', () => {
         const a = { ...base };
-        const b = { ...base, optedInStacks: ['a', 'c'] };
+        const b = { ...base, optedInStacks: entries('a', 'c') };
+        expect(meshNodeStateEqual(a, b)).toBe(false);
+    });
+
+    it('detects a resolvability flip on a stack that otherwise stays identical', () => {
+        const a = { ...base };
+        const b = {
+            ...base,
+            optedInStacks: [
+                { stackName: 'a', currentlyResolvable: false },
+                { stackName: 'b', currentlyResolvable: true },
+            ],
+        };
         expect(meshNodeStateEqual(a, b)).toBe(false);
     });
 

--- a/frontend/src/lib/mesh-topology-layout.ts
+++ b/frontend/src/lib/mesh-topology-layout.ts
@@ -22,8 +22,11 @@ export function miniMapColorFor(node: MeshNodeStatus | undefined): string {
     return MINIMAP_BRAND;
 }
 
-export function stacksKey(stacks: readonly string[]): string {
-    return [...stacks].sort().join(' ');
+export function stacksKey(stacks: MeshNodeStatus['optedInStacks']): string {
+    return [...stacks]
+        .map((s) => `${s.stackName}:${s.currentlyResolvable ? '1' : '0'}`)
+        .sort()
+        .join(' ');
 }
 
 export function meshNodeStateEqual(a: MeshNodeStatus, b: MeshNodeStatus): boolean {

--- a/frontend/src/types/mesh.ts
+++ b/frontend/src/types/mesh.ts
@@ -53,7 +53,14 @@ export interface MeshNodeStatus {
     reachableReason: string | null;
     /** Peer→central reverse path state. `not_applicable` for non-proxy peers. */
     reverseCallbackStatus: MeshReverseCallbackStatus;
-    optedInStacks: string[];
+    /**
+     * Stacks opted into the mesh on this node. `currentlyResolvable` is `true`
+     * iff the central's alias cache currently carries at least one alias for
+     * that (nodeId, stackName) pair. A suspended opt-in (stack stopped,
+     * services not running) reports `currentlyResolvable: false`; the Routing
+     * tab renders a `suspended` pill for those entries.
+     */
+    optedInStacks: Array<{ stackName: string; currentlyResolvable: boolean }>;
     activeStreamCount: number;
 }
 


### PR DESCRIPTION
## Summary

- Add `currentlyResolvable: boolean` per entry in `MeshNodeStatus.optedInStacks`, computed from the existing alias cache so the new flag stays consistent with `/api/mesh/aliases` without an extra Dockerode or cross-node inspect on the status path.
- Render an amber `suspended` pill for entries whose stack is opted in but currently has no running services, plus a single explanatory caption `Stack stopped, alias resumes when services start.` below the suspended list.
- Resolve the contradictory `Mesh stacks: 1 / Aliases: 0 / No mesh services on this node yet` copy on the node card; the misleading line is now only shown when the node truly has no opt-ins.

Closes F-13 and F-12 from `docs/internal/mesh-e2e-2026-05-17.md`. Bundled because both findings touch the same Routing surface, same data path, and same code lines; the F-13 UI change replaces the F-12 contradictory copy as a natural consequence.

## Approach

- **Backend (`backend/src/services/MeshService.ts`).** `MeshNodeStatus.optedInStacks` wire shape moves from `string[]` to `Array<{ stackName: string; currentlyResolvable: boolean }>` (greenfield per Directive 20, no compat shim). `getStatus()` precomputes a `Set<${nodeId}:${stackName}>` from `this.aliasCache.values()` once per call, then projects each `mesh_stacks` row through `Set.has`. O(N+M), no extra I/O. The cache is already refreshed every 60s on the `ALIAS_REFRESH_INTERVAL_MS` timer plus on every opt-in / opt-out and pilot reconnect, so the new field aligns with `/api/mesh/aliases` for free.
- **Frontend types (`frontend/src/types/mesh.ts`).** Duplicated `MeshNodeStatus` type mirrors the backend shape change. The two types are co-edited together per repo convention; there is no shared package today.
- **Frontend memoization (`frontend/src/lib/mesh-topology-layout.ts`).** `stacksKey` folds `currentlyResolvable` into the memoization key so the topology graph re-renders when a stack flips state. `meshNodeStateEqual` uses the same key.
- **Frontend UI (`frontend/src/components/fleet/RoutingNodeCard.tsx`).** Resolvable opt-ins continue to render through the existing `nodeAliases.map` path. Unresolvable opt-ins render as separate rows carrying the stack name plus an amber `suspended` pill (mirroring the styling of the existing `reverse unavailable` pill on the same component). Defensive de-dup filters suspended entries against the live alias snapshot to handle the transient gap where `/mesh/status` and `/mesh/aliases` return slightly inconsistent views from their separate fetches.

## Test plan

- [x] `cd backend && npx tsc --noEmit` clean.
- [x] `cd frontend && npx tsc -b --noEmit` clean.
- [x] `npx vitest run mesh-status-resolvability` — 6 cases green (resolvable, suspended, mixed, empty shape regression, per-node scoping, stale-alias-no-phantom invariant).
- [x] `npx vitest run mesh-topology-layout` — 26 cases green, including the new `stacksKey` resolvability-flip case and the `meshNodeStateEqual` resolvability-flip case.
- [x] Frontend `npx vitest run` — 240 cases green across 27 test files.
- [x] Backend mesh suite — all directly-affected tests green. One pre-existing cross-test timing flake in `mesh-service.test.ts > optOutStack cascades recompose to every other meshed stack` reproduces on `main` and passes when run in isolation; not related to this change.
- [ ] End-to-end validation collaborative with the remote peer after deploy. Plan: stop the `whoami` container on the peer (`docker stop whoami-whoami-1`); within one `ALIAS_REFRESH_INTERVAL_MS` tick (~60s + slack) central's `mesh/status.nodes[id=peer].optedInStacks[0].currentlyResolvable` flips to `false` and `/api/mesh/aliases` drops the entry; restart the container and the flip reverses. UI walked once on central: opt-in card, stop, observe `suspended` pill + caption, start, observe pill clear. Activity log scrub on both sides over a 60s window expects zero `mesh.disable | mesh.reconcile.fail | proxy-tunnel.open.fail | tunnel.fail | route.resolve.fail` entries.

## Notes

- **Gate parity (Directive 30).** No tier, role, capability, or experimental-flag gate was touched. Pre-commit grep against the gate substring set returned empty.
- **Architecture map (Directive 26).** No routes, middleware, WebSocket dispatch, services, or flow topology changed; only the shape of an existing payload. `docs/internal/architecture-map/sencho-architecture.json` does not need an update.
- **Greenfield (Directive 20).** No back-compat shim. The wire shape change is clean.