### PR TITLE
fix(mesh): clean up activeStreams on src socket close/error (F-10)

### DIFF
--- a/backend/src/__tests__/mesh-service.test.ts
+++ b/backend/src/__tests__/mesh-service.test.ts
@@ -1089,6 +1089,108 @@ describe('MeshService.openCrossNode (BUG-4)', () => {
             vi.useRealTimers();
         }
     });
+
+    // F-10 regression: src.on('close')/src.on('error') must delete the
+    // activeStreams entry, not just call tcpStream.destroy(). MeshTcpStream-
+    // Like.destroy() only sends a tcp_close frame; the handle's own 'close'
+    // event waits for the remote ack. If that ack never lands (peer gone,
+    // network drop), the record sits in activeStreams until tunnel idle-
+    // close. Use an EventEmitter-backed fake src so emit('close') actually
+    // delivers to the listener (the plain makeFakeSocket uses vi.fn for .on
+    // which records calls but never fires them).
+    function makeEmittingSocket(): EventEmitter & {
+        destroy: ReturnType<typeof vi.fn>;
+        end: ReturnType<typeof vi.fn>;
+        write: ReturnType<typeof vi.fn>;
+    } {
+        const ee = new EventEmitter() as EventEmitter & {
+            destroy: ReturnType<typeof vi.fn>;
+            end: ReturnType<typeof vi.fn>;
+            write: ReturnType<typeof vi.fn>;
+        };
+        ee.destroy = vi.fn();
+        ee.end = vi.fn();
+        ee.write = vi.fn();
+        return ee;
+    }
+
+    it('src.on(close) deletes activeStreams entry even when tcpStream never emits close', async () => {
+        const svc = MeshService.getInstance();
+        const target: MeshTarget = {
+            nodeId: 14, stack: 'audit-mesh-pilot', service: 'echo',
+            port: 9001, alias: 'echo.audit-mesh-pilot.sencho-pilot-test.sencho',
+        };
+        const fakeStream = makeFakeStream(50);
+        vi.spyOn(
+            svc as unknown as { dialMeshTcpStream: (t: MeshTarget) => MeshTcpStreamLike | null },
+            'dialMeshTcpStream',
+        ).mockReturnValue(fakeStream);
+
+        const fakeSrc = makeEmittingSocket();
+        await (svc as unknown as { openCrossNode: (t: MeshTarget, s: unknown) => Promise<void> })
+            .openCrossNode(target, fakeSrc);
+
+        const activeStreams = (svc as unknown as { activeStreams: Map<number, unknown> }).activeStreams;
+        expect(activeStreams.size).toBe(1);
+        expect(activeStreams.has(50)).toBe(true);
+
+        fakeSrc.emit('close');
+
+        expect(activeStreams.size).toBe(0);
+        expect(fakeStream.destroy).toHaveBeenCalled();
+    });
+
+    it('src.on(error) deletes activeStreams entry symmetrically', async () => {
+        const svc = MeshService.getInstance();
+        const target: MeshTarget = {
+            nodeId: 14, stack: 'audit-mesh-pilot', service: 'echo',
+            port: 9001, alias: 'echo.audit-mesh-pilot.sencho-pilot-test.sencho',
+        };
+        const fakeStream = makeFakeStream(51);
+        vi.spyOn(
+            svc as unknown as { dialMeshTcpStream: (t: MeshTarget) => MeshTcpStreamLike | null },
+            'dialMeshTcpStream',
+        ).mockReturnValue(fakeStream);
+
+        const fakeSrc = makeEmittingSocket();
+        await (svc as unknown as { openCrossNode: (t: MeshTarget, s: unknown) => Promise<void> })
+            .openCrossNode(target, fakeSrc);
+
+        const activeStreams = (svc as unknown as { activeStreams: Map<number, unknown> }).activeStreams;
+        expect(activeStreams.size).toBe(1);
+
+        fakeSrc.emit('error', new Error('connection reset by peer'));
+
+        expect(activeStreams.size).toBe(0);
+        expect(fakeStream.destroy).toHaveBeenCalled();
+    });
+
+    it('cleanup is idempotent when both src and tcpStream emit close', async () => {
+        const svc = MeshService.getInstance();
+        const target: MeshTarget = {
+            nodeId: 14, stack: 'audit-mesh-pilot', service: 'echo',
+            port: 9001, alias: 'echo.audit-mesh-pilot.sencho-pilot-test.sencho',
+        };
+        const fakeStream = makeFakeStream(52);
+        vi.spyOn(
+            svc as unknown as { dialMeshTcpStream: (t: MeshTarget) => MeshTcpStreamLike | null },
+            'dialMeshTcpStream',
+        ).mockReturnValue(fakeStream);
+
+        const fakeSrc = makeEmittingSocket();
+        await (svc as unknown as { openCrossNode: (t: MeshTarget, s: unknown) => Promise<void> })
+            .openCrossNode(target, fakeSrc);
+
+        const activeStreams = (svc as unknown as { activeStreams: Map<number, unknown> }).activeStreams;
+        expect(activeStreams.size).toBe(1);
+
+        expect(() => {
+            fakeSrc.emit('close');
+            fakeStream.emit('close');
+        }).not.toThrow();
+
+        expect(activeStreams.size).toBe(0);
+    });
 });
 
 describe('MeshService.openCrossNode without reverseDialer', () => {

--- a/backend/src/services/MeshService.ts
+++ b/backend/src/services/MeshService.ts
@@ -1888,6 +1888,16 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
         const clearOpenTimer = () => {
             if (openTimer) { clearTimeout(openTimer); openTimer = null; }
         };
+        // Idempotent stream cleanup. F-10: src.on('close'/'error') used to
+        // only destroy tcpStream and never delete the activeStreams entry,
+        // so failed dials whose remote tcp_close ack was lost (or whose peer
+        // was already gone) leaked records until the whole tunnel idle-
+        // closed. Map.delete is naturally idempotent, so it's safe for both
+        // the src side and the tcpStream side to call this.
+        const cleanupRecord = () => {
+            clearOpenTimer();
+            this.activeStreams.delete(record.streamId);
+        };
 
         tcpStream.on('open', () => {
             clearOpenTimer();
@@ -1903,18 +1913,16 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
             try { src.write(chunk); } catch { /* ignore */ }
         });
         tcpStream.on('error', (err: Error) => {
-            clearOpenTimer();
+            cleanupRecord();
             this.logActivity({
                 source: 'pilot', level: 'error', type: 'tunnel.fail',
                 nodeId: target.nodeId, alias: target.alias, streamId: record.streamId,
                 message: sanitizeForLog(err.message),
             });
-            this.activeStreams.delete(record.streamId);
             try { src.destroy(); } catch { /* ignore */ }
         });
         tcpStream.on('close', () => {
-            clearOpenTimer();
-            this.activeStreams.delete(record.streamId);
+            cleanupRecord();
             try { src.end(); } catch { /* ignore */ }
         });
         src.on('data', (chunk: Buffer) => {
@@ -1922,8 +1930,8 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
             tcpStream.write(chunk);
         });
         src.on('end', () => tcpStream.end());
-        src.on('close', () => { clearOpenTimer(); tcpStream.destroy(); });
-        src.on('error', () => { clearOpenTimer(); tcpStream.destroy(); });
+        src.on('close', () => { cleanupRecord(); try { tcpStream.destroy(); } catch { /* ignore */ } });
+        src.on('error', () => { cleanupRecord(); try { tcpStream.destroy(); } catch { /* ignore */ } });
     }
 
     private registerActiveStream(alias: string, streamId?: number): ActiveStreamRecord {


### PR DESCRIPTION
## Summary

Fixes F-10 from the mesh E2E audit (`docs/internal/mesh-e2e-2026-05-17.md`): failed cross-node mesh streams leaked entries into `MeshService.activeStreams` until the entire tunnel idle-closed, producing a monotonically-climbing `activeStreamCount`.

- Root cause: `MeshService.openCrossNode` wired `src.on('close')` and `src.on('error')` to call `tcpStream.destroy()` but never delete the activeStreams record. `MeshTcpStreamLike.destroy()` sends a `tcp_close` frame to the remote; the local `close` event only fires when the remote acks back via `_dispatchClose`. Lost acks (peer gone, network drop, F-9-era timeouts) left the record indefinitely.
- Fix: introduce a `cleanupRecord()` closure that clears the open timer and deletes the record, and route all four lifecycle handlers through it. `Map.delete` is idempotent so double-cleanup on normal close is a free no-op.
- The same-node `openSameNode` path already had this shape via its `teardown()` closure; this brings cross-node to parity.

## Test plan

- [x] `cd backend && npx tsc --noEmit` — zero type errors
- [x] `cd backend && npx vitest run mesh-service` — 62 passing (existing 59 + 3 new)
- [x] Full backend suite — 2271 passing (the one Windows file-lock flake on `filesystem-backup.test.ts` is the pre-existing flake documented in the F-3 validation block of the audit)
- [x] Code review across reuse / quality / efficiency dimensions; no actionable findings against the diff
- [ ] **Post-merge end-to-end across workstation central + sencho-test-03 peer** (anticipated `0.81.15`):
  - Baseline `/api/mesh/diag` activeStreamCount.
  - 5 failing curls from a meshed local container to a remote alias on an intentionally-wrong port; assert counter returns to baseline within ~5 s (pre-fix: stays elevated until tunnel idle-close).
  - 5 successful curls on the correct port; assert counter returns to baseline (success-path regression).
  - F-9 forward alpine probe regression check.
  - Peer-side cross-check from the Claude on `sencho-test-03` snapshotting its own `/api/mesh/diag` across the same window.
  - Activity-log scrub for `forwarder.error` / `mesh.reconcile.fail` / `proxy-tunnel.open.fail` (expect zero); `tunnel.fail` count from the failed-dial phase is expected and benign.

## Notes

- No public API change. No new state. No new types. Branch isolated to `MeshService.openCrossNode` lifecycle handlers (production) and one new describe-block-local helper plus three Vitest cases (test).
- Three new test cases use an EventEmitter-backed fake `src` so `emit('close')` actually delivers to the registered listener; the existing `makeFakeSocket()` in the same describe block uses `vi.fn` for `.on` which records calls but never fires them.