### PR TITLE
fix(stack-editor): reset tab to compose.yaml when clicking edit

### DIFF
--- a/frontend/src/components/EditorLayout/EditorView.tsx
+++ b/frontend/src/components/EditorLayout/EditorView.tsx
@@ -823,7 +823,7 @@ export function EditorView({
                         envContent={envContent}
                         selectedEnvFile={selectedEnvFile}
                         gitSourcePending={Boolean(gitSourcePendingMap[stackName])}
-                        onEditCompose={() => setEditingCompose(true)}
+                        onEditCompose={() => { setEditingCompose(true); setActiveTab('compose'); }}
                         onOpenFiles={() => { setEditingCompose(true); setActiveTab('files'); }}
                         onOpenGitSource={() => setGitSourceOpen(true)}
                         onApplyUpdate={() => { void updateStack(); }}


### PR DESCRIPTION
## Summary

- The Edit button on the stack anatomy panel previously only flipped the editor visibility flag and did not reset the active tab.
- After a user clicked Files (which sets the active tab to Files), closed the editor, then clicked Edit, the editor reopened still on the Files tab instead of the compose.yaml editor.
- Make `onEditCompose` mirror the sibling `onOpenFiles` handler by also setting `activeTab` to `'compose'`, so the Edit button always lands on the compose editor regardless of which tab was last viewed.

## Test plan

- [x] Frontend type-check (`npx tsc -b --noEmit`) is clean.
- [x] Manual repro and verification on a stack detail page:
  - Click Files in the anatomy panel header, confirm the editor opens on the Files tab.
  - Click Close editor, confirm the anatomy panel returns.
  - Click Edit, confirm the editor reopens with the compose.yaml tab selected and the YAML content visible.
- [x] Code review run on the diff.

## Notes

There is a small follow-up worth tracking: the pair `setEditingCompose + setActiveTab` is now called inline at three sites (`EditorView.tsx` twice, `useStackActions.ts` once). Extracting an `openEditor(tab)` / `closeEditor()` helper on `useEditorViewState` would fold the duplication, but that is a refactor and is intentionally not bundled into this bug-fix PR.