### PR TITLE
feat(cloud-backup): paginate cloud snapshots list

### DIFF
--- a/frontend/src/components/settings/CloudBackupSection.tsx
+++ b/frontend/src/components/settings/CloudBackupSection.tsx
@@ -10,7 +10,7 @@ import { toast } from '@/components/ui/toast-store';
 import { apiFetch } from '@/lib/api';
 import { formatBytes } from '@/lib/utils';
 import { AdmiralGate } from '@/components/AdmiralGate';
-import { Cloud, CloudOff, RefreshCw, CheckCircle2, Loader2, Trash2, Download } from 'lucide-react';
+import { Cloud, CloudOff, RefreshCw, CheckCircle2, Loader2, Trash2, Download, ChevronLeft, ChevronRight } from 'lucide-react';
 import { SettingsPrimaryButton } from './SettingsActions';
 import { useMastheadStats } from './MastheadStatsContext';
 
@@ -64,6 +64,8 @@ const PROVIDER_OPTIONS = [
 
 const PANEL_CLASS = 'rounded-lg border border-card-border border-t-card-border-top bg-card shadow-card-bevel p-4 space-y-3';
 
+const PAGE_SIZE = 10;
+
 export function CloudBackupSection() {
     const [loading, setLoading] = useState(true);
     const [saving, setSaving] = useState(false);
@@ -76,6 +78,12 @@ export function CloudBackupSection() {
     const [testing, setTesting] = useState(false);
     const [provisioning, setProvisioning] = useState(false);
     const [deleteKey, setDeleteKey] = useState<string | null>(null);
+    const [page, setPage] = useState(0);
+
+    const totalPages = Math.max(1, Math.ceil(snapshots.length / PAGE_SIZE));
+    const safePage = Math.min(page, totalPages - 1);
+    const pagedSnapshots = snapshots.slice(safePage * PAGE_SIZE, (safePage + 1) * PAGE_SIZE);
+    const needsPagination = snapshots.length > PAGE_SIZE;
 
     const loadConfig = useCallback(async () => {
         try {
@@ -449,9 +457,24 @@ export function CloudBackupSection() {
                     <div className={PANEL_CLASS}>
                         <div className="flex items-center justify-between">
                             <span className="font-medium text-sm">Cloud Snapshots</span>
-                            <Button size="sm" variant="ghost" onClick={loadSnapshots}>
-                                <RefreshCw className="w-3.5 h-3.5" strokeWidth={1.5} />
-                            </Button>
+                            <div className="flex items-center gap-1.5">
+                                {needsPagination && (
+                                    <>
+                                        <Button variant="ghost" size="icon" className="h-6 w-6" disabled={safePage === 0} onClick={() => setPage(safePage - 1)} aria-label="Previous page">
+                                            <ChevronLeft className="h-3.5 w-3.5" strokeWidth={1.5} />
+                                        </Button>
+                                        <span className="text-xs font-mono tabular-nums text-stat-subtitle min-w-[3rem] text-center">
+                                            {safePage + 1} / {totalPages}
+                                        </span>
+                                        <Button variant="ghost" size="icon" className="h-6 w-6" disabled={safePage >= totalPages - 1} onClick={() => setPage(safePage + 1)} aria-label="Next page">
+                                            <ChevronRight className="h-3.5 w-3.5" strokeWidth={1.5} />
+                                        </Button>
+                                    </>
+                                )}
+                                <Button size="sm" variant="ghost" onClick={loadSnapshots}>
+                                    <RefreshCw className="w-3.5 h-3.5" strokeWidth={1.5} />
+                                </Button>
+                            </div>
                         </div>
                         {snapshots.length === 0 ? (
                             <div className="flex items-start gap-2 text-xs text-muted-foreground py-2">
@@ -460,7 +483,7 @@ export function CloudBackupSection() {
                             </div>
                         ) : (
                             <ul className="space-y-1.5">
-                                {snapshots.map(s => (
+                                {pagedSnapshots.map(s => (
                                     <li key={s.objectKey} className="flex items-center justify-between gap-2 rounded-md border border-glass-border px-3 py-2">
                                         <div className="min-w-0 flex-1">
                                             <div className="text-xs font-mono truncate">{s.objectKey.split('/').pop()}</div>


### PR DESCRIPTION
## Summary
- Adds client-side pagination (10 per page) with prev/next chevrons and a page counter to the **Settings > Cloud Backup > Cloud Snapshots** panel.
- Long-running deployments that accumulate many snapshots no longer overflow the settings panel.
- Mirrors the existing pattern already shipped in Fleet Snapshots (`frontend/src/components/FleetSnapshots.tsx`), keeping the two snapshot surfaces consistent.

## Notes
- Pure frontend, single file changed (`frontend/src/components/settings/CloudBackupSection.tsx`).
- No backend changes: the existing `GET /cloud-backup/snapshots` already returns the list capped at 1000 S3 objects, so client-side slicing is sufficient.
- The `safePage` clamp covers the last-page-delete case (auto-falls back to the previous page) without extra reset logic.
- Pagination controls only render when `snapshots.length > 10`.
- Chevron buttons carry `aria-label` values for screen-reader accessibility.

## Test plan
- [ ] Configure Cloud Backup (Sencho Cloud Backup or custom S3) on an Admiral-tier instance with more than 10 fleet snapshots in the bucket.
- [ ] Navigate to **Settings > Cloud Backup**. Confirm the Cloud Snapshots panel shows the first 10 entries and a `1 / N` counter.
- [ ] Click the right chevron. Counter advances; older snapshots appear; left chevron becomes enabled.
- [ ] On the last page, confirm the right chevron is disabled.
- [ ] Delete a snapshot on the last page when only one entry is left there. Page should auto-clamp to the previous page (no blank list).
- [ ] On a node with 10 or fewer snapshots, confirm the chevron/counter trio is hidden and only the refresh button is present.
- [ ] Confirm the refresh button still reloads the list and updates the counter.