### PR TITLE
fix(stack-update): refresh frontend state automatically after a stack update

### DIFF
--- a/backend/src/routes/imageUpdates.ts
+++ b/backend/src/routes/imageUpdates.ts
@@ -292,6 +292,15 @@ autoUpdateRouter.post('/execute', authMiddleware, async (req: Request, res: Resp
         await compose.updateStack(stackName, undefined, atomic);
         db.clearStackUpdateStatus(req.nodeId, stackName);
 
+        NotificationService.getInstance().broadcastEvent({
+          type: 'state-invalidate',
+          scope: 'image-updates',
+          nodeId: req.nodeId,
+          stackName,
+          action: 'stack-updated',
+          ts: Date.now(),
+        });
+
         NotificationService.getInstance().dispatchAlert(
           'info',
           'image_update_applied',

--- a/backend/src/routes/stacks.ts
+++ b/backend/src/routes/stacks.ts
@@ -834,6 +834,14 @@ stacksRouter.post('/:stackName/update', async (req: Request, res: Response) => {
     await ComposeService.getInstance(req.nodeId).updateStack(stackName, getTerminalWs(), atomic);
     DatabaseService.getInstance().clearStackUpdateStatus(req.nodeId, stackName);
     invalidateNodeCaches(req.nodeId);
+    NotificationService.getInstance().broadcastEvent({
+      type: 'state-invalidate',
+      scope: 'image-updates',
+      nodeId: req.nodeId,
+      stackName,
+      action: 'stack-updated',
+      ts: Date.now(),
+    });
     console.log(`[Stacks] Update completed: ${sanitizeForLog(stackName)}`);
     if (debug) console.debug(`[Stacks:debug] Update finished in ${Date.now() - t0}ms`);
     res.json({ status: 'Update completed' });

--- a/frontend/src/components/EditorLayout.tsx
+++ b/frontend/src/components/EditorLayout.tsx
@@ -83,6 +83,7 @@ export default function EditorLayout() {
     scheduleStateInvalidateRefresh,
     toggleBulkMode, toggleSelect, clearSelection, handleBulkAction,
     stackUpdates,
+    fetchImageUpdates,
     pinned,
     isCollapsed, toggleCollapse,
     remoteSearchLoading,
@@ -130,6 +131,7 @@ export default function EditorLayout() {
     nodes,
     onStateInvalidate: scheduleStateInvalidateRefresh,
     onAutoUpdateChange: fetchAutoUpdateSettings,
+    onImageUpdatesChange: fetchImageUpdates,
   });
 
   const containerStats = useContainerStats(containers);

--- a/frontend/src/components/EditorLayout/hooks/useNotifications.test.ts
+++ b/frontend/src/components/EditorLayout/hooks/useNotifications.test.ts
@@ -60,7 +60,7 @@ describe('useNotifications', () => {
 
   it('starts with empty notifications and disconnected state', () => {
     const { result } = renderHook(() =>
-      useNotifications({ nodes: [localNode], onStateInvalidate: vi.fn(), onAutoUpdateChange: vi.fn() }),
+      useNotifications({ nodes: [localNode], onStateInvalidate: vi.fn(), onAutoUpdateChange: vi.fn(), onImageUpdatesChange: vi.fn() }),
     );
     expect(result.current.notifications).toEqual([]);
     expect(result.current.tickerConnected).toBe(false);
@@ -68,7 +68,7 @@ describe('useNotifications', () => {
 
   it('opens a local notification WebSocket on mount', () => {
     renderHook(() =>
-      useNotifications({ nodes: [localNode], onStateInvalidate: vi.fn(), onAutoUpdateChange: vi.fn() }),
+      useNotifications({ nodes: [localNode], onStateInvalidate: vi.fn(), onAutoUpdateChange: vi.fn(), onImageUpdatesChange: vi.fn() }),
     );
     expect(MockWS.instances.length).toBeGreaterThanOrEqual(1);
     expect(MockWS.instances[0]).toBeDefined();
@@ -76,7 +76,7 @@ describe('useNotifications', () => {
 
   it('sets tickerConnected true when local WS opens', () => {
     const { result } = renderHook(() =>
-      useNotifications({ nodes: [localNode], onStateInvalidate: vi.fn(), onAutoUpdateChange: vi.fn() }),
+      useNotifications({ nodes: [localNode], onStateInvalidate: vi.fn(), onAutoUpdateChange: vi.fn(), onImageUpdatesChange: vi.fn() }),
     );
     act(() => { MockWS.instances[0]?.onopen?.(); });
     expect(result.current.tickerConnected).toBe(true);
@@ -84,7 +84,7 @@ describe('useNotifications', () => {
 
   it('adds notification when local WS receives notification message', () => {
     const { result } = renderHook(() =>
-      useNotifications({ nodes: [localNode], onStateInvalidate: vi.fn(), onAutoUpdateChange: vi.fn() }),
+      useNotifications({ nodes: [localNode], onStateInvalidate: vi.fn(), onAutoUpdateChange: vi.fn(), onImageUpdatesChange: vi.fn() }),
     );
     act(() => { MockWS.instances[0]?.onopen?.(); });
     act(() => {
@@ -98,7 +98,7 @@ describe('useNotifications', () => {
 
   it('clearAllNotifications empties the local state', async () => {
     const { result } = renderHook(() =>
-      useNotifications({ nodes: [localNode], onStateInvalidate: vi.fn(), onAutoUpdateChange: vi.fn() }),
+      useNotifications({ nodes: [localNode], onStateInvalidate: vi.fn(), onAutoUpdateChange: vi.fn(), onImageUpdatesChange: vi.fn() }),
     );
     act(() => { MockWS.instances[0]?.onopen?.(); });
     act(() => {
@@ -111,9 +111,69 @@ describe('useNotifications', () => {
     await waitFor(() => expect(result.current.notifications).toHaveLength(0));
   });
 
+  it('fires onImageUpdatesChange on state-invalidate with action="stack-updated"', () => {
+    const onStateInvalidate = vi.fn();
+    const onImageUpdatesChange = vi.fn();
+    const onAutoUpdateChange = vi.fn();
+    renderHook(() =>
+      useNotifications({ nodes: [localNode], onStateInvalidate, onAutoUpdateChange, onImageUpdatesChange }),
+    );
+    act(() => { MockWS.instances[0]?.onopen?.(); });
+    act(() => {
+      MockWS.instances[0]?.onmessage?.({
+        data: JSON.stringify({
+          type: 'state-invalidate', scope: 'image-updates', nodeId: 1,
+          stackName: 'foo', action: 'stack-updated', ts: 1000,
+        }),
+      });
+    });
+    expect(onImageUpdatesChange).toHaveBeenCalledTimes(1);
+    expect(onStateInvalidate).toHaveBeenCalledTimes(1);
+    expect(onAutoUpdateChange).not.toHaveBeenCalled();
+  });
+
+  it('does not fire onImageUpdatesChange on a generic state-invalidate', () => {
+    const onStateInvalidate = vi.fn();
+    const onImageUpdatesChange = vi.fn();
+    renderHook(() =>
+      useNotifications({ nodes: [localNode], onStateInvalidate, onAutoUpdateChange: vi.fn(), onImageUpdatesChange }),
+    );
+    act(() => { MockWS.instances[0]?.onopen?.(); });
+    act(() => {
+      MockWS.instances[0]?.onmessage?.({
+        data: JSON.stringify({
+          type: 'state-invalidate', scope: 'stack', nodeId: 1,
+          stackName: 'foo', action: 'start', ts: 1000,
+        }),
+      });
+    });
+    expect(onStateInvalidate).toHaveBeenCalledTimes(1);
+    expect(onImageUpdatesChange).not.toHaveBeenCalled();
+  });
+
+  it('does not fire onImageUpdatesChange on auto-update-settings-changed', () => {
+    const onAutoUpdateChange = vi.fn();
+    const onImageUpdatesChange = vi.fn();
+    const onStateInvalidate = vi.fn();
+    renderHook(() =>
+      useNotifications({ nodes: [localNode], onStateInvalidate, onAutoUpdateChange, onImageUpdatesChange }),
+    );
+    act(() => { MockWS.instances[0]?.onopen?.(); });
+    act(() => {
+      MockWS.instances[0]?.onmessage?.({
+        data: JSON.stringify({
+          type: 'state-invalidate', nodeId: 1, action: 'auto-update-settings-changed', ts: 1000,
+        }),
+      });
+    });
+    expect(onAutoUpdateChange).toHaveBeenCalledTimes(1);
+    expect(onImageUpdatesChange).not.toHaveBeenCalled();
+    expect(onStateInvalidate).not.toHaveBeenCalled();
+  });
+
   it('deleteNotification removes the matching item', async () => {
     const { result } = renderHook(() =>
-      useNotifications({ nodes: [localNode], onStateInvalidate: vi.fn(), onAutoUpdateChange: vi.fn() }),
+      useNotifications({ nodes: [localNode], onStateInvalidate: vi.fn(), onAutoUpdateChange: vi.fn(), onImageUpdatesChange: vi.fn() }),
     );
     act(() => { MockWS.instances[0]?.onopen?.(); });
     const notif = makeNotif({ id: 5, nodeId: localNode.id });

--- a/frontend/src/components/EditorLayout/hooks/useNotifications.ts
+++ b/frontend/src/components/EditorLayout/hooks/useNotifications.ts
@@ -8,9 +8,10 @@ interface UseNotificationsOptions {
   nodes: Node[];
   onStateInvalidate: () => void;
   onAutoUpdateChange: () => void;
+  onImageUpdatesChange: () => void;
 }
 
-export function useNotifications({ nodes, onStateInvalidate, onAutoUpdateChange }: UseNotificationsOptions) {
+export function useNotifications({ nodes, onStateInvalidate, onAutoUpdateChange, onImageUpdatesChange }: UseNotificationsOptions) {
   const [notifications, setNotifications] = useState<NotificationItem[]>([]);
   const [tickerConnected, setTickerConnected] = useState(false);
 
@@ -23,6 +24,8 @@ export function useNotifications({ nodes, onStateInvalidate, onAutoUpdateChange 
   onStateInvalidateRef.current = onStateInvalidate;
   const onAutoUpdateChangeRef = useRef(onAutoUpdateChange);
   onAutoUpdateChangeRef.current = onAutoUpdateChange;
+  const onImageUpdatesChangeRef = useRef(onImageUpdatesChange);
+  onImageUpdatesChangeRef.current = onImageUpdatesChange;
 
   const fetchNotifications = async () => {
     try {
@@ -98,6 +101,9 @@ export function useNotifications({ nodes, onStateInvalidate, onAutoUpdateChange 
               onAutoUpdateChangeRef.current();
             } else {
               onStateInvalidateRef.current();
+              if (msg.scope === 'image-updates' && msg.action === 'stack-updated') {
+                onImageUpdatesChangeRef.current();
+              }
             }
           }
         } catch (e) {
@@ -171,6 +177,9 @@ export function useNotifications({ nodes, onStateInvalidate, onAutoUpdateChange 
             } else if (msg.type === 'state-invalidate') {
               window.dispatchEvent(new CustomEvent('sencho:state-invalidate', { detail: { ...msg, nodeId: rn.id } }));
               onStateInvalidateRef.current();
+              if (msg.scope === 'image-updates' && msg.action === 'stack-updated') {
+                onImageUpdatesChangeRef.current();
+              }
             }
           } catch (e) {
             console.error(`[WS notifications:${rn.name}] parse error`, e);

--- a/frontend/src/components/EditorLayout/hooks/useStackListState.ts
+++ b/frontend/src/components/EditorLayout/hooks/useStackListState.ts
@@ -37,7 +37,6 @@ export function useStackListState() {
   const [isLoading, setIsLoading] = useState(false);
   const [stackActions, setStackActions] = useState<Record<string, StackAction>>({});
   const stackActionsRef = useRef<Record<string, StackAction>>({});
-  stackActionsRef.current = stackActions;
 
   const [isScanning, setIsScanning] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
@@ -65,15 +64,21 @@ export function useStackListState() {
     if (evictedOldest) toast.info('Pinned. Unpinned oldest (max 10).');
   }, [evictedOldest]);
 
+  // Ref is updated synchronously alongside the state setter so any code that
+  // runs right after (e.g. `refreshStacks(true)` in an action's finally block)
+  // observes the cleared map before React commits the next render. Without
+  // this, the busy-stack check inside refreshStacks would still flag the
+  // stack as in-progress and preserve the optimistic status mask.
   const setStackAction = (stackFile: string, action: StackAction) => {
-    setStackActions(prev => ({ ...prev, [stackFile]: action }));
+    const next = { ...stackActionsRef.current, [stackFile]: action };
+    stackActionsRef.current = next;
+    setStackActions(next);
   };
   const clearStackAction = (stackFile: string) => {
-    setStackActions(prev => {
-      const next = { ...prev };
-      delete next[stackFile];
-      return next;
-    });
+    const next = { ...stackActionsRef.current };
+    delete next[stackFile];
+    stackActionsRef.current = next;
+    setStackActions(next);
   };
   const isStackBusy = useCallback((stackFile: string) => stackFile in stackActionsRef.current, []);
 
@@ -271,9 +276,13 @@ export function useStackListState() {
   const handleBulkAction = useCallback((action: BulkAction) => {
     const filesToAction = Array.from(selectedFiles);
     runBulk(action, filesToAction, {
-      onAfter: () => { refreshStacksRef.current(true); clearSelection(); },
+      onAfter: () => {
+        refreshStacksRef.current(true);
+        if (action === 'update') void fetchImageUpdates();
+        clearSelection();
+      },
     });
-  }, [selectedFiles, runBulk, clearSelection]);
+  }, [selectedFiles, runBulk, clearSelection, fetchImageUpdates]);
 
   const chipFilteredFilesRef = useRef(chipFilteredFiles);
   useEffect(() => { chipFilteredFilesRef.current = chipFilteredFiles; }, [chipFilteredFiles]);


### PR DESCRIPTION
## Summary

After a stack update, the sidebar's pulsing **update available** dot stayed visible and the stack's status indicator was stuck on the optimistic post-update value until the page was manually refreshed. Two distinct root causes:

1. **Image-updates state refresh was a fire-and-forget call in some paths and entirely missing from others.** The single-stack `Update` button called `fetchImageUpdates()` without awaiting and racey with the post-update `refreshStacks`. The bulk-update path, the auto-update path, and the `state-invalidate` WebSocket handler never refreshed image-updates at all.
2. **The optimistic stack-status mask lingered.** `stackActionsRef.current` was resynced only at render time, so the post-update `refreshStacks(true)` running in the action's `finally` block read a stale "busy" map and preserved the optimistic mask via `prev[file] ?? status` (line 154 of `useStackListState.ts`).

## Changes

**Backend** — broadcast a `state-invalidate` event with `scope: 'image-updates'` and `action: 'stack-updated'` after every successful update:
- `backend/src/routes/stacks.ts` (`POST /:stackName/update`), after `clearStackUpdateStatus`.
- `backend/src/routes/imageUpdates.ts` (`autoUpdateRouter.execute` per-stack loop), after `db.clearStackUpdateStatus`.

The envelope shape matches the canonical `DockerEventService` event, reusing the existing `NotificationService.broadcastEvent` plumbing. No new WebSocket route.

**Frontend** — route the new event to a single refresh entry point so every update path clears the dot through the same code:
- `useNotifications`: new `onImageUpdatesChange` callback fired from both local and remote WS message handlers when `msg.scope === 'image-updates' && msg.action === 'stack-updated'`. Existing `onStateInvalidate` and `onAutoUpdateChange` behaviour preserved.
- `EditorLayout.tsx`: wires `onImageUpdatesChange` to `stackListState.fetchImageUpdates`.
- `useStackListState.ts`:
  - Bulk update's `onAfter` now also calls `fetchImageUpdates()` for fast local feedback (in addition to the backend broadcast that covers other open clients).
  - `setStackAction` and `clearStackAction` now keep `stackActionsRef` synchronously in sync with state, so the busy-stack check inside `refreshStacks` observes the cleared map before React commits the next render. This drops the optimistic mask as soon as the real status arrives.

**Tests** — 3 new unit tests in `useNotifications.test.ts` cover the new branch:
- Positive: `state-invalidate` with `scope: 'image-updates'` + `action: 'stack-updated'` fires `onImageUpdatesChange` in addition to `onStateInvalidate`.
- Negative: generic `state-invalidate` (e.g. `scope: 'stack'`, `action: 'start'`) does not fire it.
- Negative: `auto-update-settings-changed` continues to route only to `onAutoUpdateChange`.

## Test plan

- [x] `npx tsc --noEmit` (backend) — zero errors
- [x] `npx tsc -b --noEmit` (frontend) — zero errors
- [x] `npx vitest run useNotifications.test.ts` — 9/9 pass
- [x] Backend Vitest subset for adjacent areas — pre-existing Windows file-lock flake only
- [x] Dev servers boot clean; login + dashboard render with no JS errors from the change
- [x] Code-reviewed; scope-gating tightened so the new callback fires only on the intended payload
- [ ] Manual end-to-end on a stack with a real registry digest change: confirm dot disappears within ~1 s of clicking Update without a page refresh (single, bulk, auto-update paths)

## Notes

No DB schema changes. No tier-gate changes (Directive 30 N/A). No new dependencies. Stack update is still gated behind `requirePermission('stack:deploy')`. The architecture map is unchanged because this hardens an existing flow rather than adding a new node or edge.