### PR TITLE
fix(fleet-secrets): align bundle-row action aria-label with icon ("Send")

### DIFF
--- a/frontend/src/components/fleet/secrets/SecretsTab.tsx
+++ b/frontend/src/components/fleet/secrets/SecretsTab.tsx
@@ -107,7 +107,7 @@ export function SecretsTab() {
                                             <Button type="button" variant="ghost" size="icon" onClick={() => setEditing(s)} aria-label="Edit">
                                                 <Pencil className="w-4 h-4" />
                                             </Button>
-                                            <Button type="button" variant="ghost" size="icon" onClick={() => setPushing(s)} aria-label="Push">
+                                            <Button type="button" variant="ghost" size="icon" onClick={() => setPushing(s)} aria-label="Send">
                                                 <Send className="w-4 h-4" />
                                             </Button>
                                             <Button


### PR DESCRIPTION
## Summary

The bundle-row action on the Secrets tab uses the lucide `Send` icon. Its `aria-label` was `Push`, which mismatched the visible/iconic intent and the way the same action is referred to in the feature docs. This aligns the screen-reader label with the icon.

## Test plan

- [x] Inspect the bundle-row Send button in DevTools and confirm `aria-label="Send"`.