### PR TITLE
fix(fleet): rename Traffic tab label to Routing for consistency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,7 +106,7 @@ SSO_CALLBACK_URL=
 
 # Experimental UI surfaces. When unset or any value other than "true",
 # the UI hides surfaces that are kept in the repo but not yet promoted
-# to the default 1.0 build (Fleet Traffic · Routing tab, Fleet
+# to the default 1.0 build (Fleet Routing tab, Fleet
 # Deployments / Blueprints tab, Fleet Federation tab, Fleet Secrets
 # sync tab, Fleet Actions tab). Backend routes for these surfaces stay
 # live regardless. This flag controls UI discovery only.

--- a/docs/features/fleet-actions.mdx
+++ b/docs/features/fleet-actions.mdx
@@ -7,7 +7,7 @@ description: Run fleet-wide bulk operations from one place — stop stacks acros
   Fleet Actions require a Sencho **Skipper** or **Admiral** license.
 </Note>
 
-The **Fleet Actions** tab inside Fleet centralizes bulk operations that span more than a single stack and would otherwise need many manual clicks. It lives next to **Deployments** and **Traffic** in the Fleet view, after the separator that follows Status.
+The **Fleet Actions** tab inside Fleet centralizes bulk operations that span more than a single stack and would otherwise need many manual clicks. It lives next to **Deployments** and **Routing** in the Fleet view, after the separator that follows Status.
 
 Fleet Actions covers the operations that aren't already exposed elsewhere in Sencho:
 

--- a/frontend/src/components/FleetView.tsx
+++ b/frontend/src/components/FleetView.tsx
@@ -99,7 +99,7 @@ export function FleetView({ onNavigateToNode }: FleetViewProps) {
                             {isAdmiral && (
                                 <TabsHighlightItem value="routing">
                                     <TabsTrigger value="routing">
-                                        <ArrowLeftRight className="w-4 h-4 mr-1.5" />Traffic
+                                        <ArrowLeftRight className="w-4 h-4 mr-1.5" />Routing
                                     </TabsTrigger>
                                 </TabsHighlightItem>
                             )}


### PR DESCRIPTION
## Summary

- Renames the Fleet view sub-tab label from **Traffic** to **Routing** so it matches the underlying component (`RoutingTab.tsx`), the backend route file (`backend/src/routes/mesh.ts`), the localStorage key (`sencho-routing-view-mode`), the SegmentedControl aria label (`Routing view mode`), and the engineering vocabulary used everywhere else.
- Updates the two operator-doc references that named the tab by its old label: `docs/features/fleet-actions.mdx` and the `SENCHO_EXPERIMENTAL` comment in `.env.example`.
- 3 files, 3 lines, no logic change.

## Background

The Fleet sub-tab that opens `RoutingTab.tsx` was labeled `Traffic` in the rendered tablist while every adjacent identifier in the codebase used `Routing`. Anyone reading the engineering vocabulary, internal docs, or the route file and looking for "the Routing tab" could not find it because the visible label said something else. Picked `Routing` because the implementation already commits to it.

## Test plan

- [x] `npx tsc -b --noEmit` in `frontend` returns clean
- [x] Manual UI walkthrough as Admiral admin in a clean browser session: Fleet view → tab strip now reads `Overview · Snapshots · Status | Deployments · Routing · Federation | Fleet Actions · Secrets`, and clicking the renamed tab still opens the `RoutingTab` content (mesh state loads as expected, no console regressions tied to the rename)
- [x] Repo-wide grep confirms no other user-visible "Traffic" tab references remain; the surviving "traffic" strings describe networking traffic in prose ("Mesh traffic", "node-to-node traffic", etc.) and are correct usage
- [x] Code review of the diff for reuse, quality, and efficiency: clean for this PR (see Notes for two out-of-scope observations)

## Notes

Two unrelated observations surfaced during review and are intentionally **not** in this PR's scope (Directive 4: one branch, one concern). Filing them here so they aren't lost:

1. The `SENCHO_EXPERIMENTAL` comment block in `.env.example` (lines 107-113) still lists Fleet Routing, Deployments / Blueprints, Federation, Secrets sync, and Fleet Actions as surfaces gated by the flag. Per the 1.0 cut-line, all five were promoted to tier gates and `FleetView.tsx` uses `{isAdmiral && ...}` / `{isPaid && ...}` rather than `useExperimental()`. The comment misrepresents the current gating model. Worth a separate `docs:` or `chore:` branch.
2. The tab still uses the `ArrowLeftRight` lucide icon, which read intuitively as "Traffic" (bidirectional exchange) but maps less naturally to "Routing". A `Route` / `Waypoints` / `Network` glyph would be more semantically aligned. Observation only; no change here.