### PR TITLE
fix(self-update): resolve /app/data through bind or named volume

### DIFF
--- a/backend/src/__tests__/self-update-data-mount.test.ts
+++ b/backend/src/__tests__/self-update-data-mount.test.ts
@@ -1,0 +1,56 @@
+/**
+ * findDataDirHost detects the host-side path for /app/data across bind AND
+ * named-volume mounts. Pre-fix the helper bound the resolver to Type='bind'
+ * only, so a pilot-agent deployed with the recommended `sencho-agent-data:/
+ * app/data` named volume logged "/app/data mount not found - update error
+ * recovery will be unavailable" at boot.
+ */
+import { describe, expect, it } from 'vitest';
+import { findDataDirHost } from '../services/SelfUpdateService';
+
+describe('findDataDirHost', () => {
+  it('returns the host path for a bind mount at /app/data', () => {
+    const source = findDataDirHost([
+      { Type: 'bind', Source: '/opt/sencho/data', Destination: '/app/data' },
+    ]);
+    expect(source).toBe('/opt/sencho/data');
+  });
+
+  it('returns the host path for a named volume at /app/data', () => {
+    const source = findDataDirHost([
+      { Type: 'volume', Source: '/var/lib/docker/volumes/sencho-agent-data/_data', Destination: '/app/data' },
+    ]);
+    expect(source).toBe('/var/lib/docker/volumes/sencho-agent-data/_data');
+  });
+
+  it('returns null when no mount targets /app/data', () => {
+    const source = findDataDirHost([
+      { Type: 'bind', Source: '/var/run/docker.sock', Destination: '/var/run/docker.sock' },
+      { Type: 'bind', Source: '/opt/compose', Destination: '/app/compose' },
+    ]);
+    expect(source).toBeNull();
+  });
+
+  it('picks the /app/data mount out of a mixed list and ignores siblings', () => {
+    const source = findDataDirHost([
+      { Type: 'bind', Source: '/var/run/docker.sock', Destination: '/var/run/docker.sock' },
+      { Type: 'volume', Source: '/var/lib/docker/volumes/sencho-agent-data/_data', Destination: '/app/data' },
+      { Type: 'bind', Source: '/opt/compose', Destination: '/app/compose' },
+    ]);
+    expect(source).toBe('/var/lib/docker/volumes/sencho-agent-data/_data');
+  });
+
+  it('returns null when a /app/data entry carries no Source', () => {
+    const source = findDataDirHost([
+      { Type: 'bind', Source: '', Destination: '/app/data' },
+    ]);
+    expect(source).toBeNull();
+  });
+
+  it('ignores tmpfs and other non-bind/volume types', () => {
+    const source = findDataDirHost([
+      { Type: 'tmpfs', Source: '', Destination: '/app/data' },
+    ]);
+    expect(source).toBeNull();
+  });
+});

--- a/backend/src/services/SelfUpdateService.ts
+++ b/backend/src/services/SelfUpdateService.ts
@@ -17,6 +17,28 @@ interface HostMount {
   destination: string;
 }
 
+/** Narrow projection of the Dockerode mount entry we actually consume. */
+export type DockerMount = {
+  Type: 'bind' | 'volume' | 'tmpfs' | 'npipe' | 'cluster' | 'image';
+  Source: string;
+  Destination: string;
+};
+
+/**
+ * Find the host-side path Docker resolved for /app/data, regardless of whether
+ * the operator declared a bind or a named volume. The helper container uses
+ * this path to mount /app/data:rw so it can write UPDATE_ERROR_FILE when a
+ * compose recreate fails before the gateway can persist the error itself.
+ */
+export function findDataDirHost(mounts: ReadonlyArray<DockerMount>): string | null {
+  const match = mounts.find(m =>
+    m.Destination === '/app/data' &&
+    (m.Type === 'bind' || m.Type === 'volume') &&
+    !!m.Source,
+  );
+  return match?.Source ?? null;
+}
+
 interface ComposeContext {
   workingDir: string;
   configFiles: string;
@@ -86,14 +108,12 @@ class SelfUpdateService {
       // Collect all host bind mounts so the helper container can forward them.
       // This lets docker compose resolve env_file, configs, secrets, and any
       // other host-path references that live outside the compose working dir.
-      const rawMounts = (info.Mounts ?? []) as Array<{
-        Type: string; Source: string; Destination: string;
-      }>;
+      const rawMounts = (info.Mounts ?? []) as DockerMount[];
       const hostBindMounts: HostMount[] = rawMounts
         .filter(m => m.Type === 'bind' && m.Source && m.Destination)
         .map(m => ({ source: m.Source, destination: m.Destination }));
 
-      const dataDirHost = hostBindMounts.find(m => m.destination === '/app/data')?.source ?? null;
+      const dataDirHost = findDataDirHost(rawMounts);
       if (!dataDirHost) {
         console.log('[SelfUpdate] /app/data mount not found - update error recovery will be unavailable');
       }


### PR DESCRIPTION
## Summary

- `SelfUpdateService.initialize()` looked up the host-side `/app/data` source by filtering `info.Mounts` to `Type === 'bind'` only. A pilot deployed via the recommended Compose snippet uses a **named volume** (`sencho-agent-data:/app/data`, `Type === 'volume'`), so the lookup returned null.
- Result: boot log read `/app/data mount not found - update error recovery will be unavailable`. Self-update itself still ran, but the helper container could not persist `UPDATE_ERROR_FILE` on a failed pull, so the next gateway process had nothing to surface to the user.
- Extracted `findDataDirHost(mounts)` and broadened it to accept `Type === 'bind'` OR `Type === 'volume'`. Docker populates `Source` with the on-disk volume directory for either type, so the existing `-v <source>:/app/data:rw` line in the helper spawn works unchanged.
- The separate `hostBindMounts` filter that forwards operator-declared compose paths (env_file, configs, secrets, etc.) stays strict to `Type === 'bind'`. Named volumes are not in scope for that channel.

## Why

Surfaced during PR #1121 verification on `sencho-pilot-test`: SelfUpdate booted ready (compose labels present) but the data-mount warning fired because the recommended snippet uses a named volume rather than a host bind. Without this fix every Compose-deployed Sencho silently loses error recovery on a failed self-update.

## Test plan

- [x] Backend `tsc --noEmit` clean.
- [x] New `self-update-data-mount` vitest covers 6 cases (bind hit, volume hit, no `/app/data`, mixed list with siblings, empty Source, tmpfs ignored). 6/6 green.
- [x] Pure helper extraction is type-checked against a narrow `DockerMount` union (`'bind' | 'volume' | 'tmpfs' | ...`) so a typo like `'volumes'` is now a compile error rather than a silent runtime miss.
- [ ] End-to-end against a Compose-deployed pilot: boot log should now show `[SelfUpdate] Ready` without the `/app/data mount not found` warning. Deferred to post-merge.

## Gate parity

No tier/role/capability/flag touched. Pre-commit grep clean.

## Notes

- Greenfield (Directive 20): code-comments-only context for "Pre-fix / Post-fix" wording in the test file; no user-facing docs reference legacy behavior.
- The `hostBindMounts` array stays bind-only by design (different semantic from `findDataDirHost`'s broader lookup). The two filters are now visibly distinct in the source so the contract is harder to break.