### PR TITLE
fix(mesh): address audit follow-ups (early-data, recompose, admiral gate, error codes, docs)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,9 +120,9 @@ SSO_CALLBACK_URL=
 # live regardless. This flag controls UI discovery only.
 SENCHO_EXPERIMENTAL=false
 
-# Idle teardown (in ms) for on-demand mesh tunnels that central opens
-# to Distributed API (proxy-mode) remotes. After this many milliseconds
-# of zero active mesh streams, central closes the WebSocket; the next
-# mesh dial re-opens it. Defaults to 5 minutes. Set to 0 to keep
-# tunnels open until the remote drops them or central shuts down.
-SENCHO_MESH_PROXY_TUNNEL_IDLE_MS=300000
+# Idle teardown for the persistent mesh proxy tunnel central opens to
+# Distributed API (proxy-mode) remotes. The tunnel stays open for the
+# life of the WebSocket. Set a positive number of milliseconds to
+# enable idle teardown after that many ms of zero active mesh streams;
+# the next mesh dial re-opens it. Default 0 (persistent).
+SENCHO_MESH_PROXY_TUNNEL_IDLE_MS=0

--- a/backend/src/__tests__/mesh-inspect-remote.test.ts
+++ b/backend/src/__tests__/mesh-inspect-remote.test.ts
@@ -148,4 +148,44 @@ describe('MeshService.inspectStackServices dispatch (C-3 fix)', () => {
         expect(fetchSpy).not.toHaveBeenCalled();
         db.deleteNode(remoteNodeId);
     });
+
+    it('logs an offline-shaped warn (not a generic error) when proxyFetch throws MeshError no_target', async () => {
+        const svc = MeshService.getInstance();
+        const db = DatabaseService.getInstance();
+        const remoteNodeId = db.addNode({
+            name: 'inspect-remote-no-target',
+            type: 'remote',
+            mode: 'pilot_agent',
+            compose_dir: '/tmp',
+            is_default: false,
+            api_url: '',
+            api_token: '',
+        });
+
+        // getProxyTarget returns null -> proxyFetch raises MeshError('no_target').
+        // The catch branch must recognise no_target alongside push_failed and
+        // emit console.warn (operator-friendly), not console.error (which the
+        // Routing tab surfaces as an unexpected fault).
+        vi.spyOn(NodeRegistry.getInstance(), 'getProxyTarget').mockReturnValue(null);
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { /* swallow */ });
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => { /* swallow */ });
+
+        const out = await (svc as unknown as { inspectStackServices: (n: number, s: string) => Promise<unknown> })
+            .inspectStackServices(remoteNodeId, 'audit-mesh-pilot');
+
+        expect(out).toEqual([]);
+        const warnedAboutNoTarget = warnSpy.mock.calls.some((args) =>
+            String(args[0] ?? '').includes('inspectStackServices: unreachable') &&
+            String(args[0] ?? '').includes('no_target'),
+        );
+        expect(warnedAboutNoTarget).toBe(true);
+        // No "remote unreachable" error log: that path is reserved for
+        // unexpected exceptions, not the known no_target / push_failed pair.
+        const erroredAsUnreachable = errorSpy.mock.calls.some((args) =>
+            String(args[0] ?? '').includes('inspectStackServices remote unreachable'),
+        );
+        expect(erroredAsUnreachable).toBe(false);
+
+        db.deleteNode(remoteNodeId);
+    });
 });

--- a/backend/src/__tests__/mesh-remove-override-remote.test.ts
+++ b/backend/src/__tests__/mesh-remove-override-remote.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Narrow contract test for `MeshService.removeOverrideFromNode` against a
+ * remote node. Pins the HTTP shape (method, path, headers) so a regression
+ * inside `removeOverrideFromNode` itself is caught even when callers like
+ * `disableForNode` are tested against a mock of the helper.
+ *
+ * Same fetch-spy pattern as `mesh-inspect-remote.test.ts`.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { setupTestDb, cleanupTestDb } from './helpers/setupTestDb';
+
+let tmpDir: string;
+let MeshService: typeof import('../services/MeshService').MeshService;
+let DatabaseService: typeof import('../services/DatabaseService').DatabaseService;
+let NodeRegistry: typeof import('../services/NodeRegistry').NodeRegistry;
+
+beforeAll(async () => {
+    tmpDir = await setupTestDb();
+    ({ MeshService } = await import('../services/MeshService'));
+    ({ DatabaseService } = await import('../services/DatabaseService'));
+    ({ NodeRegistry } = await import('../services/NodeRegistry'));
+});
+
+afterAll(() => {
+    vi.restoreAllMocks();
+    cleanupTestDb(tmpDir);
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('MeshService.removeOverrideFromNode (remote dispatch)', () => {
+    it('issues DELETE /api/mesh/local-override/<stack> with Authorization and tier headers', async () => {
+        const svc = MeshService.getInstance();
+        const db = DatabaseService.getInstance();
+        const remoteNodeId = db.addNode({
+            name: 'remove-override-remote-test',
+            type: 'remote',
+            mode: 'proxy',
+            compose_dir: '/tmp',
+            is_default: false,
+            api_url: 'https://remote.example.com:1852',
+            api_token: 'remote-tok',
+        });
+
+        vi.spyOn(NodeRegistry.getInstance(), 'getProxyTarget').mockReturnValue({
+            apiUrl: 'https://remote.example.com:1852',
+            apiToken: 'remote-tok',
+        });
+
+        const fetchMock = vi
+            .spyOn(globalThis, 'fetch')
+            .mockResolvedValue(new Response('ok', { status: 200 }));
+
+        await svc.removeOverrideFromNode(remoteNodeId, 'sample-stack');
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const call = fetchMock.mock.calls[0];
+        expect(String(call[0])).toBe('https://remote.example.com:1852/api/mesh/local-override/sample-stack');
+        const init = call[1] as { method: string; headers: Record<string, string> };
+        expect(init.method).toBe('DELETE');
+        expect(init.headers['Authorization']).toBe('Bearer remote-tok');
+        expect(init.headers).toHaveProperty('x-sencho-tier');
+        expect(init.headers).toHaveProperty('x-sencho-variant');
+
+        db.deleteNode(remoteNodeId);
+    });
+
+    it('url-encodes the stack name in the path', async () => {
+        const svc = MeshService.getInstance();
+        const db = DatabaseService.getInstance();
+        const remoteNodeId = db.addNode({
+            name: 'remove-override-encode-test',
+            type: 'remote',
+            mode: 'proxy',
+            compose_dir: '/tmp',
+            is_default: false,
+            api_url: 'https://remote.example.com:1852',
+            api_token: 'remote-tok',
+        });
+
+        vi.spyOn(NodeRegistry.getInstance(), 'getProxyTarget').mockReturnValue({
+            apiUrl: 'https://remote.example.com:1852',
+            apiToken: 'remote-tok',
+        });
+
+        const fetchMock = vi
+            .spyOn(globalThis, 'fetch')
+            .mockResolvedValue(new Response('ok', { status: 200 }));
+
+        await svc.removeOverrideFromNode(remoteNodeId, 'stack with space');
+
+        const call = fetchMock.mock.calls[0];
+        expect(String(call[0])).toBe('https://remote.example.com:1852/api/mesh/local-override/stack%20with%20space');
+
+        db.deleteNode(remoteNodeId);
+    });
+
+    it('swallows network errors from the remote so the disable cascade can continue', async () => {
+        const svc = MeshService.getInstance();
+        const db = DatabaseService.getInstance();
+        const remoteNodeId = db.addNode({
+            name: 'remove-override-error-test',
+            type: 'remote',
+            mode: 'proxy',
+            compose_dir: '/tmp',
+            is_default: false,
+            api_url: 'https://remote.example.com:1852',
+            api_token: 'remote-tok',
+        });
+
+        vi.spyOn(NodeRegistry.getInstance(), 'getProxyTarget').mockReturnValue({
+            apiUrl: 'https://remote.example.com:1852',
+            apiToken: 'remote-tok',
+        });
+
+        vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { /* silence */ });
+
+        // Must not throw: the remote being offline is a tolerable condition;
+        // the cascade upstream uses Promise.allSettled and continues.
+        await expect(svc.removeOverrideFromNode(remoteNodeId, 'sample-stack')).resolves.toBeUndefined();
+        expect(warnSpy).toHaveBeenCalled();
+
+        db.deleteNode(remoteNodeId);
+    });
+});

--- a/backend/src/__tests__/mesh-service.test.ts
+++ b/backend/src/__tests__/mesh-service.test.ts
@@ -362,8 +362,7 @@ describe('MeshService.disableForNode', () => {
             'cascadeRecomposeAcrossFleet',
         ).mockImplementation(() => { /* noop */ });
         const triggerSpy = vi.spyOn(svc, 'triggerRedeploy').mockImplementation(() => { /* noop */ });
-        vi.spyOn(svc as unknown as { removeStackOverride: (n: number, s: string) => Promise<void> }, 'removeStackOverride')
-            .mockResolvedValue(undefined);
+        const removeSpy = vi.spyOn(svc, 'removeOverrideFromNode').mockResolvedValue(undefined);
 
         await svc.disableForNode(localNodeId, 'tester');
 
@@ -383,6 +382,47 @@ describe('MeshService.disableForNode', () => {
         expect(triggerSpy).toHaveBeenCalledTimes(2);
         expect(triggerSpy).toHaveBeenCalledWith(localNodeId, 'alpha', 'tester');
         expect(triggerSpy).toHaveBeenCalledWith(localNodeId, 'beta', 'tester');
+        // disableForNode routes through removeOverrideFromNode (not the
+        // local-only removeStackOverride) so remote nodes also have their
+        // pushed override files deleted via DELETE /api/mesh/local-override.
+        expect(removeSpy).toHaveBeenCalledTimes(2);
+        expect(removeSpy).toHaveBeenCalledWith(localNodeId, 'alpha');
+        expect(removeSpy).toHaveBeenCalledWith(localNodeId, 'beta');
+
+        db.deleteNode(remoteNodeId);
+    });
+
+    it('dispatches removeOverrideFromNode for each stack when the disabled node is remote', async () => {
+        const svc = MeshService.getInstance();
+        const db = DatabaseService.getInstance();
+        const remoteNodeId = db.addNode({
+            name: 'remote-pilot-disable', type: 'remote', mode: 'pilot_agent',
+            compose_dir: '/tmp', is_default: false, api_url: '', api_token: '',
+        });
+        db.setNodeMeshEnabled(remoteNodeId, true);
+        db.insertMeshStack(remoteNodeId, 'delta', 'setup');
+        db.insertMeshStack(remoteNodeId, 'epsilon', 'setup');
+
+        vi.spyOn(
+            svc as unknown as { regenerateOverridesAcrossFleet: (n?: number, s?: string) => Promise<void> },
+            'regenerateOverridesAcrossFleet',
+        ).mockResolvedValue(undefined);
+        vi.spyOn(
+            svc as unknown as { cascadeRecomposeAcrossFleet: (n: number | undefined, s: string | undefined, a: string) => void },
+            'cascadeRecomposeAcrossFleet',
+        ).mockImplementation(() => { /* noop */ });
+        vi.spyOn(svc, 'triggerRedeploy').mockImplementation(() => { /* noop */ });
+        const removeSpy = vi.spyOn(svc, 'removeOverrideFromNode').mockResolvedValue(undefined);
+
+        await svc.disableForNode(remoteNodeId, 'tester');
+
+        expect(db.getNodeMeshEnabled(remoteNodeId)).toBe(false);
+        // Remote-node disable must dispatch the remote-aware helper so the
+        // override file pushed earlier via applyLocalOverride is deleted
+        // on the peer via DELETE /api/mesh/local-override/:stack.
+        expect(removeSpy).toHaveBeenCalledTimes(2);
+        expect(removeSpy).toHaveBeenCalledWith(remoteNodeId, 'delta');
+        expect(removeSpy).toHaveBeenCalledWith(remoteNodeId, 'epsilon');
 
         db.deleteNode(remoteNodeId);
     });
@@ -401,8 +441,7 @@ describe('MeshService.disableForNode', () => {
             'cascadeRecomposeAcrossFleet',
         ).mockImplementation(() => { /* noop */ });
         const triggerSpy = vi.spyOn(svc, 'triggerRedeploy').mockImplementation(() => { /* noop */ });
-        vi.spyOn(svc as unknown as { removeStackOverride: (n: number, s: string) => Promise<void> }, 'removeStackOverride')
-            .mockResolvedValue(undefined);
+        vi.spyOn(svc, 'removeOverrideFromNode').mockResolvedValue(undefined);
 
         await svc.disableForNode(localNodeId);
 

--- a/backend/src/__tests__/mesh-service.test.ts
+++ b/backend/src/__tests__/mesh-service.test.ts
@@ -339,6 +339,79 @@ describe('MeshService.optInStack', () => {
     });
 });
 
+describe('MeshService.disableForNode', () => {
+    it('redeploys affected stacks and cascades across the fleet on node disable', async () => {
+        const svc = MeshService.getInstance();
+        const db = DatabaseService.getInstance();
+        const localNodeId = db.getNodes()[0].id;
+        const remoteNodeId = db.addNode({
+            name: 'remote-pilot', type: 'remote', mode: 'pilot_agent',
+            compose_dir: '/tmp', is_default: false, api_url: '', api_token: '',
+        });
+        db.setNodeMeshEnabled(localNodeId, true);
+        db.insertMeshStack(localNodeId, 'alpha', 'setup');
+        db.insertMeshStack(localNodeId, 'beta', 'setup');
+        db.insertMeshStack(remoteNodeId, 'gamma', 'setup');
+
+        const regenSpy = vi.spyOn(
+            svc as unknown as { regenerateOverridesAcrossFleet: (n?: number, s?: string) => Promise<void> },
+            'regenerateOverridesAcrossFleet',
+        ).mockResolvedValue(undefined);
+        const cascadeSpy = vi.spyOn(
+            svc as unknown as { cascadeRecomposeAcrossFleet: (n: number | undefined, s: string | undefined, a: string) => void },
+            'cascadeRecomposeAcrossFleet',
+        ).mockImplementation(() => { /* noop */ });
+        const triggerSpy = vi.spyOn(svc, 'triggerRedeploy').mockImplementation(() => { /* noop */ });
+        vi.spyOn(svc as unknown as { removeStackOverride: (n: number, s: string) => Promise<void> }, 'removeStackOverride')
+            .mockResolvedValue(undefined);
+
+        await svc.disableForNode(localNodeId, 'tester');
+
+        expect(db.getNodeMeshEnabled(localNodeId)).toBe(false);
+        // Disabled-node rows are deleted before the cascade so listMeshStacks
+        // does not return them. The other node's row stays.
+        expect(db.listMeshStacks(localNodeId)).toEqual([]);
+        expect(db.listMeshStacks(remoteNodeId).map((s) => s.stack_name)).toEqual(['gamma']);
+
+        expect(regenSpy).toHaveBeenCalledTimes(1);
+        // Cascade walks every remaining mesh_stacks row, no skip tuple.
+        expect(cascadeSpy).toHaveBeenCalledWith(undefined, undefined, 'tester');
+        // Each disabled-node stack triggers a direct redeploy so its
+        // container detaches from sencho_mesh. Cascade is mocked, so the
+        // only triggerRedeploy calls come from the disable loop itself
+        // (twice, not three: gamma stays put on the remote node).
+        expect(triggerSpy).toHaveBeenCalledTimes(2);
+        expect(triggerSpy).toHaveBeenCalledWith(localNodeId, 'alpha', 'tester');
+        expect(triggerSpy).toHaveBeenCalledWith(localNodeId, 'beta', 'tester');
+
+        db.deleteNode(remoteNodeId);
+    });
+
+    it('defaults the actor when none is supplied so legacy callers still log a non-empty actor', async () => {
+        const svc = MeshService.getInstance();
+        const db = DatabaseService.getInstance();
+        const localNodeId = db.getNodes()[0].id;
+        db.setNodeMeshEnabled(localNodeId, true);
+        db.insertMeshStack(localNodeId, 'solo', 'setup');
+
+        vi.spyOn(svc as unknown as { regenerateOverridesAcrossFleet: () => Promise<void> }, 'regenerateOverridesAcrossFleet')
+            .mockResolvedValue(undefined);
+        const cascadeSpy = vi.spyOn(
+            svc as unknown as { cascadeRecomposeAcrossFleet: (n: number | undefined, s: string | undefined, a: string) => void },
+            'cascadeRecomposeAcrossFleet',
+        ).mockImplementation(() => { /* noop */ });
+        const triggerSpy = vi.spyOn(svc, 'triggerRedeploy').mockImplementation(() => { /* noop */ });
+        vi.spyOn(svc as unknown as { removeStackOverride: (n: number, s: string) => Promise<void> }, 'removeStackOverride')
+            .mockResolvedValue(undefined);
+
+        await svc.disableForNode(localNodeId);
+
+        expect(db.getNodeMeshEnabled(localNodeId)).toBe(false);
+        expect(cascadeSpy.mock.calls[0][2]).toBe('system:mesh.disable');
+        expect(triggerSpy.mock.calls[0][2]).toBe('system:mesh.disable');
+    });
+});
+
 describe('MeshService activity log', () => {
     it('keeps the most recent events under the 1000-cap', () => {
         const svc = MeshService.getInstance();

--- a/backend/src/__tests__/pilot-bridge-reverse.test.ts
+++ b/backend/src/__tests__/pilot-bridge-reverse.test.ts
@@ -212,4 +212,67 @@ describe('PilotTunnelBridge handles tcp_open_reverse (Phase B)', () => {
         bridge.close();
         vi.restoreAllMocks();
     });
+
+    it('buffers TcpData arriving during ensureBridge and flushes it on target open (reverse-relay early-data fix)', async () => {
+        const mockWs = makeMockTunnelWs();
+        const bridge = new PilotTunnelBridge(1, mockWs as unknown as WebSocket);
+        await bridge.start();
+
+        // Fake target stream: an EventEmitter with a write() method that
+        // captures bytes. We control when 'open' fires to widen the
+        // race window the fix guards.
+        const writes: Buffer[] = [];
+        const fakeTargetStream = new EventEmitter() as EventEmitter & {
+            write: (b: Buffer) => void;
+        };
+        fakeTargetStream.write = (b: Buffer) => { writes.push(b); };
+
+        const fakeTargetBridge = {
+            openTcpStream: vi.fn(() => fakeTargetStream),
+            getBufferedAmount: () => 0,
+        };
+
+        const { PilotTunnelManager } = await import('../services/PilotTunnelManager');
+        // Delay ensureBridge so a TcpData frame fired back-to-back with
+        // tcp_open_reverse lands while acceptReverseRelay is still
+        // waiting on the target bridge. Without the fix the bytes are
+        // dropped at the lookup-miss path in handleBinaryFrame.
+        vi.spyOn(PilotTunnelManager.getInstance(), 'ensureBridge')
+            .mockImplementation(() => new Promise((r) => setTimeout(() => r(fakeTargetBridge as never), 50)));
+
+        const { NodeRegistry } = await import('../services/NodeRegistry');
+        const localNodeId = NodeRegistry.getInstance().getDefaultNodeId();
+        const remoteTargetNodeId = localNodeId + 99;
+
+        const s = AGENT_REVERSE_ID_BASE + 7;
+        mockWs.emit('message', encodeJsonFrame({
+            t: 'tcp_open_reverse', s,
+            targetNodeId: remoteTargetNodeId, stack: 'real', service: 'svc', port: 8080,
+        }), false);
+        // Immediately push the request bytes while ensureBridge is in flight.
+        mockWs.emit('message',
+            encodeBinaryFrame(BinaryFrameType.TcpData, s, Buffer.from('POST /hook HTTP/1.1\r\n\r\n')),
+            true);
+
+        // Wait for the relay to call openTcpStream on the fake bridge.
+        await waitFor(() => (fakeTargetBridge.openTcpStream.mock.calls.length > 0) ? true : undefined);
+        // Fire 'open' on the fake target so the relay flushes its pending buffer.
+        fakeTargetStream.emit('open');
+
+        const ack = await waitFor(() => findAck(mockWs, s));
+        expect(ack.ok).toBe(true);
+        // Buffered bytes were delivered exactly once, intact, in order.
+        const combined = Buffer.concat(writes).toString();
+        expect(combined).toBe('POST /hook HTTP/1.1\r\n\r\n');
+
+        // Subsequent post-open writes also flow.
+        mockWs.emit('message',
+            encodeBinaryFrame(BinaryFrameType.TcpData, s, Buffer.from('trailer')),
+            true);
+        await waitFor(() => (writes.length >= 2) ? true : undefined);
+        expect(Buffer.concat(writes).toString()).toBe('POST /hook HTTP/1.1\r\n\r\ntrailer');
+
+        bridge.close();
+        vi.restoreAllMocks();
+    });
 });

--- a/backend/src/__tests__/pilot-bridge-reverse.test.ts
+++ b/backend/src/__tests__/pilot-bridge-reverse.test.ts
@@ -254,23 +254,40 @@ describe('PilotTunnelBridge handles tcp_open_reverse (Phase B)', () => {
             encodeBinaryFrame(BinaryFrameType.TcpData, s, Buffer.from('POST /hook HTTP/1.1\r\n\r\n')),
             true);
 
-        // Wait for the relay to call openTcpStream on the fake bridge.
-        await waitFor(() => (fakeTargetBridge.openTcpStream.mock.calls.length > 0) ? true : undefined);
+        // Wait until acceptReverseRelay has actually swapped the reservation
+        // to kind:'reverse_relay' (and targetOpen is still false because the
+        // target hasn't emitted 'open'). Polling the bridge's stream state
+        // directly is more deterministic than polling openTcpStream.mock
+        // calls, since the state swap is synchronous after openTcpStream
+        // returns but the JS scheduler decides when the test sees it.
+        const bridgeStreams = (bridge as unknown as { streams: Map<number, { kind: string; targetOpen?: boolean }> }).streams;
+        await waitFor(() => {
+            const cur = bridgeStreams.get(s);
+            return (cur?.kind === 'reverse_relay' && cur.targetOpen === false) ? true : undefined;
+        });
+        // Second TcpData frame in the targetOpen===false window after the
+        // state swap. Without the reverse_relay branch's pendingData buffer,
+        // these bytes would be silently dropped.
+        mockWs.emit('message',
+            encodeBinaryFrame(BinaryFrameType.TcpData, s, Buffer.from('mid-window')),
+            true);
         // Fire 'open' on the fake target so the relay flushes its pending buffer.
         fakeTargetStream.emit('open');
 
         const ack = await waitFor(() => findAck(mockWs, s));
         expect(ack.ok).toBe(true);
-        // Buffered bytes were delivered exactly once, intact, in order.
+        // Both pre-openTcpStream and post-state-swap buffered bytes were
+        // flushed exactly once, intact, in order.
+        await waitFor(() => (Buffer.concat(writes).toString().includes('mid-window')) ? true : undefined);
         const combined = Buffer.concat(writes).toString();
-        expect(combined).toBe('POST /hook HTTP/1.1\r\n\r\n');
+        expect(combined).toBe('POST /hook HTTP/1.1\r\n\r\nmid-window');
 
         // Subsequent post-open writes also flow.
         mockWs.emit('message',
             encodeBinaryFrame(BinaryFrameType.TcpData, s, Buffer.from('trailer')),
             true);
-        await waitFor(() => (writes.length >= 2) ? true : undefined);
-        expect(Buffer.concat(writes).toString()).toBe('POST /hook HTTP/1.1\r\n\r\ntrailer');
+        await waitFor(() => (Buffer.concat(writes).toString().endsWith('trailer')) ? true : undefined);
+        expect(Buffer.concat(writes).toString()).toBe('POST /hook HTTP/1.1\r\n\r\nmid-windowtrailer');
 
         bridge.close();
         vi.restoreAllMocks();

--- a/backend/src/__tests__/upgrade-order.test.ts
+++ b/backend/src/__tests__/upgrade-order.test.ts
@@ -8,7 +8,7 @@
  * product paths. This test pins each position by observing behavior that
  * could only originate from the expected handler.
  */
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import WebSocket from 'ws';
 import jwt from 'jsonwebtoken';
 import crypto from 'crypto';
@@ -43,9 +43,21 @@ describe('WebSocket upgrade dispatch order', () => {
 
     const token = jwt.sign({ username: TEST_USERNAME }, TEST_JWT_SECRET, { expiresIn: '1m' });
     sessionCookie = `sencho_token=${token}`;
+
+    // Existing /api/mesh/proxy-tunnel scope tests assume the receiver
+    // license clears the Admiral check. Set the license to Admiral so
+    // the credential-only assertions below still hold; the dedicated
+    // license-gating describe block flips and restores per-test.
+    DatabaseService.getInstance().setSystemState('license_status', 'active');
+    DatabaseService.getInstance().setSystemState('license_variant_type', 'admiral');
   });
 
   afterAll(async () => {
+    // Clear the Admiral state beforeAll set so this file does not leak
+    // license context into other tests sharing the same test DB.
+    const { DatabaseService } = await import('../services/DatabaseService');
+    DatabaseService.getInstance().setSystemState('license_status', 'community');
+    DatabaseService.getInstance().setSystemState('license_variant_type', '');
     await new Promise<void>((resolve, reject) => {
       server.close((err) => (err ? reject(err) : resolve()));
     });
@@ -212,6 +224,69 @@ describe('WebSocket upgrade dispatch order', () => {
 
     it('rejects a session cookie at the upgrade with HTTP 403 (mesh is not a UI surface)', async () => {
       const ws = connect('/api/mesh/proxy-tunnel', { cookie: sessionCookie });
+      const outcome = await waitForOutcome(ws);
+      expect(outcome.kind).toBe('unexpected');
+      if (outcome.kind === 'unexpected') expect(outcome.status).toBe(403);
+    });
+  });
+
+  describe('/api/mesh/proxy-tunnel Admiral entitlement gating', () => {
+    // The mesh data plane is Admiral-only on the *receiving* node, matching
+    // the HTTP mesh routes in routes/mesh.ts (every route calls
+    // requireAdmiral). These tests pin the parity so a future change to one
+    // surface cannot silently drift the other. The credential gate above
+    // still applies first; this block flips only the license to community
+    // or skipper while keeping a valid node_proxy or full-admin token.
+
+    async function setLicense(status: string, variantType: string | null): Promise<void> {
+      const { DatabaseService } = await import('../services/DatabaseService');
+      DatabaseService.getInstance().setSystemState('license_status', status);
+      if (variantType === null) {
+        DatabaseService.getInstance().setSystemState('license_variant_type', '');
+      } else {
+        DatabaseService.getInstance().setSystemState('license_variant_type', variantType);
+      }
+    }
+
+    afterEach(async () => {
+      // Restore the Admiral state beforeAll established so subsequent
+      // tests in this file (and the proxy-tunnel scope block) keep passing.
+      await setLicense('active', 'admiral');
+    });
+
+    it('rejects a node_proxy Bearer with HTTP 403 when the receiver license is community', async () => {
+      await setLicense('community', null);
+      const nodeProxyToken = jwt.sign({ scope: 'node_proxy' }, TEST_JWT_SECRET, { expiresIn: '1m' });
+      const ws = connect('/api/mesh/proxy-tunnel', { bearer: nodeProxyToken });
+      const outcome = await waitForOutcome(ws);
+      expect(outcome.kind).toBe('unexpected');
+      if (outcome.kind === 'unexpected') expect(outcome.status).toBe(403);
+    });
+
+    it('rejects a node_proxy Bearer with HTTP 403 when the receiver license is paid but Skipper (not Admiral)', async () => {
+      await setLicense('active', 'skipper');
+      const nodeProxyToken = jwt.sign({ scope: 'node_proxy' }, TEST_JWT_SECRET, { expiresIn: '1m' });
+      const ws = connect('/api/mesh/proxy-tunnel', { bearer: nodeProxyToken });
+      const outcome = await waitForOutcome(ws);
+      expect(outcome.kind).toBe('unexpected');
+      if (outcome.kind === 'unexpected') expect(outcome.status).toBe(403);
+    });
+
+    it('rejects a full-admin api_token with HTTP 403 when the receiver license is community', async () => {
+      await setLicense('community', null);
+      const { DatabaseService } = await import('../services/DatabaseService');
+      const rawToken = generateApiToken();
+      const tokenHash = crypto.createHash('sha256').update(rawToken).digest('hex');
+      const adminId = DatabaseService.getInstance().getUserByUsername(TEST_USERNAME)!.id;
+      DatabaseService.getInstance().addApiToken({
+        token_hash: tokenHash,
+        name: `mesh-license-gate-${Date.now()}`,
+        scope: 'full-admin',
+        user_id: adminId,
+        created_at: Date.now(),
+        expires_at: null,
+      });
+      const ws = connect('/api/mesh/proxy-tunnel', { bearer: rawToken });
       const outcome = await waitForOutcome(ws);
       expect(outcome.kind).toBe('unexpected');
       if (outcome.kind === 'unexpected') expect(outcome.status).toBe(403);

--- a/backend/src/__tests__/upgrade-order.test.ts
+++ b/backend/src/__tests__/upgrade-order.test.ts
@@ -15,6 +15,7 @@ import crypto from 'crypto';
 import type { AddressInfo } from 'net';
 import { setupTestDb, cleanupTestDb, TEST_USERNAME, TEST_JWT_SECRET } from './helpers/setupTestDb';
 import { generateApiToken } from '../utils/apiTokenFormat';
+import { createTestApiToken } from './helpers/apiTokenTestHelper';
 
 describe('WebSocket upgrade dispatch order', () => {
   let tmpDir: string;
@@ -287,16 +288,12 @@ describe('WebSocket upgrade dispatch order', () => {
     it('rejects a full-admin api_token with HTTP 403 when the receiver license is community (forwarded headers ignored on api_token path)', async () => {
       await setLicense('community', null);
       const { DatabaseService } = await import('../services/DatabaseService');
-      const rawToken = generateApiToken();
-      const tokenHash = crypto.createHash('sha256').update(rawToken).digest('hex');
       const adminId = DatabaseService.getInstance().getUserByUsername(TEST_USERNAME)!.id;
-      DatabaseService.getInstance().addApiToken({
-        token_hash: tokenHash,
-        name: `mesh-license-gate-${Date.now()}`,
+      const rawToken = createTestApiToken({
+        db: DatabaseService,
         scope: 'full-admin',
-        user_id: adminId,
-        created_at: Date.now(),
-        expires_at: null,
+        userId: adminId,
+        name: `mesh-license-gate-${Date.now()}`,
       });
       // Header is set but must be ignored: the full-admin api_token is a
       // local-entitlement credential, not a node_proxy forwarder.

--- a/backend/src/__tests__/upgrade-order.test.ts
+++ b/backend/src/__tests__/upgrade-order.test.ts
@@ -64,10 +64,14 @@ describe('WebSocket upgrade dispatch order', () => {
     cleanupTestDb(tmpDir);
   });
 
-  function connect(pathAndQuery: string, opts: { cookie?: string; bearer?: string } = {}): WebSocket {
+  function connect(
+    pathAndQuery: string,
+    opts: { cookie?: string; bearer?: string; extraHeaders?: Record<string, string> } = {},
+  ): WebSocket {
     const headers: Record<string, string> = {};
     if (opts.cookie) headers['cookie'] = opts.cookie;
     if (opts.bearer) headers['authorization'] = `Bearer ${opts.bearer}`;
+    if (opts.extraHeaders) Object.assign(headers, opts.extraHeaders);
     return new WebSocket(`ws://127.0.0.1:${port}${pathAndQuery}`, { headers });
   }
 
@@ -231,12 +235,20 @@ describe('WebSocket upgrade dispatch order', () => {
   });
 
   describe('/api/mesh/proxy-tunnel Admiral entitlement gating', () => {
-    // The mesh data plane is Admiral-only on the *receiving* node, matching
-    // the HTTP mesh routes in routes/mesh.ts (every route calls
-    // requireAdmiral). These tests pin the parity so a future change to one
-    // surface cannot silently drift the other. The credential gate above
-    // still applies first; this block flips only the license to community
-    // or skipper while keeping a valid node_proxy or full-admin token.
+    // Admiral entitlement on the WS data plane is decided against the
+    // *central's* asserted tier, matching the HTTP mesh routes
+    // (requireAdmiral in routes/mesh.ts reads req.proxyTier from forwarded
+    // headers off the node_proxy credential). The WS dispatcher trusts
+    // x-sencho-tier / x-sencho-variant only when the upgrade carries a
+    // node_proxy JWT; when no headers are present, or when the credential
+    // is a full-admin api_token (no central is asserting tier), it falls
+    // back to the receiver's own license. These tests pin both branches:
+    // (a) the trusted-header path accepts an Admiral central even on a
+    //     Community receiver, and rejects a Community central on an
+    //     Admiral receiver;
+    // (b) the local-fallback path keeps the receiver-license check intact
+    //     for full-admin api_token upgrades and for header-less node_proxy
+    //     upgrades.
 
     async function setLicense(status: string, variantType: string | null): Promise<void> {
       const { DatabaseService } = await import('../services/DatabaseService');
@@ -254,7 +266,7 @@ describe('WebSocket upgrade dispatch order', () => {
       await setLicense('active', 'admiral');
     });
 
-    it('rejects a node_proxy Bearer with HTTP 403 when the receiver license is community', async () => {
+    it('rejects a node_proxy Bearer with HTTP 403 when no tier headers and the receiver license is community', async () => {
       await setLicense('community', null);
       const nodeProxyToken = jwt.sign({ scope: 'node_proxy' }, TEST_JWT_SECRET, { expiresIn: '1m' });
       const ws = connect('/api/mesh/proxy-tunnel', { bearer: nodeProxyToken });
@@ -263,7 +275,7 @@ describe('WebSocket upgrade dispatch order', () => {
       if (outcome.kind === 'unexpected') expect(outcome.status).toBe(403);
     });
 
-    it('rejects a node_proxy Bearer with HTTP 403 when the receiver license is paid but Skipper (not Admiral)', async () => {
+    it('rejects a node_proxy Bearer with HTTP 403 when no tier headers and the receiver license is paid but Skipper (not Admiral)', async () => {
       await setLicense('active', 'skipper');
       const nodeProxyToken = jwt.sign({ scope: 'node_proxy' }, TEST_JWT_SECRET, { expiresIn: '1m' });
       const ws = connect('/api/mesh/proxy-tunnel', { bearer: nodeProxyToken });
@@ -272,7 +284,7 @@ describe('WebSocket upgrade dispatch order', () => {
       if (outcome.kind === 'unexpected') expect(outcome.status).toBe(403);
     });
 
-    it('rejects a full-admin api_token with HTTP 403 when the receiver license is community', async () => {
+    it('rejects a full-admin api_token with HTTP 403 when the receiver license is community (forwarded headers ignored on api_token path)', async () => {
       await setLicense('community', null);
       const { DatabaseService } = await import('../services/DatabaseService');
       const rawToken = generateApiToken();
@@ -286,7 +298,47 @@ describe('WebSocket upgrade dispatch order', () => {
         created_at: Date.now(),
         expires_at: null,
       });
-      const ws = connect('/api/mesh/proxy-tunnel', { bearer: rawToken });
+      // Header is set but must be ignored: the full-admin api_token is a
+      // local-entitlement credential, not a node_proxy forwarder.
+      const ws = connect('/api/mesh/proxy-tunnel', {
+        bearer: rawToken,
+        extraHeaders: { 'x-sencho-tier': 'paid', 'x-sencho-variant': 'admiral' },
+      });
+      const outcome = await waitForOutcome(ws);
+      expect(outcome.kind).toBe('unexpected');
+      if (outcome.kind === 'unexpected') expect(outcome.status).toBe(403);
+    });
+
+    it('accepts a node_proxy Bearer asserting paid+admiral via forwarded headers even when the receiver license is community', async () => {
+      await setLicense('community', null);
+      const nodeProxyToken = jwt.sign({ scope: 'node_proxy' }, TEST_JWT_SECRET, { expiresIn: '1m' });
+      const ws = connect('/api/mesh/proxy-tunnel', {
+        bearer: nodeProxyToken,
+        extraHeaders: { 'x-sencho-tier': 'paid', 'x-sencho-variant': 'admiral' },
+      });
+      const outcome = await waitForOutcome(ws);
+      expect(outcome.kind).toBe('open');
+      try { ws.terminate(); } catch { /* ignore */ }
+    });
+
+    it('rejects a node_proxy Bearer asserting community via forwarded headers even when the receiver license is Admiral', async () => {
+      // Receiver state is already Admiral (set by beforeAll / afterEach).
+      const nodeProxyToken = jwt.sign({ scope: 'node_proxy' }, TEST_JWT_SECRET, { expiresIn: '1m' });
+      const ws = connect('/api/mesh/proxy-tunnel', {
+        bearer: nodeProxyToken,
+        extraHeaders: { 'x-sencho-tier': 'community' },
+      });
+      const outcome = await waitForOutcome(ws);
+      expect(outcome.kind).toBe('unexpected');
+      if (outcome.kind === 'unexpected') expect(outcome.status).toBe(403);
+    });
+
+    it('rejects a node_proxy Bearer asserting paid+skipper via forwarded headers (paid but not Admiral)', async () => {
+      const nodeProxyToken = jwt.sign({ scope: 'node_proxy' }, TEST_JWT_SECRET, { expiresIn: '1m' });
+      const ws = connect('/api/mesh/proxy-tunnel', {
+        bearer: nodeProxyToken,
+        extraHeaders: { 'x-sencho-tier': 'paid', 'x-sencho-variant': 'skipper' },
+      });
       const outcome = await waitForOutcome(ws);
       expect(outcome.kind).toBe('unexpected');
       if (outcome.kind === 'unexpected') expect(outcome.status).toBe(403);

--- a/backend/src/routes/mesh.ts
+++ b/backend/src/routes/mesh.ts
@@ -85,7 +85,7 @@ meshRouter.post('/nodes/:nodeId/disable', async (req: Request, res: Response): P
     const nodeId = Number.parseInt(req.params.nodeId as string, 10);
     if (!Number.isFinite(nodeId)) { res.status(400).json({ error: 'Invalid node id' }); return; }
     try {
-        await MeshService.getInstance().disableForNode(nodeId);
+        await MeshService.getInstance().disableForNode(nodeId, actorFor(req));
         res.json({ ok: true });
     } catch (err) {
         res.status(500).json({ error: (err as Error).message });

--- a/backend/src/services/MeshForwarder.ts
+++ b/backend/src/services/MeshForwarder.ts
@@ -2,19 +2,17 @@ import net from 'net';
 import { sanitizeForLog } from '../utils/safeLog';
 
 /**
- * In-process mesh TCP forwarder. Owns per-port `net.Server` listeners on the
- * host network and delegates accepted sockets to the host (MeshService) for
- * resolve + splice. Replaces the separate `saelix/sencho-mesh` sidecar
- * container that previously did this job over a control WebSocket. The
- * resolve step is now a sync map lookup rather than a round-trip, so
- * MeshForwarder is just a thin lifecycle layer; all routing + splicing
- * lives on MeshService.
+ * In-process mesh TCP forwarder. Owns per-port `net.Server` listeners and
+ * delegates accepted sockets to the host (MeshService) for resolve +
+ * splice. All routing and splicing logic lives on MeshService;
+ * MeshForwarder is a thin lifecycle layer that opens and closes ports.
  *
- * Sencho's container must run in `network_mode: host` (Linux) for the
- * listeners to bind on the host's network where meshed containers'
- * `extra_hosts: <alias>:host-gateway` entries point. Without host network
- * mode, `net.createServer().listen(port)` lands inside the container's
- * namespace and inbound traffic from peers never reaches it.
+ * Sencho runs in standard Docker bridge mode and attaches its own
+ * container to the shared `sencho_mesh` network at a stable IP. Meshed
+ * user containers are attached to the same network, so they reach the
+ * forwarder by the Sencho IP without `network_mode: host` or the
+ * `extra_hosts: <alias>:host-gateway` indirection an older sidecar
+ * design required.
  */
 
 export interface MeshForwarderHost {
@@ -50,9 +48,10 @@ export class MeshForwarder {
                     const onListening = () => { server.removeListener('error', onError); resolve(); };
                     server.once('error', onError);
                     server.once('listening', onListening);
-                    // Bind on all interfaces. Under host network mode this is
-                    // the host's own network; under bridge mode (mesh disabled
-                    // at boot) this would be the container's namespace.
+                    // Bind on all interfaces inside the Sencho container's
+                    // networking namespace. The sencho_mesh bridge attaches
+                    // both Sencho and meshed user containers, so peers reach
+                    // this listener at Sencho's mesh-network IP.
                     server.listen(port, '0.0.0.0');
                 });
                 this.listeners.set(port, server);

--- a/backend/src/services/MeshProxyTunnelDialer.ts
+++ b/backend/src/services/MeshProxyTunnelDialer.ts
@@ -9,6 +9,8 @@ import { httpUrlToWs } from '../utils/wsUrl';
 import { isDebugEnabled } from '../utils/debug';
 import { PilotMetrics } from './PilotMetrics';
 import type { MeshActivityType } from './MeshService';
+import { LicenseService } from './LicenseService';
+import { PROXY_TIER_HEADER, PROXY_VARIANT_HEADER } from './license-headers';
 
 /**
  * Central-side dialer for proxy-mode mesh tunnels.
@@ -234,10 +236,23 @@ export class MeshProxyTunnelDialer extends EventEmitter {
         // the peer falls back to its local DB default (always 1) and treats
         // cross-node aliases as same-node.
         const wsUrl = httpUrlToWs(target.apiUrl) + `/api/mesh/proxy-tunnel?nodeId=${nodeId}`;
+        // Forward central's tier and variant so the receiver enforces Admiral
+        // against the *central's* license (matching the HTTP mesh routes,
+        // which all gate on `requireAdmiral` against `req.proxyTier`). Without
+        // these the receiver falls back to its own local license, which would
+        // both reject Admiral centrals talking to Community remotes and let
+        // Community centrals dial locally-Admiral remotes. The headers are
+        // trusted on the receiver only when the WS carries a node_proxy /
+        // pilot_tunnel credential (see middleware/auth.ts:117-135).
+        const proxyHeaders = LicenseService.getInstance().getProxyHeaders();
         let ws: WebSocket;
         try {
             ws = new WebSocket(wsUrl, {
-                headers: { Authorization: `Bearer ${target.apiToken}` },
+                headers: {
+                    Authorization: `Bearer ${target.apiToken}`,
+                    [PROXY_TIER_HEADER]: proxyHeaders.tier,
+                    [PROXY_VARIANT_HEADER]: proxyHeaders.variant || '',
+                },
                 handshakeTimeout: HANDSHAKE_TIMEOUT_MS,
                 maxPayload: MAX_FRAME_SIZE_BYTES,
             });

--- a/backend/src/services/MeshService.ts
+++ b/backend/src/services/MeshService.ts
@@ -242,9 +242,8 @@ interface ActiveStreamRecord {
 
 /**
  * Sencho Mesh orchestrator. Owns:
- *   - in-process TCP forwarder (`MeshForwarder`) that binds host-network
- *     listeners on alias ports. Replaces the prior separate sidecar
- *     container; one container per node now.
+ *   - in-process TCP forwarder (`MeshForwarder`) that binds per-alias
+ *     listeners on Sencho's `sencho_mesh` bridge-network IP.
  *   - opt-in / opt-out persistence and cascading override regeneration
  *   - global alias aggregation (across the fleet via the existing HTTP
  *     proxy chain, see `inspectStackServices`)
@@ -258,8 +257,6 @@ interface ActiveStreamRecord {
  *     Docker bridge network. Meshed user services join `sencho_mesh` so
  *     that IP is reachable from inside their containers without any
  *     host-firewall coordination.
- *   - cross-node mesh routing is central → pilot in this phase. Pilot →
- *     central and pilot ↔ pilot via central relay land in Phase B.
  */
 export class MeshService extends EventEmitter implements MeshForwarderHost {
     private static instance: MeshService;
@@ -912,8 +909,18 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
         const stacks = DatabaseService.getInstance().listMeshStacks(nodeId);
         for (const s of stacks) {
             DatabaseService.getInstance().deleteMeshStack(nodeId, s.stack_name);
-            await this.removeStackOverride(nodeId, s.stack_name);
         }
+        // Dispatch DELETE /api/mesh/local-override/:stack for remote nodes
+        // (pilot or proxy) so the override file pushed earlier via
+        // applyLocalOverride is removed; falls back to local deletion for
+        // local nodes. Parallelize per the regenerateOverridesForNode
+        // rationale: each remote call is its own HTTP round-trip, so
+        // awaiting sequentially turns N stacks into N serialised DELETEs.
+        // `allSettled` so a single failure does not abort the others
+        // (removeOverrideFromNode already swallows errors internally).
+        await Promise.allSettled(
+            stacks.map((s) => this.removeOverrideFromNode(nodeId, s.stack_name)),
+        );
         await this.refreshAliasCache();
         await this.syncForwarderListeners();
         // Mirror optOutStack: regenerate every remaining node's override
@@ -1705,12 +1712,12 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
 
     /**
      * Same-node forward: dial the target container's bridge IP directly.
-     * Sencho runs in `network_mode: host` so it sees the docker bridge
-     * networks and can reach container IPs without going through any
-     * host-port publish. Looks up the container by Compose's
-     * `<project>-<service>-<index>` naming convention; falls back to a
-     * label-filtered listContainers if the conventional name is absent
-     * (e.g. when the operator overrode the project name).
+     * Sencho joins the `sencho_mesh` Docker bridge network alongside the
+     * meshed user containers, so it can reach their bridge IPs without
+     * going through any host-port publish. Looks up the container by
+     * Compose's `<project>-<service>-<index>` naming convention; falls
+     * back to a label-filtered listContainers if the conventional name
+     * is absent (e.g. when the operator overrode the project name).
      */
     private async openSameNode(target: MeshTarget, src: net.Socket): Promise<void> {
         const ip = await this.resolveContainerIp(target);
@@ -2259,13 +2266,6 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
     private isLocalForwarderActive(): boolean {
         return this.started && this.forwarder.getListenerPorts().length > 0;
     }
-
-    // mintSidecarToken / verifySidecarToken / spawnSidecar / stopSidecar /
-    // isSidecarRunning / handleSidecarResolve / sendSidecar /
-    // attachSidecarSocket are gone: the in-process MeshForwarder replaces
-    // the entire sidecar layer. Routing decisions happen via direct
-    // MeshService calls — no JWT minting, no separate container, no control
-    // WebSocket. See `docs/internal/architecture/mesh.md` for the new flow.
 }
 
 export type MeshErrorCode =

--- a/backend/src/services/MeshService.ts
+++ b/backend/src/services/MeshService.ts
@@ -1428,11 +1428,13 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
             const body = await res.json() as { services?: Array<{ service: string; ports: number[] }> };
             return body.services ?? [];
         } catch (err) {
-            // proxyFetch throws MeshError('push_failed') when getProxyTarget
-            // returns null (e.g. pilot tunnel offline). Treat the same as a
-            // non-OK response: empty list.
-            if (err instanceof MeshError && err.code === 'push_failed') {
-                console.warn(`[MeshService] inspectStackServices: no proxy target for node ${nodeId} (${sanitizeForLog(node.name)})`);
+            // proxyFetch throws MeshError('no_target') when getProxyTarget
+            // returns null (pilot tunnel offline, proxy bridge unreachable)
+            // and MeshError('push_failed') on a non-OK HTTP response. Treat
+            // both as a soft "no services to report" so the Routing tab does
+            // not surface a stack trace for a node that is simply offline.
+            if (err instanceof MeshError && (err.code === 'no_target' || err.code === 'push_failed')) {
+                console.warn(`[MeshService] inspectStackServices: unreachable node ${nodeId} (${sanitizeForLog(node.name)}): ${err.code}`);
                 return [];
             }
             console.error('[MeshService] inspectStackServices remote unreachable:', sanitizeForLog((err as Error).message));

--- a/backend/src/services/MeshService.ts
+++ b/backend/src/services/MeshService.ts
@@ -904,7 +904,10 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
         }
     }
 
-    public async disableForNode(nodeId: number): Promise<void> {
+    public async disableForNode(
+        nodeId: number,
+        actor: string = 'system:mesh.disable',
+    ): Promise<void> {
         DatabaseService.getInstance().setNodeMeshEnabled(nodeId, false);
         const stacks = DatabaseService.getInstance().listMeshStacks(nodeId);
         for (const s of stacks) {
@@ -913,6 +916,16 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
         }
         await this.refreshAliasCache();
         await this.syncForwarderListeners();
+        // Mirror optOutStack: regenerate every remaining node's override
+        // without the dropped aliases, recompose the rest of the fleet so
+        // their containers shed the stale extra_hosts, and redeploy the
+        // disabled node's own stacks so their containers detach from the
+        // sencho_mesh network and lose the alias entries they owned.
+        await this.regenerateOverridesAcrossFleet();
+        this.cascadeRecomposeAcrossFleet(undefined, undefined, actor);
+        for (const s of stacks) {
+            this.triggerRedeploy(nodeId, s.stack_name, actor);
+        }
         this.logActivity({
             source: 'mesh', level: 'info', type: 'mesh.disable',
             nodeId, message: `mesh disabled on node ${nodeId}`,

--- a/backend/src/services/PilotTunnelBridge.ts
+++ b/backend/src/services/PilotTunnelBridge.ts
@@ -91,6 +91,16 @@ interface ReverseLocalTcpStreamState extends StreamMeta {
 interface ReverseRelayTcpStreamState extends StreamMeta {
     kind: 'reverse_relay';
     target: TcpStream;
+    /**
+     * False between `acceptReverseRelay` swapping the reservation for this
+     * state and the target stream emitting `'open'`. `TcpData` frames
+     * arriving in that window are queued in `pendingData` rather than
+     * written into the target stream, whose own remote ack may not yet
+     * have landed.
+     */
+    targetOpen: boolean;
+    pendingData: Buffer[];
+    pendingBytes: number;
     bytesIn: number;
     bytesOut: number;
 }
@@ -639,7 +649,23 @@ export class PilotTunnelBridge extends EventEmitter implements MeshTunnelHandle 
                 } else if (s.kind === 'reverse_relay') {
                     s.bytesIn += frame.payload.length;
                     this.refreshIdleTimer(frame.streamId, s);
-                    s.target.write(frame.payload);
+                    if (s.targetOpen) {
+                        s.target.write(frame.payload);
+                    } else {
+                        // Mirror the reverse_local pending-data path: between
+                        // the state swap in acceptReverseRelay and the target
+                        // stream's 'open' event, buffer up to the cap. Without
+                        // this, a peer that sends body bytes immediately after
+                        // tcp_open_reverse would drop them into a stream that
+                        // is still waiting for its remote ack.
+                        if (s.pendingBytes + frame.payload.length > STREAM_PENDING_DATA_MAX_BYTES) {
+                            this.removeStream(frame.streamId);
+                            this.sendJson({ t: 'tcp_close', s: frame.streamId });
+                            break;
+                        }
+                        s.pendingData.push(Buffer.from(frame.payload));
+                        s.pendingBytes += frame.payload.length;
+                    }
                 }
                 break;
             }
@@ -825,11 +851,12 @@ export class PilotTunnelBridge extends EventEmitter implements MeshTunnelHandle 
             if (targetNodeId === localNodeId) {
                 await this.acceptReverseLocal(s, { stack, service, port });
             } else {
-                // Relay path does not yet buffer early data (separate
-                // follow-up); drop the local-shaped reservation so the
-                // relay state machine starts from a clean slot. Any frames
-                // buffered up to this point are discarded with it.
-                if (this.streams.get(s) === reservation) this.removeStream(s);
+                // Leave the local-shaped reservation in place so any
+                // TcpData arriving while ensureBridge + openTcpStream
+                // resolve keeps buffering through the reverse_local
+                // branch in handleBinaryFrame. acceptReverseRelay
+                // transplants the buffered frames into the relay state
+                // and flushes them before the open ack.
                 await this.acceptReverseRelay(s, targetNodeId, { stack, service, port });
             }
         })().catch((err) => {
@@ -938,25 +965,62 @@ export class PilotTunnelBridge extends EventEmitter implements MeshTunnelHandle 
     }
 
     private async acceptReverseRelay(s: number, targetNodeId: number, target: { stack: string; service: string; port: number }): Promise<void> {
+        // Pull the reverse_local-shaped reservation that handleTcpOpenReverse
+        // placed synchronously. Its pendingData buffer holds any TcpData
+        // frames that arrived while we were dispatching, which we transplant
+        // into the relay state so they can be flushed once the target stream
+        // opens.
+        const reservation = this.streams.get(s);
+        if (!reservation || reservation.kind !== 'reverse_local') return;
+
         const { PilotTunnelManager } = await import('./PilotTunnelManager');
         // ensureBridge resolves either an existing pilot tunnel or a fresh
         // proxy-mode tunnel dialed on demand, so proxy <-> proxy relays
         // succeed even when neither remote has a pilot agent.
         const targetBridge = await PilotTunnelManager.getInstance().ensureBridge(targetNodeId);
         if (!targetBridge) {
+            if (this.streams.get(s) === reservation) this.removeStream(s);
             this.sendJson({ t: 'tcp_open_ack', s, ok: false, err: 'unreachable' });
             return;
         }
+        // Reservation may have been evicted under the pending-bytes cap
+        // while ensureBridge was resolving. If so, the peer has already
+        // been told via tcp_close to tear down; bail out cleanly.
+        if (this.streams.get(s) !== reservation) return;
+
         const targetStream = targetBridge.openTcpStream(target);
         if (!targetStream) {
+            if (this.streams.get(s) === reservation) this.removeStream(s);
             this.sendJson({ t: 'tcp_open_ack', s, ok: false, err: 'unreachable' });
             return;
         }
-        const state: ReverseRelayTcpStreamState = { kind: 'reverse_relay', target: targetStream, bytesIn: 0, bytesOut: 0 };
+        const state: ReverseRelayTcpStreamState = {
+            kind: 'reverse_relay',
+            target: targetStream,
+            targetOpen: false,
+            pendingData: reservation.pendingData,
+            pendingBytes: reservation.pendingBytes,
+            bytesIn: reservation.bytesIn,
+            bytesOut: 0,
+        };
         this.streams.set(s, state);
         this.refreshIdleTimer(s, state);
 
         targetStream.once('open', () => {
+            const cur = this.streams.get(s);
+            if (!cur || cur.kind !== 'reverse_relay') return;
+            // Flush buffered early data into the target stream BEFORE
+            // acking so the peer sees a clean "ack + data" sequence and
+            // the upstream receives the request body ahead of anything
+            // that arrives post-ack.
+            if (cur.pendingData.length > 0) {
+                for (const buf of cur.pendingData) {
+                    try { cur.target.write(buf); } catch { /* ignore */ }
+                }
+                cur.pendingData = [];
+                cur.pendingBytes = 0;
+            }
+            cur.targetOpen = true;
             this.sendJson({ t: 'tcp_open_ack', s, ok: true });
         });
         targetStream.on('data', (chunk: Buffer) => {

--- a/backend/src/websocket/upgradeHandler.ts
+++ b/backend/src/websocket/upgradeHandler.ts
@@ -16,6 +16,8 @@ import { handleHostConsoleWs } from './hostConsole';
 import { handleGenericWs, attachGenericConnectionHandlers } from './generic';
 import { rejectUpgrade as reject } from './reject';
 import { looksLikeApiToken, verifyApiTokenChecksum } from '../utils/apiTokenFormat';
+import { PROXY_TIER_HEADER, PROXY_VARIANT_HEADER } from '../services/license-headers';
+import { isLicenseTier, normalizeTier, isLicenseVariant, normalizeVariant } from '../services/license-normalize';
 
 function parseCookies(req: IncomingMessage): Record<string, string> {
   const header = req.headers.cookie || '';
@@ -139,20 +141,29 @@ export function attachUpgrade(
       // decoded scope is undefined (isProxyToken=false, wsApiTokenScope=null).
       // Restricted api_token scopes (read-only, deploy-only) are blocked
       // earlier by the scope gate above before this branch is reached.
-      // The data plane additionally requires this node's own license to be
-      // Admiral so the WS and the HTTP mesh routes share one entitlement
-      // surface (HTTP mesh routes in routes/mesh.ts all call requireAdmiral).
-      // Read the local license directly rather than going through
-      // effectiveTier()/requireAdmiral: those consult req.proxyTier (trusted
-      // forwarded headers from a fronting Sencho), and a remote peer dialing
-      // in over WS cannot be trusted to assert our entitlement. The dialer
-      // sends only Authorization Bearer; tier is decided here on the receiver.
+      //
+      // Admiral entitlement is decided against the *central's* license, not
+      // the receiver's, matching every HTTP mesh route in routes/mesh.ts that
+      // uses `requireAdmiral` / `effectiveTier`. On the node_proxy path the
+      // central forwards `x-sencho-tier` / `x-sencho-variant` and the WS
+      // dispatcher trusts them off the node_proxy credential (same rule as
+      // middleware/auth.ts:117-135 for HTTP). On the full-admin api_token
+      // path no central is asserting tier, so we fall back to the receiver's
+      // own license. Both produce paid+admiral or the upgrade is rejected.
       if (pathname === '/api/mesh/proxy-tunnel') {
         if (!isProxyToken && wsApiTokenScope !== 'full-admin') {
           return reject(socket, 403, 'Forbidden');
         }
         const license = LicenseService.getInstance();
-        if (license.getTier() !== 'paid' || license.getVariant() !== 'admiral') {
+        const tunnelTierHeader = req.headers[PROXY_TIER_HEADER] as string | undefined;
+        const tunnelVariantHeader = req.headers[PROXY_VARIANT_HEADER] as string | undefined;
+        const tunnelTier = isProxyToken && isLicenseTier(tunnelTierHeader)
+          ? normalizeTier(tunnelTierHeader)
+          : license.getTier();
+        const tunnelVariant = isProxyToken && tunnelVariantHeader !== undefined && isLicenseVariant(tunnelVariantHeader)
+          ? normalizeVariant(tunnelVariantHeader)
+          : license.getVariant();
+        if (tunnelTier !== 'paid' || tunnelVariant !== 'admiral') {
           return reject(socket, 403, 'Forbidden');
         }
         await handleMeshProxyTunnel(req, socket, head);

--- a/backend/src/websocket/upgradeHandler.ts
+++ b/backend/src/websocket/upgradeHandler.ts
@@ -4,6 +4,7 @@ import type { WebSocketServer } from 'ws';
 import jwt from 'jsonwebtoken';
 import crypto from 'crypto';
 import { DatabaseService, type UserRole } from '../services/DatabaseService';
+import { LicenseService } from '../services/LicenseService';
 import { NodeRegistry } from '../services/NodeRegistry';
 import { COOKIE_NAME } from '../helpers/constants';
 import { handlePilotTunnel } from './pilotTunnel';
@@ -138,8 +139,20 @@ export function attachUpgrade(
       // decoded scope is undefined (isProxyToken=false, wsApiTokenScope=null).
       // Restricted api_token scopes (read-only, deploy-only) are blocked
       // earlier by the scope gate above before this branch is reached.
+      // The data plane additionally requires this node's own license to be
+      // Admiral so the WS and the HTTP mesh routes share one entitlement
+      // surface (HTTP mesh routes in routes/mesh.ts all call requireAdmiral).
+      // Read the local license directly rather than going through
+      // effectiveTier()/requireAdmiral: those consult req.proxyTier (trusted
+      // forwarded headers from a fronting Sencho), and a remote peer dialing
+      // in over WS cannot be trusted to assert our entitlement. The dialer
+      // sends only Authorization Bearer; tier is decided here on the receiver.
       if (pathname === '/api/mesh/proxy-tunnel') {
         if (!isProxyToken && wsApiTokenScope !== 'full-admin') {
+          return reject(socket, 403, 'Forbidden');
+        }
+        const license = LicenseService.getInstance();
+        if (license.getTier() !== 'paid' || license.getVariant() !== 'admiral') {
           return reject(socket, 403, 'Forbidden');
         }
         await handleMeshProxyTunnel(req, socket, head);


### PR DESCRIPTION
## Summary

Addresses the five findings from the Sencho Mesh audit, plus two High issues and two Low cleanups surfaced by a second-pass audit on this branch, plus one test-coverage closure from a third-pass audit.

- **High**: reverse-relay path on `PilotTunnelBridge` dropped early TcpData. The local-shaped reservation that buffered frames during the dispatch race was discarded as soon as the target was found to be on a third node. A peer that sent a request body immediately after `tcp_open_reverse` lost those bytes. The reservation is now carried through `acceptReverseRelay`, its pending frames are transplanted into a new `reverse_relay` state, and they are flushed into the target stream before the open ack. A `targetOpen` gate keeps frames buffered until the target stream opens.
- **Medium**: `MeshService.disableForNode` only cleared the control plane (DB rows, override files, alias cache). Running containers on the disabled node stayed attached to `sencho_mesh` with stale `/etc/hosts` aliases until manually redeployed. The function now mirrors `optOutStack`: it regenerates fleet-wide overrides, cascade-recomposes other nodes, and redeploys each previously meshed stack on the disabled node so containers detach cleanly. The route threads the actor via `actorFor(req)` for parity with opt-in / opt-out. Override removal now routes through `removeOverrideFromNode` so remote nodes also have their pushed override files deleted via `DELETE /api/mesh/local-override/:stack`; the per-stack removes fan out in parallel via `Promise.allSettled`.
- **High (audit follow-up)**: `/api/mesh/proxy-tunnel` WS upgrade asserted Admiral against the receiver's local license, contradicting both the docs ("An Admiral license on the central Sencho") and every other distributed-license check, which trusts `x-sencho-tier` / `x-sencho-variant` forwarded off a `node_proxy` credential. The dialer (`MeshProxyTunnelDialer`) now sends those headers from `LicenseService.getProxyHeaders()`. The receiver in `upgradeHandler.ts` trusts them only when the upgrade carries a node_proxy credential and falls back to the local license otherwise (full-admin api_token path). Matches the trust model already used by `requireAdmiral` on the HTTP mesh routes and by `hostConsole.ts` for the host-console WS.
- **Low**: `inspectStackServices` caught `MeshError('push_failed')` but `proxyFetch` actually throws `MeshError('no_target')` for offline remotes. Both codes are now recognized; the warn log names the unreachable node and the code instead of falling through to the generic error path.
- **Low**: `.env.example` shipped `SENCHO_MESH_PROXY_TUNNEL_IDLE_MS=300000` with a comment describing five-minute idle teardown, but the code default is `0` (persistent). Operators copying the example silently reintroduced the idle close the dialer removed. Default flipped to `0` and the comment rewritten. `MeshForwarder.ts` docblock and inline comment also rewritten to reflect bridge-network reality (no `network_mode: host`, no `host-gateway` indirection).
- **Low (audit follow-up)**: extended the reverse-relay buffering test to cover the post-state-swap window (TcpData arriving after `openTcpStream` returns but before the target emits `open`). Refreshed three stale `MeshService` comments that still referenced the removed sidecar layer and host-network listener model.
- **Low (third-pass audit follow-up)**: the existing remote-node `disableForNode` test mocks `removeOverrideFromNode` itself, so a regression inside that helper would slip through. New `mesh-remove-override-remote.test.ts` pins the HTTP shape directly: `DELETE /api/mesh/local-override/:stack` against the resolved proxy target with `Authorization` and tier headers, plus the `encodeURIComponent` path and the swallowed-network-error behavior the disable cascade depends on.

## Gate parity

Per Directive 30:

- **Backend**: `/api/mesh/proxy-tunnel` WS upgrade now requires Admiral via the central's asserted tier (forwarded headers off the node_proxy credential), falling back to the receiver's local license on the full-admin api_token path (`backend/src/websocket/upgradeHandler.ts`, `backend/src/services/MeshProxyTunnelDialer.ts`).
- **Frontend**: no paired change required. The mesh UI surfaces (Routing tab, Diagnostics, alias detail sheet) live on the central and are already Admiral-gated by the HTTP mesh routes they call (`AdmiralGate` plus per-route `requireAdmiral`); no new UI affordance was added or removed in this PR.

## Test plan

- [x] `backend/src/__tests__/pilot-bridge-reverse.test.ts`: fires `tcp_open_reverse` then an immediate `TcpData` frame while `ensureBridge` is in flight, then waits for the fake target stream's `open` event. Asserts the buffered payload arrives intact, in order, before the ack, and that subsequent post-open writes still flow. Extended to also emit a second `TcpData` frame after the state swap to `reverse_relay` but before the target's `open` event, asserting both buffered chunks land in order.
- [x] `backend/src/__tests__/mesh-service.test.ts`: tests cover the redeploy fan-out, the cascade with no skip tuple, the default actor fallback, and the remote-node disable path dispatching `removeOverrideFromNode` for each stack.
- [x] `backend/src/__tests__/mesh-remove-override-remote.test.ts`: pins `removeOverrideFromNode` against a remote node to `DELETE /api/mesh/local-override/<stack>` with `Authorization` and tier headers; covers URL encoding and tolerated network errors.
- [x] `backend/src/__tests__/upgrade-order.test.ts`: six tests pin both branches of the Admiral entitlement gate. The trusted-header path accepts an Admiral central even on a Community receiver and rejects a Community central on an Admiral receiver. The local-fallback path keeps the receiver-license check intact for full-admin api_token upgrades and for header-less node_proxy upgrades.
- [x] `backend/src/__tests__/mesh-inspect-remote.test.ts`: spies on `console.warn` / `console.error` to pin the branch that recognizes `no_target` and emits the operator-friendly log.
- [x] Backend full suite: 2349 passed, 7 skipped, 1 pre-existing Windows EBUSY flake on `filesystem-backup.test.ts` (last touched in unrelated PRs).
- [x] Backend `tsc --noEmit`: clean.
- [x] Frontend `tsc -b --noEmit`: clean.

## Notes

- Internal-only doc edits (`docs/internal/architecture/mesh.md`, etc.) updated locally in the working tree but not part of the diff since `docs/internal/` is gitignored.
- The third-pass audit also flagged an asymmetry in how the WS gate handles `paid + empty variant`. On closer trace it is not a real bug: HTTP `effectiveVariant` uses `??`, which collapses `null` and `undefined` to the local-license fallback, so the `else if (variantHeader === '')` branch in `auth.ts` is functionally equivalent to leaving `proxyVariant` undefined. The WS gate falls back to local for the same input, producing the same result on both surfaces.
- Out of scope, called out by the audit but tracked separately:
  - E2E source-node Routing tab probe (audit currently probes only from central / local).
  - Suspended-opt-in and port-collision regression tests.