### PR TITLE
docs(licensing): refresh tier prices and rename Lifetime to Founder Lifetime

### DIFF
--- a/docs/features/licensing.mdx
+++ b/docs/features/licensing.mdx
@@ -11,15 +11,15 @@ Sencho uses an open-core model. The **Community** tier is free forever with unli
 
 ## Plans
 
-| Tier | Annual (per mo, billed yearly) | Monthly | Lifetime (EA) | Seats |
-|------|--------------------------------|---------|---------------|-------|
+| Tier | Annual (per mo, billed yearly) | Monthly | Founder Lifetime | Seats |
+|------|--------------------------------|---------|------------------|-------|
 | **Community** | Free | Free | Free | 1 admin |
-| **Skipper** | $11.99 | $14.99 | $449 | 1 admin + 3 viewers |
-| **Admiral** | $69.99 | $89.99 | $2,499 | Unlimited |
+| **Skipper** | $5.75 | $9.99 | $149 | 1 admin + 3 viewers |
+| **Admiral** | $20.75 | $39.99 | $499 | Unlimited |
 
-For larger deployments, an **Enterprise** tier is available from $3,500 per year with SLA, priority support, security questionnaires, and custom contracts. See [the pricing page](https://sencho.io/pricing) for the full comparison.
+For larger deployments, an **Enterprise** tier is available with custom pricing, including SLA, priority support, security questionnaires, and custom contracts. Contact [licensing@sencho.io](mailto:licensing@sencho.io) or see [the pricing page](https://sencho.io/pricing) for details.
 
-Lifetime pricing is an Early Access offer available for a limited time.
+**Founder Lifetime** is an Early Access offer available for a limited time. Once the window closes, only the Monthly and Annual cycles remain.
 
 ### Feature breakdown
 
@@ -68,7 +68,7 @@ Lifetime pricing is an Early Access offer available for a limited time.
 
 ## Free trial
 
-Sencho offers a **14-day Admiral trial** so you can evaluate the flagship features (Host Console, Sencho Mesh, scheduled operations, LDAP / Active Directory, audit log, unlimited accounts) with your real infrastructure before committing. The trial is offered on the monthly and annual Admiral plans; the lifetime plan does not include a trial.
+Sencho offers a **14-day Admiral trial** so you can evaluate the flagship features (Host Console, Sencho Mesh, scheduled operations, LDAP / Active Directory, audit log, unlimited accounts) with your real infrastructure before committing. The trial is offered on the monthly and annual Admiral plans; the Founder Lifetime plan does not include a trial.
 
 To start a trial:
 


### PR DESCRIPTION
## Summary

Update `docs/features/licensing.mdx` to match the new website pricing.

| Tier | Annual (per mo, billed yearly) | Monthly | Founder Lifetime | Seats |
|------|--------------------------------|---------|------------------|-------|
| Community | Free | Free | Free | 1 admin |
| Skipper | $5.75 (= $69/yr) | $9.99 | $149 | 1 admin + 3 viewers |
| Admiral | $20.75 (= $249/yr) | $39.99 | $499 | Unlimited |
| Enterprise | custom | custom | n/a | tailored |

Four edits, one file:

1. Pricing table values updated; "Lifetime (EA)" column header renamed to "Founder Lifetime".
2. Enterprise blurb replaced with custom-pricing wording (was a fixed annual minimum).
3. EA blurb renamed to "Founder Lifetime" and clarified that closing the EA window leaves only the Monthly and Annual cycles.
4. Trial-section caveat updated from "the lifetime plan" to "the Founder Lifetime plan".

## Scope notes

A repo-wide audit (`docs/`, `README.md`, `frontend/src/`) confirmed that **prices live in exactly one file**. All other tier references name Community/Skipper/Admiral without dollar amounts, and the README plus overview pages link out to `sencho.io/pricing` rather than quoting prices. No frontend changes needed.

The in-app license-duration model is unchanged: the masthead `DURATION: lifetime` pill, the `### Lifetime licenses` operational subsection, the license-states table row "Active lifetime", and the troubleshooting "Lifetime license" callout all still describe app runtime behaviour and are intentionally left as-is. Only the SKU/customer-facing name changed.

## Test plan

- [x] Greps for stale prices (`11.99`, `14.99`, `69.99`, `89.99`, `2,499`, `3,500`, `Lifetime (EA)`) return zero matches across `docs/` and `README.md`.
- [x] Greenfield check: no "previously", "used to", or upgrade framing in the new prose.
- [x] No em dashes (CLAUDE.md Directive 18).
- [x] No fence-spec, no tier-bypass walkthroughs (Directives 27, 29, 31).
- [ ] Mintlify dev preview renders the pricing table with four columns; the Enterprise and Founder Lifetime sentences read naturally.