### PR TITLE
fix(fleet): equalize action card heights, swap order, replace native autocomplete

### DIFF
--- a/frontend/src/components/fleet/FleetActions/FleetActionsTab.tsx
+++ b/frontend/src/components/fleet/FleetActions/FleetActionsTab.tsx
@@ -22,14 +22,17 @@ export function FleetActionsTab({ nodes }: Props) {
     return <EmptyState />;
   }
 
-  // Grid breakpoints per audit §18.7: 1 / 2 / 3 columns at 760 / 1280. The
-  // 4-column breakpoint is reserved for when a 4th card lands; v1 has three
-  // so it is intentionally omitted to avoid a hanging gap on wide displays.
+  // Grid: 1 col under lg, 2 cols at lg and above. auto-rows-fr distributes
+  // available height evenly across the auto-created rows, and each card uses
+  // `flex flex-col h-full` (in <FleetActionCard>) with a `flex-1` body so it
+  // fills its grid cell. Result: all three cards render at the same height,
+  // with shorter cards growing their body whitespace before the footer pins.
+  // Order: Prune top-left, Bulk top-right, Stop on row 2.
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-[18px] items-start auto-rows-min">
-      <LabelFleetStopCard nodes={nodes} />
-      <BulkLabelAssignCard nodes={nodes} />
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-[18px] auto-rows-fr">
       <FleetPruneCard nodes={nodes} />
+      <BulkLabelAssignCard nodes={nodes} />
+      <LabelFleetStopCard nodes={nodes} />
     </div>
   );
 }

--- a/frontend/src/components/fleet/FleetActions/cards/LabelFleetStopCard.tsx
+++ b/frontend/src/components/fleet/FleetActions/cards/LabelFleetStopCard.tsx
@@ -201,18 +201,13 @@ export function LabelFleetStopCard({ nodes }: Props) {
           title="Label · target"
           meta={`auto-suggested · ${knownLabelNames.length} known`}
         >
-          <Input
-            id="fleet-stop-label-input"
-            list="fleet-stop-label-suggestions"
+          <LabelAutocomplete
             value={labelName}
-            onChange={(e) => setLabelName(e.target.value)}
-            placeholder="e.g. production"
-            className="h-9 text-sm"
+            onChange={setLabelName}
+            suggestions={knownLabelNames}
             disabled={running}
+            placeholder="e.g. production"
           />
-          <datalist id="fleet-stop-label-suggestions">
-            {knownLabelNames.map(n => <option key={n} value={n} />)}
-          </datalist>
         </SheetSection>
 
         {previewSection}
@@ -305,6 +300,94 @@ function PreviewWell({ perNode }: PreviewWellProps) {
           </li>
         )}
       </ul>
+    </div>
+  );
+}
+
+interface LabelAutocompleteProps {
+  value: string;
+  onChange: (next: string) => void;
+  suggestions: string[];
+  disabled?: boolean;
+  placeholder?: string;
+}
+
+// Free-form text input with a Sencho-styled suggestion popover. Replaces the
+// browser-native <datalist> so the dropdown matches the rest of the kit (same
+// surface tokens as <Combobox>). The operator can still type a label name
+// that was not in the suggestions list; the server-side match-preview will
+// resolve it or report 0 nodes match.
+function LabelAutocomplete({ value, onChange, suggestions, disabled, placeholder }: LabelAutocompleteProps) {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  const filtered = useMemo(() => {
+    const q = value.trim().toLowerCase();
+    if (q.length === 0) return suggestions;
+    return suggestions.filter(s => s.toLowerCase().includes(q));
+  }, [value, suggestions]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onClick);
+    document.addEventListener('keydown', onKey, true);
+    return () => {
+      document.removeEventListener('mousedown', onClick);
+      document.removeEventListener('keydown', onKey, true);
+    };
+  }, [open]);
+
+  const handleSelect = (next: string) => {
+    onChange(next);
+    setOpen(false);
+  };
+
+  return (
+    <div ref={wrapperRef} className="relative">
+      <Input
+        id="fleet-stop-label-input"
+        value={value}
+        onChange={(e) => {
+          onChange(e.target.value);
+          if (!open) setOpen(true);
+        }}
+        onFocus={() => { if (!disabled) setOpen(true); }}
+        placeholder={placeholder}
+        className="h-9 text-sm"
+        disabled={disabled}
+        autoComplete="off"
+        spellCheck={false}
+      />
+      {open && filtered.length > 0 && (
+        <div className="absolute left-0 top-full mt-1 z-50 w-full rounded-md border border-glass-border bg-popover text-popover-foreground shadow-md backdrop-blur-[10px] backdrop-saturate-[1.15]">
+          <ul className="max-h-[200px] overflow-y-auto overflow-x-hidden p-1">
+            {filtered.map((s) => (
+              <li key={s}>
+                <button
+                  type="button"
+                  // mousedown + preventDefault keeps the input focused so the
+                  // selection registers before any blur-driven close fires.
+                  onMouseDown={(e) => { e.preventDefault(); handleSelect(s); }}
+                  className="flex w-full items-center rounded-sm px-2 py-1.5 font-mono text-xs text-stat-value hover:bg-accent hover:text-accent-foreground"
+                >
+                  {s}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/ui/fleet-action-card.tsx
+++ b/frontend/src/components/ui/fleet-action-card.tsx
@@ -12,6 +12,14 @@ export type FleetActionClass = 'destructive' | 'transformative' | 'maintenance';
 export type BlastRadiusTone = 'warning' | 'success' | 'muted';
 export type PrimaryActionVariant = 'primary' | 'destructive';
 
+/**
+ * System-Sheet recipe card for the Fleet Actions tab (audit §18, DESIGN §10).
+ *
+ * Layout note: the outer <Card> is `flex flex-col h-full` and the body slot
+ * is `flex-1`, so when a parent gives the card explicit height (e.g. the
+ * equalized-row wrapper in FleetActionsTab.tsx), the body grows and the
+ * footer pins to the bottom. In a content-sized parent this is a no-op.
+ */
 export interface FleetActionCardProps {
   /** Crumb segments. Last segment renders in --stat-title; the rest in --stat-subtitle with separators. */
   crumb: string[];
@@ -107,7 +115,7 @@ export function FleetActionCard(props: FleetActionCardProps) {
   const headCrumbs = crumb.slice(0, -1);
 
   return (
-    <Card className="relative overflow-hidden p-0">
+    <Card className="relative overflow-hidden p-0 flex flex-col h-full">
       <span
         aria-hidden="true"
         className="absolute inset-y-0 left-0 w-[3px] bg-brand"
@@ -166,7 +174,7 @@ export function FleetActionCard(props: FleetActionCardProps) {
         />
       </div>
 
-      <div className="px-6">
+      <div className="px-6 flex-1">
         {children}
       </div>
 


### PR DESCRIPTION
Polish follow-up to #1137.

## Summary

- **Cards equal in height, two per row.** Grid drops `xl:grid-cols-3` and gains `auto-rows-fr`; `<FleetActionCard>` becomes `flex flex-col h-full` with a `flex-1` body so the card actually fills its grid cell. All three cards render at the same height regardless of which row they land in; the shorter card grows its body whitespace and the footer pins to the bottom.
- **Card order swapped.** JSX order is now Prune → Bulk → Stop. Prune lands top-left with its live `~ N GB reclaimable` estimate populated on first render; Stop (which reads `awaiting target` until the operator types) drops to row 2.
- **Custom dropdown on the Stop card.** Replaces the browser-native `<datalist>` with a new inline `LabelAutocomplete`: free-form text input + a Sencho-styled popover (`border-glass-border bg-popover backdrop-blur-[10px]`) that filters the known-label set as the operator types. `onMouseDown` + `preventDefault` on the suggestion button keeps the input focused so the click registers before any blur-driven close. Outside-click and Escape (capture phase) close the popover. The operator can still run against a label that was not in the autocomplete; the server-side match-preview resolves it.
- **Primary button never wraps.** Added `whitespace-nowrap` to the primary so `Stop fleet` / `Prune fleet` stay on a single line in tight viewports.

## Test plan

Validated end-to-end in a real browser at `http://localhost:5173`:

- Fleet → Fleet Actions renders three cards, all at 440.5px height (Prune top-left, Bulk top-right, Stop on row 2). Confirmed via `offsetHeight` readback.
- Typed `D` into the Stop card's label input. Autocomplete opened with `DEV` and `Media` filtered in (case-insensitive substring match — `Me**d**ia`). The popover sits inside the card body with the design-system surface tokens.
- Clicked `DEV` from the popover. Input filled with `DEV`, popover closed, blast-radius readout updated to `3 stacks · 1 nodes` via the live match-preview endpoint, Preview SheetSection populated with three rows.
- Typed a label that does not exist. Blast readout switched to `0 nodes match` (muted dot), Dry run + Stop fleet both force-disabled by the primitive's literal-prefix rule.
- `tsc -b --noEmit` clean. No new lint warnings on the changed files.

## Notes

- **No JS measurement.** I went down a `useLayoutEffect` + `ResizeObserver` rabbit hole before realizing CSS Grid's `auto-rows-fr` does what's needed in this layout (the Fleet view's content area is content-sized, not container-stretched, so `1fr` resolves to the tallest row's natural height instead of inflating to the viewport). The current code is plain CSS; no measurement state, no resize listener.
- **`LabelAutocomplete` lives in the card file for now.** It is structurally similar to `<Combobox>` in `frontend/src/components/ui/`, with the difference that it preserves free-form typing. When the second consumer for this pattern lands, extract it to `components/ui/`.
- **Accessibility gap to follow up:** the popover does not yet wear `role="listbox"` / `role="option"` and the input does not yet expose `aria-controls` / `aria-expanded`. `<Combobox>` has the same gap. Worth a dedicated a11y pass on both primitives.
- **Body stretch is documented.** Added a JSDoc note on `<FleetActionCardProps>` explaining that the body `flex-1` only stretches when the parent gives the card explicit height (e.g. the `auto-rows-fr` grid here); in a content-sized parent the body sits at its natural height.

## Gate parity

No gates moved. All chrome; no backend changes, no `requirePaid` / `requireAdmin` shifts. Fleet Actions remains Skipper+ via the existing tab-level `isPaid` check.