### PR TITLE
fix(hub-only-guard): reject hub-only collection paths without trailing slash

### DIFF
--- a/backend/src/__tests__/hub-only-guard.test.ts
+++ b/backend/src/__tests__/hub-only-guard.test.ts
@@ -87,6 +87,39 @@ describe('hubOnlyGuard', () => {
     expect(res.body?.code).not.toBe('HUB_ONLY_ENDPOINT');
   });
 
+  // Regression: HUB_ONLY_PREFIXES entries carry a trailing slash, and a bare
+  // startsWith() match would let the collection paths (no trailing slash) fall
+  // through to the remote proxy. The matcher must accept both forms.
+  it('rejects /api/scheduled-tasks (no trailing slash) with 403 when nodeId targets a remote node', async () => {
+    const res = await request(app)
+      .get('/api/scheduled-tasks')
+      .set('Authorization', authHeader)
+      .set('x-node-id', String(remoteNodeId));
+
+    expect(res.status).toBe(403);
+    expect(res.body?.code).toBe('HUB_ONLY_ENDPOINT');
+  });
+
+  it('rejects /api/audit-log (no trailing slash) with 403 when nodeId targets a remote node', async () => {
+    const res = await request(app)
+      .get('/api/audit-log')
+      .set('Authorization', authHeader)
+      .set('x-node-id', String(remoteNodeId));
+
+    expect(res.status).toBe(403);
+    expect(res.body?.code).toBe('HUB_ONLY_ENDPOINT');
+  });
+
+  it('rejects /api/notification-routes (no trailing slash) with 403 when nodeId targets a remote node', async () => {
+    const res = await request(app)
+      .get('/api/notification-routes')
+      .set('Authorization', authHeader)
+      .set('x-node-id', String(remoteNodeId));
+
+    expect(res.status).toBe(403);
+    expect(res.body?.code).toBe('HUB_ONLY_ENDPOINT');
+  });
+
   it('does not interfere with non-hub paths even when nodeId targets a remote node', async () => {
     // /api/stacks is not hub-only and should be forwarded by the proxy.
     // The exact upstream-error status is not the contract here; what

--- a/backend/src/helpers/proxyExemptPaths.ts
+++ b/backend/src/helpers/proxyExemptPaths.ts
@@ -29,6 +29,12 @@ export function isProxyExemptPath(path: string): boolean {
 // nodeId resolves to a remote node so a script/curl call cannot trick the
 // proxy into forwarding hub-only authority across a node boundary.
 //
+// Entries are stored with a trailing slash; the matcher accepts the exact
+// collection path (without the trailing slash) AND any sub-path under it,
+// so e.g. `/api/scheduled-tasks` and `/api/scheduled-tasks/42` both match.
+// A bare startsWith() would let the collection path silently fall through
+// and be forwarded by the remote proxy.
+//
 // Frontend nav surfaces are gated separately via `HUB_ONLY_VIEWS` in
 // useViewNavigationState.ts; this list is the backend defense-in-depth.
 //
@@ -44,6 +50,7 @@ export const HUB_ONLY_PREFIXES: readonly string[] = [
 export function isHubOnlyPath(path: string): boolean {
   for (const prefix of HUB_ONLY_PREFIXES) {
     if (path.startsWith(prefix)) return true;
+    if (path === prefix.slice(0, -1)) return true;
   }
   return false;
 }


### PR DESCRIPTION
## Summary

`HUB_ONLY_PREFIXES` entries are stored with a trailing slash (e.g. `/api/scheduled-tasks/`), but `isHubOnlyPath()` matched with a bare `path.startsWith(prefix)`. The collection paths without trailing slash silently fell through the guard, so a scripted client could send `GET /api/scheduled-tasks` (or `POST`, etc.) with `x-node-id: <remote>` and the request would be forwarded by the remote proxy. The bypass affected all three hub-only path families:

- `/api/scheduled-tasks` (list + create)
- `/api/audit-log` (list)
- `/api/notification-routes` (list + create)

The matcher now accepts the slash-suffixed prefix **or** the exact prefix with the trailing slash dropped. `path.startsWith('/api/scheduled-tasks/')` covers `/api/scheduled-tasks/42`; the new exact-match clause covers `/api/scheduled-tasks` itself.

## What changed

- `backend/src/helpers/proxyExemptPaths.ts`: `isHubOnlyPath()` adds an `||  path === prefix.slice(0, -1)` clause. Comment expanded to explain why both forms are needed.
- `backend/src/__tests__/hub-only-guard.test.ts`: three regression tests added — one per hub-only family — asserting `403 HUB_ONLY_ENDPOINT` for the bare collection path with a remote `x-node-id`.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npm test -- hub-only-guard` — 8/8 pass (5 existing + 3 new).
- [x] Regression coverage: stashed the matcher change and re-ran the test file. With the bug present, the 3 new tests fail; with the fix, all 8 pass. Restored the change.
- [x] Code review of the diff: no actionable defects. Verified `slice(0, -1)` is safe across the current entries (all end with `/`) and that no sibling route shares the prefix string up to but not including the slash.

## Notes

- `PROXY_EXEMPT_PREFIXES` in the same file uses the same `startsWith`-only matcher with a mix of slash and no-slash entries. That helper is permissive (skip JSON parse, skip node resolution), so the worst case of an unintended hit is a local handler getting a request it would have gotten anyway. The two helpers have inverse failure modes; only the restrictive one needed tightening. Out of scope for this PR.
- Adjacent issue (not fixed here, flagged for a future cleanup): the doc comment and test header both reference "rejected with 409" while the middleware returns 403. Pre-existing wording drift, not in scope.
- Sibling PR #1141 (Scheduled Operations → Skipper) makes the schedule collection endpoints reachable to a larger user base, which is what raised this finding in audit. This fix should land first or alongside.