### PR TITLE
fix(frontend): wire favicon to existing logo assets

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,9 @@
 
 <head>
   <meta charset="UTF-8" />
-  <link rel="icon" type="image/png" href="/sencho-logo.png" />
+  <link rel="icon" type="image/png" href="/sencho-logo-dark.png" media="(prefers-color-scheme: dark)" />
+  <link rel="icon" type="image/png" href="/sencho-logo-light.png" media="(prefers-color-scheme: light)" />
+  <link rel="apple-touch-icon" href="/sencho-logo-light.png" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Sencho</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
## Summary
- `frontend/index.html` referenced `/sencho-logo.png`, which is not present in `frontend/public/`. Every page load 404'd the favicon and tabs fell back to the browser's generic icon.
- Point the favicon at the two PNGs that actually ship (`sencho-logo-dark.png` and `sencho-logo-light.png`) and let the browser pick the right one via `prefers-color-scheme`.
- Add an `apple-touch-icon` so iOS home-screen pinning has a real asset to use.

## Test plan
- [x] Both `/sencho-logo-dark.png` (8976 bytes) and `/sencho-logo-light.png` (9843 bytes) resolve from the Vite dev server with matching byte counts.
- [x] Served `index.html` includes all three new `<link>` tags.
- [ ] Manual: load the app, confirm the tab icon renders on a fresh load in both light and dark system themes.

## Notes
- The two PNG variants already drive the in-app brand swap in `SidebarBrand.tsx`. The favicon now follows the same dark/light split via the system-level preference, since favicon `<link>` tags can only key off `prefers-color-scheme` (they cannot follow the user's manual in-app theme toggle without JS).
- `apple-touch-icon` uses the light-mode variant (the darker-colored logo), which reads better on the typical iOS home-screen wallpaper.