### PR TITLE
docs: expand Features subgroups by default

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -96,6 +96,7 @@
               "features/overview",
               {
                 "group": "Stacks",
+                "expanded": true,
                 "pages": [
                   "features/stack-management",
                   "features/editor",
@@ -107,6 +108,7 @@
               },
               {
                 "group": "Deployment",
+                "expanded": true,
                 "pages": [
                   "features/deploy-progress",
                   "features/atomic-deployments",
@@ -119,6 +121,7 @@
               "features/resources",
               {
                 "group": "Observability",
+                "expanded": true,
                 "pages": [
                   "features/dashboard",
                   "features/global-search",
@@ -129,6 +132,7 @@
               },
               {
                 "group": "Fleet",
+                "expanded": true,
                 "pages": [
                   "features/multi-node",
                   "features/pilot-agent",
@@ -146,6 +150,7 @@
               },
               {
                 "group": "Automation",
+                "expanded": true,
                 "pages": [
                   "features/scheduled-operations",
                   "features/auto-update-policies",
@@ -155,6 +160,7 @@
               },
               {
                 "group": "Security & Identity",
+                "expanded": true,
                 "pages": [
                   "features/two-factor-authentication",
                   "features/rbac",


### PR DESCRIPTION
## Summary

Mintlify nested groups collapse unless `expanded: true` is set on each group object. Adding it to all six Features subgroups (Stacks, Deployment, Observability, Fleet, Automation, Security & Identity) so users land on a fully scannable sidebar instead of six folded headers.

Top-level groups (Getting Started, Features, Operations, Reference) are always expanded by Mintlify — no change needed there.

## Test plan

- [x] `docs/docs.json` parses as valid JSON
- [ ] Local Mintlify preview (`cd docs && npx mintlify dev`) — confirm all six Features subgroups render expanded on first load