### PR TITLE
feat(security): move managed Trivy auto-update to Skipper tier

### DIFF
--- a/backend/src/__tests__/security-trivy-auto-update-route.test.ts
+++ b/backend/src/__tests__/security-trivy-auto-update-route.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for the role + tier gate on PUT /api/security/trivy-auto-update.
+ *
+ * The route flips the global `trivy_auto_update` setting that the scheduler
+ * reads every 24h to decide whether to pull newer Trivy binary releases.
+ * It must be reachable only by an admin on a paid (Skipper or Admiral) tier.
+ */
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import request from 'supertest';
+import bcrypt from 'bcrypt';
+import { setupTestDb, cleanupTestDb, loginAsTestAdmin } from './helpers/setupTestDb';
+
+let tmpDir: string;
+let app: import('express').Express;
+let DatabaseService: typeof import('../services/DatabaseService').DatabaseService;
+let adminCookie: string;
+let viewerCookie: string;
+
+beforeAll(async () => {
+  tmpDir = await setupTestDb();
+  ({ DatabaseService } = await import('../services/DatabaseService'));
+
+  const { LicenseService } = await import('../services/LicenseService');
+  vi.spyOn(LicenseService.getInstance(), 'getTier').mockReturnValue('paid');
+  vi.spyOn(LicenseService.getInstance(), 'getVariant').mockReturnValue('admiral');
+  vi.spyOn(LicenseService.getInstance(), 'getSeatLimits').mockReturnValue({ maxAdmins: null, maxViewers: null });
+
+  ({ app } = await import('../index'));
+  adminCookie = await loginAsTestAdmin(app);
+
+  const viewerHash = await bcrypt.hash('viewerpass3', 1);
+  DatabaseService.getInstance().addUser({ username: 'trivy-viewer', password_hash: viewerHash, role: 'viewer' });
+  const viewerRes = await request(app).post('/api/auth/login').send({ username: 'trivy-viewer', password: 'viewerpass3' });
+  const cookies = viewerRes.headers['set-cookie'] as string | string[];
+  viewerCookie = Array.isArray(cookies) ? cookies[0] : cookies;
+});
+
+afterAll(() => cleanupTestDb(tmpDir));
+
+describe('PUT /api/security/trivy-auto-update', () => {
+  it('rejects unauthenticated requests with 401', async () => {
+    const res = await request(app)
+      .put('/api/security/trivy-auto-update')
+      .send({ enabled: true });
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects authenticated viewer with 403', async () => {
+    const res = await request(app)
+      .put('/api/security/trivy-auto-update')
+      .set('Cookie', viewerCookie)
+      .send({ enabled: true });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects Community tier with 403', async () => {
+    const { LicenseService } = await import('../services/LicenseService');
+    const spy = vi.spyOn(LicenseService.getInstance(), 'getTier').mockReturnValue('community');
+    try {
+      const res = await request(app)
+        .put('/api/security/trivy-auto-update')
+        .set('Cookie', adminCookie)
+        .send({ enabled: true });
+      expect(res.status).toBe(403);
+    } finally {
+      spy.mockReturnValue('paid');
+    }
+  });
+
+  it('accepts paid admin and persists the setting (enable)', async () => {
+    const res = await request(app)
+      .put('/api/security/trivy-auto-update')
+      .set('Cookie', adminCookie)
+      .send({ enabled: true });
+    expect(res.status).toBe(200);
+    expect(res.body.autoUpdate).toBe(true);
+    expect(DatabaseService.getInstance().getGlobalSettings().trivy_auto_update).toBe('1');
+  });
+
+  it('accepts paid admin and persists the setting (disable)', async () => {
+    const res = await request(app)
+      .put('/api/security/trivy-auto-update')
+      .set('Cookie', adminCookie)
+      .send({ enabled: false });
+    expect(res.status).toBe(200);
+    expect(res.body.autoUpdate).toBe(false);
+    expect(DatabaseService.getInstance().getGlobalSettings().trivy_auto_update).toBe('0');
+  });
+});

--- a/backend/src/routes/security.ts
+++ b/backend/src/routes/security.ts
@@ -1,6 +1,6 @@
 import { Router, type Request, type Response } from 'express';
 import { authMiddleware } from '../middleware/auth';
-import { requireAdmin, requireAdmiral, requirePaid } from '../middleware/tierGates';
+import { requireAdmin, requirePaid } from '../middleware/tierGates';
 import { trivyInstallLimiter } from '../middleware/rateLimiters';
 import TrivyService, { SbomFormat } from '../services/TrivyService';
 import TrivyInstaller from '../services/TrivyInstaller';
@@ -203,7 +203,7 @@ securityRouter.post('/trivy-update', trivyInstallLimiter, authMiddleware, async 
 });
 
 securityRouter.put('/trivy-auto-update', authMiddleware, (req: Request, res: Response): void => {
-  if (!requireAdmiral(req, res)) return;
+  if (!requirePaid(req, res)) return;
   const enabled = req.body?.enabled === true;
   try {
     DatabaseService.getInstance().updateGlobalSetting('trivy_auto_update', enabled ? '1' : '0');

--- a/backend/src/routes/security.ts
+++ b/backend/src/routes/security.ts
@@ -203,6 +203,7 @@ securityRouter.post('/trivy-update', trivyInstallLimiter, authMiddleware, async 
 });
 
 securityRouter.put('/trivy-auto-update', authMiddleware, (req: Request, res: Response): void => {
+  if (!requireAdmin(req, res)) return;
   if (!requirePaid(req, res)) return;
   const enabled = req.body?.enabled === true;
   try {

--- a/docs/features/licensing.mdx
+++ b/docs/features/licensing.mdx
@@ -47,6 +47,7 @@ For larger deployments, an **Enterprise** tier is available with custom pricing,
 - Auto-heal policies
 - Scheduled operations across the full action catalog (lifecycle, updates, scans, snapshots, prune)
 - Scan policies with `block_on_deploy` deploy enforcement, SBOM (SPDX, CycloneDX), and SARIF export
+- Auto-update of the managed Trivy binary
 - Bulk actions on a label (deploy, stop, or restart every stack tagged with it)
 - Remote OTA node updates from the control instance
 - Fleet Actions (bulk update all, bulk restart Sencho)
@@ -64,7 +65,6 @@ For larger deployments, an **Enterprise** tier is available with custom pricing,
 - Private and custom registry credentials
 - Sencho Mesh (cross-node container networking)
 - Sencho Cloud Backup
-- Auto-update of the managed Trivy binary
 
 ## Free trial
 

--- a/docs/features/overview.mdx
+++ b/docs/features/overview.mdx
@@ -159,7 +159,7 @@ Generate scoped API tokens for CI/CD pipelines, scripts, and automation workflow
 
 ### Vulnerability scanning
 
-Scan container images for known CVEs with [Trivy](https://trivy.dev). Manual scanning, secret and misconfiguration detection, scan comparison, and CVE suppressions are available on every tier; scheduled scans, scan policies that gate deploys, SBOM generation, and SARIF export are available on Skipper and Admiral. Auto-update of the managed Trivy binary is Admiral. [Learn more →](/features/vulnerability-scanning)
+Scan container images for known CVEs with [Trivy](https://trivy.dev). Manual scanning, secret and misconfiguration detection, scan comparison, and CVE suppressions are available on every tier; scheduled scans, scan policies that gate deploys, SBOM generation, and SARIF export are available on Skipper and Admiral. Auto-update of the managed Trivy binary is Skipper. [Learn more →](/features/vulnerability-scanning)
 
 ### CVE suppressions
 

--- a/docs/features/vulnerability-scanning.mdx
+++ b/docs/features/vulnerability-scanning.mdx
@@ -36,7 +36,7 @@ The Trivy CLI must be available on the machine running Sencho. Trivy is not bund
 | Scan policies with `block_on_deploy` enforcement |  | ✓ | ✓ |
 | SBOM generation (SPDX, CycloneDX) |  | ✓ | ✓ |
 | SARIF export (code scanning integration) |  | ✓ | ✓ |
-| Auto-update of the managed Trivy binary |  |  | ✓ |
+| Auto-update of the managed Trivy binary |  | ✓ | ✓ |
 
 ## On-demand scanning
 

--- a/docs/operations/trivy-setup.mdx
+++ b/docs/operations/trivy-setup.mdx
@@ -44,7 +44,7 @@ When a newer Trivy release is available, Settings → Security shows an **Update
 
 To update automatically instead, toggle **Auto-update Trivy** on. Sencho checks for new releases once a day and installs them in the background. You'll get an in-app notification each time a new version is installed, or when an update is available and auto-update is off.
 
-The install, update, and uninstall buttons are available to admins on every tier. The **Auto-update Trivy** toggle is Admiral only.
+The install, update, and uninstall buttons are available to admins on every tier. The **Auto-update Trivy** toggle requires Skipper.
 
 ### Removing the managed install
 

--- a/docs/reference/settings.mdx
+++ b/docs/reference/settings.mdx
@@ -388,7 +388,7 @@ See [Stack Labels](/features/stack-labels) for the full walkthrough.
 ## Security
 
 <Note>
-  Security is admin-only. The Trivy installer and CVE/misconfig suppressions are available on all tiers; scan policies require Sencho Skipper or Admiral; the **Auto-update Trivy** toggle requires Admiral and a managed Trivy binary.
+  Security is admin-only. The Trivy installer and CVE/misconfig suppressions are available on all tiers; scan policies and the **Auto-update Trivy** toggle require Sencho Skipper or Admiral (the toggle also requires a managed Trivy binary).
 </Note>
 
 **Scope:** Per-node
@@ -406,7 +406,7 @@ Manage the Trivy scanner, scan policies, suppressions, and acknowledgements that
 | **Status** | `Installed (managed)` when Sencho manages the binary, `Installed (host)` when an existing host binary is being reused, or empty when nothing is detected. |
 | **Version** | The current Trivy version, when installed. |
 | **Install / Update / Uninstall** | Lifecycle actions for the managed binary. Uninstall asks for confirmation. |
-| **Auto-update Trivy** toggle | When on, Sencho checks daily and installs newer Trivy releases automatically. Requires Admiral and a managed Trivy binary. |
+| **Auto-update Trivy** toggle | When on, Sencho checks daily and installs newer Trivy releases automatically. Requires Skipper and a managed Trivy binary. |
 
 ### Scan policies
 

--- a/frontend/src/components/settings/SecuritySection.tsx
+++ b/frontend/src/components/settings/SecuritySection.tsx
@@ -14,7 +14,6 @@ import { SettingsCallout } from './SettingsCallout';
 import { SettingsPrimaryButton } from './SettingsActions';
 import { useMastheadStats } from './MastheadStatsContext';
 import type { FleetRole, ScanPolicy, VulnSeverity } from '@/types/security';
-import { useLicense } from '@/context/LicenseContext';
 import { useNodes } from '@/context/NodeContext';
 import { useTrivyStatus } from '@/hooks/useTrivyStatus';
 import { SuppressionsPanel } from './SuppressionsPanel';
@@ -70,8 +69,6 @@ export function SecuritySection({ isPaid }: { isPaid: boolean }) {
   const [saving, setSaving] = useState(false);
   const [deleteId, setDeleteId] = useState<number | null>(null);
 
-  const { license } = useLicense();
-  const isAdmiral = isPaid && license?.variant === 'admiral';
   const { activeNode } = useNodes();
   const isRemote = activeNode?.type === 'remote';
   const { status: trivy, updateCheck, refresh: refreshTrivy, refreshUpdateCheck } = useTrivyStatus();
@@ -402,7 +399,7 @@ export function SecuritySection({ isPaid }: { isPaid: boolean }) {
           <div className="text-xs text-stat-subtitle">{TRIVY_SOURCE_DESCRIPTIONS[trivy.source]}</div>
         )}
 
-        {trivy.source === 'managed' && isAdmiral && (
+        {trivy.source === 'managed' && isPaid && (
           <div className="flex items-center justify-between rounded-lg border border-glass-border px-3 py-2.5">
             <div>
               <Label className="text-sm">Auto-update Trivy</Label>


### PR DESCRIPTION
## Summary

- Move the **Managed Trivy auto-update** toggle (Settings → Security → Vulnerability Scanner → *Auto-update Trivy*) from Admiral down to Skipper.
- The toggle controls a single global setting (`trivy_auto_update`) that the scheduler reads every 24h to pull and install newer Trivy binary releases.
- Auto-pulling a newer Trivy binary on a daily timer is *automation*, which is the Skipper philosophy. The rest of Sencho's automation (auto-heal, scheduled ops, per-stack image auto-update, scan policies that gate deploys, SBOM, SARIF) all already ship at Skipper. This realigns the gate with the tier model and removes the inconsistency where the *scans that use Trivy* run on a Skipper schedule but the *Trivy binary that runs them* couldn't update itself without Admiral.
- A subsequent independent audit caught that the route also needed an admin-role guard. The follow-up fix commit adds `requireAdmin` and route tests covering the full gate matrix.

## Changes

**`feat`: tier move**
- **Backend:** `PUT /api/security/trivy-auto-update` swaps `requireAdmiral` for `requirePaid`. The now-unused `requireAdmiral` import drops out. The 24h `runTrivyUpdateCheck()` in `SchedulerService` is tier-neutral and picks up the new gate automatically.
- **Frontend:** `SecuritySection.tsx` swaps the inline `isAdmiral` conditional on the toggle render for `isPaid`. The local `isAdmiral` derivation, the `useLicense` import, and the destructured `license` const become unused and are removed.
- **Docs:** licensing, overview, vulnerability-scanning matrix, trivy-setup, and the settings reference all read Skipper consistently for this feature.

**`fix`: role-gate hardening (from audit)**
- Add `requireAdmin` ahead of `requirePaid` on `PUT /api/security/trivy-auto-update`, matching the pattern every other mutating route in this file already uses (sbom, policies, suppressions, misconfig-acks).
- The route was previously authenticated and tier-gated, but neither the global `/api` authGate nor `requirePaid` checks role. Any paid viewer could flip the global setting via a direct API call. This pre-existed the tier-move commit (the original `requireAdmiral` was a variant gate, not a role gate). The fix lands in the same PR so the Skipper rollout ships with the correct role boundary.
- Add `backend/src/__tests__/security-trivy-auto-update-route.test.ts` covering: unauthenticated → 401, paid viewer → 403, community admin → 403, paid admin enable → 200 + persisted, paid admin disable → 200 + persisted. All five pass.

## Gate parity

Per CLAUDE.md Directive 30 — both sides moved in the same PR.

- **Backend route gate moved:** `PUT /api/security/trivy-auto-update` — `requireAdmiral` → `requireAdmin + requirePaid` (`backend/src/routes/security.ts:205-207`).
- **Frontend surface updated to match:** `SecuritySection.tsx:402` — inline `isAdmiral` conditional → `isPaid` conditional; dead `isAdmiral` const and `useLicense` import removed at `:17,:73-74`. The frontend already gated the entire Security section to admins via `registry.ts:178` (`adminOnly: true`), so the UI surface contract matches the new backend role check.
- **No other surfaces touched.** All other Trivy / auto-update affordances were already Skipper-aligned: the stack context-menu auto-update toggle (`useStackMenuItems.tsx:35`, `isPaid`), the Auto-Update Readiness view (`AutoUpdateReadinessView.tsx:645`, `<PaidGate>`), and the Auto-Update sidebar entry (`useViewNavigationState.ts:110`, `isPaid && isAdmin`).
- **No capability flag.** There is no `'managed-trivy-auto-update'` capability; the feature was pure tier-based gating.

## Test plan

- [x] `cd backend && npx tsc --noEmit` — zero errors.
- [x] `cd frontend && npx tsc -b --noEmit` — zero errors.
- [x] `cd frontend && npm run lint` — zero new errors.
- [x] `npx vitest run src/__tests__/security-trivy-auto-update-route.test.ts` — 5/5 passing covering the full gate matrix (unauth, viewer, community admin, paid admin enable, paid admin disable).
- [x] Backend route exercised end-to-end on a paid-tier admin session: `PUT /api/security/trivy-auto-update` returned `200 {"autoUpdate": true}` and `200 {"autoUpdate": false}`.
- [x] Visual toggle render not exercised locally because managed Trivy isn't installed on the dev instance (`trivy.source === 'managed'` predicate falls through before the tier check). The `isPaid` swap is verified by code review: `isPaid` is already a prop on the component and is used in 8+ other places, so the conditional uses the same in-scope value as the rest of the file.
- [x] Code review run on the staged diff — no blocker findings.
- [x] Independent audit run on the first commit — caught the role-gate gap; addressed in the second commit with route tests.
- [x] Directive 30 parity grep — both backend and frontend touched a gate in the staged diff.
- [x] Directive 31 fence-spec grep on the staged docs diff — zero matches.

## Notes

- Per-stack image auto-update (`stacks.ts:206`) is a different feature and is out of scope. It is already `requireAdmin + requirePaid` (Skipper+).
- The Trivy binary install / update / uninstall buttons are admin-only with no tier gate. No change.
- No `docs/internal/` updates needed: the architecture map does not encode per-route tier metadata, and the cut-line doc does not pin this feature's tier.