### PR TITLE
feat(fleet): open Fleet Actions tab to Community (admin-only)

### DIFF
--- a/backend/src/__tests__/fleet-action-card-endpoints.test.ts
+++ b/backend/src/__tests__/fleet-action-card-endpoints.test.ts
@@ -115,14 +115,15 @@ describe('POST /api/fleet/labels/match-preview', () => {
     expect(res.status).toBe(401);
   });
 
-  it('returns 403 PAID_REQUIRED on community tier', async () => {
+  it('is reachable on community tier for admins (no PAID_REQUIRED)', async () => {
     vi.spyOn(LicenseService.getInstance(), 'getTier').mockReturnValue('community');
     const res = await request(app)
       .post('/api/fleet/labels/match-preview')
       .set('Authorization', authHeader)
-      .send({ labelName: 'x' });
-    expect(res.status).toBe(403);
-    expect(res.body.code).toBe('PAID_REQUIRED');
+      .send({ labelName: 'does-not-exist' });
+    expect(res.status).toBe(200);
+    expect(res.body.code).not.toBe('PAID_REQUIRED');
+    expect(res.body.matchedNodes).toBe(0);
   });
 
   it('returns 400 when labelName is missing or empty', async () => {
@@ -171,13 +172,15 @@ describe('POST /api/fleet/prune/estimate', () => {
     expect(res.status).toBe(401);
   });
 
-  it('returns 403 PAID_REQUIRED on community tier', async () => {
+  it('is reachable on community tier for admins (no PAID_REQUIRED)', async () => {
     vi.spyOn(LicenseService.getInstance(), 'getTier').mockReturnValue('community');
     const res = await request(app)
       .post('/api/fleet/prune/estimate')
       .set('Authorization', authHeader)
       .send({ targets: ['images'], scope: 'managed' });
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(200);
+    expect(res.body.code).not.toBe('PAID_REQUIRED');
+    expect(res.body).toHaveProperty('totalBytes');
   });
 
   it('returns 400 when targets is empty', async () => {

--- a/backend/src/__tests__/fleet-action-card-endpoints.test.ts
+++ b/backend/src/__tests__/fleet-action-card-endpoints.test.ts
@@ -75,7 +75,6 @@ beforeEach(() => {
   // not polluted by earlier tests.
   vi.restoreAllMocks();
   vi.clearAllMocks();
-  vi.spyOn(LicenseService.getInstance(), 'getTier').mockReturnValue('paid');
   mockFsStacks = ['alpha', 'beta'];
   pruneManagedOnly.mockResolvedValue({ success: true, reclaimedBytes: 0 });
   pruneSystem.mockResolvedValue({ success: true, reclaimedBytes: 0 });

--- a/backend/src/__tests__/fleet-actions.test.ts
+++ b/backend/src/__tests__/fleet-actions.test.ts
@@ -38,27 +38,29 @@ describe('Fleet Actions endpoints require authentication', () => {
   });
 });
 
-describe('Fleet Actions tier gating', () => {
+describe('Fleet Actions tier gating (Community + admin)', () => {
   afterEach(() => vi.restoreAllMocks());
 
-  it('POST /api/fleet/labels/fleet-stop returns 403 on community tier (Skipper+)', async () => {
+  it('POST /api/fleet/labels/fleet-stop is reachable on community tier for admins', async () => {
     mockTier('community');
     const res = await request(app)
       .post('/api/fleet/labels/fleet-stop')
       .set('Authorization', authHeader)
-      .send({ labelName: 'prod' });
-    expect(res.status).toBe(403);
-    expect(res.body.code).toBe('PAID_REQUIRED');
+      .send({ labelName: 'this-label-does-not-exist' });
+    expect(res.status).toBe(200);
+    expect(res.body.code).not.toBe('PAID_REQUIRED');
+    expect(Array.isArray(res.body.results)).toBe(true);
   });
 
-  it('POST /api/fleet-actions/labels/bulk-assign returns 403 on community tier (Skipper+)', async () => {
+  it('POST /api/fleet-actions/labels/bulk-assign is reachable on community tier for admins', async () => {
     mockTier('community');
     const res = await request(app)
       .post('/api/fleet-actions/labels/bulk-assign')
       .set('Authorization', authHeader)
       .send({ assignments: [] });
-    expect(res.status).toBe(403);
-    expect(res.body.code).toBe('PAID_REQUIRED');
+    expect(res.status).toBe(200);
+    expect(res.body.code).not.toBe('PAID_REQUIRED');
+    expect(res.body.results).toEqual([]);
   });
 });
 

--- a/backend/src/__tests__/fleet-actions.test.ts
+++ b/backend/src/__tests__/fleet-actions.test.ts
@@ -68,7 +68,6 @@ describe('Fleet Actions input validation', () => {
   afterEach(() => vi.restoreAllMocks());
 
   it('POST /api/fleet/labels/fleet-stop rejects missing labelName', async () => {
-    mockTier('paid');
     const res = await request(app)
       .post('/api/fleet/labels/fleet-stop')
       .set('Authorization', authHeader)
@@ -78,7 +77,6 @@ describe('Fleet Actions input validation', () => {
   });
 
   it('POST /api/fleet/labels/fleet-stop rejects whitespace-only labelName', async () => {
-    mockTier('paid');
     const res = await request(app)
       .post('/api/fleet/labels/fleet-stop')
       .set('Authorization', authHeader)
@@ -87,7 +85,6 @@ describe('Fleet Actions input validation', () => {
   });
 
   it('POST /api/fleet-actions/labels/bulk-assign rejects non-array assignments', async () => {
-    mockTier('paid');
     const res = await request(app)
       .post('/api/fleet-actions/labels/bulk-assign')
       .set('Authorization', authHeader)
@@ -97,7 +94,6 @@ describe('Fleet Actions input validation', () => {
   });
 
   it('POST /api/fleet-actions/labels/bulk-assign rejects oversized payload', async () => {
-    mockTier('paid');
     const big = Array.from({ length: 1001 }, (_, i) => ({ stackName: `s${i}`, labelIds: [] }));
     const res = await request(app)
       .post('/api/fleet-actions/labels/bulk-assign')
@@ -112,7 +108,6 @@ describe('Fleet Actions orchestration shape', () => {
   afterEach(() => vi.restoreAllMocks());
 
   it('POST /api/fleet/labels/fleet-stop with unknown label returns matched:false per node', async () => {
-    mockTier('paid');
     const res = await request(app)
       .post('/api/fleet/labels/fleet-stop')
       .set('Authorization', authHeader)
@@ -126,7 +121,6 @@ describe('Fleet Actions orchestration shape', () => {
   });
 
   it('POST /api/fleet-actions/labels/bulk-assign accepts empty assignments and returns empty results', async () => {
-    mockTier('paid');
     const res = await request(app)
       .post('/api/fleet-actions/labels/bulk-assign')
       .set('Authorization', authHeader)
@@ -136,7 +130,6 @@ describe('Fleet Actions orchestration shape', () => {
   });
 
   it('POST /api/fleet-actions/labels/bulk-assign rejects an entry with bad stack name in-line', async () => {
-    mockTier('paid');
     const res = await request(app)
       .post('/api/fleet-actions/labels/bulk-assign')
       .set('Authorization', authHeader)

--- a/backend/src/__tests__/fleet-prune.test.ts
+++ b/backend/src/__tests__/fleet-prune.test.ts
@@ -66,14 +66,16 @@ describe('POST /api/fleet/labels/fleet-prune', () => {
     expect(res.status).toBe(401);
   });
 
-  it('returns 403 PAID_REQUIRED on community tier', async () => {
+  it('is reachable on community tier for admins (no PAID_REQUIRED)', async () => {
     mockTier('community');
+    mockLocalPrune({ managedBytes: { images: 128 } });
     const res = await request(app)
       .post('/api/fleet/labels/fleet-prune')
       .set('Authorization', authHeader)
       .send({ targets: ['images'], scope: 'managed' });
-    expect(res.status).toBe(403);
-    expect(res.body.code).toBe('PAID_REQUIRED');
+    expect(res.status).toBe(200);
+    expect(res.body.code).not.toBe('PAID_REQUIRED');
+    expect(Array.isArray(res.body.results)).toBe(true);
   });
 
   it('returns 400 when body is missing', async () => {

--- a/backend/src/__tests__/fleet-prune.test.ts
+++ b/backend/src/__tests__/fleet-prune.test.ts
@@ -79,7 +79,6 @@ describe('POST /api/fleet/labels/fleet-prune', () => {
   });
 
   it('returns 400 when body is missing', async () => {
-    mockTier('paid');
     const res = await request(app)
       .post('/api/fleet/labels/fleet-prune')
       .set('Authorization', authHeader)
@@ -88,7 +87,6 @@ describe('POST /api/fleet/labels/fleet-prune', () => {
   });
 
   it('returns 400 when targets is empty', async () => {
-    mockTier('paid');
     const res = await request(app)
       .post('/api/fleet/labels/fleet-prune')
       .set('Authorization', authHeader)
@@ -98,7 +96,6 @@ describe('POST /api/fleet/labels/fleet-prune', () => {
   });
 
   it('returns 400 when a target is unrecognized', async () => {
-    mockTier('paid');
     const res = await request(app)
       .post('/api/fleet/labels/fleet-prune')
       .set('Authorization', authHeader)
@@ -108,7 +105,6 @@ describe('POST /api/fleet/labels/fleet-prune', () => {
   });
 
   it('runs pruneManagedOnly per target on the local node and returns aggregated bytes', async () => {
-    mockTier('paid');
     const fake = mockLocalPrune({ managedBytes: { images: 1500, volumes: 320 } });
     const res = await request(app)
       .post('/api/fleet/labels/fleet-prune')
@@ -127,7 +123,6 @@ describe('POST /api/fleet/labels/fleet-prune', () => {
   });
 
   it('runs pruneSystem when scope is "all" and dedupes targets', async () => {
-    mockTier('paid');
     const fake = mockLocalPrune({ allBytes: { networks: 0, images: 2048 } });
     const res = await request(app)
       .post('/api/fleet/labels/fleet-prune')
@@ -141,7 +136,6 @@ describe('POST /api/fleet/labels/fleet-prune', () => {
   });
 
   it('records per-target failure when DockerController throws but continues remaining targets', async () => {
-    mockTier('paid');
     mockLocalPrune({ managedBytes: { images: 100 }, throwOn: 'volumes' });
     const res = await request(app)
       .post('/api/fleet/labels/fleet-prune')
@@ -157,7 +151,6 @@ describe('POST /api/fleet/labels/fleet-prune', () => {
   });
 
   it('reports lock contention when bulk-prune lock is already held', async () => {
-    mockTier('paid');
     mockLocalPrune();
     const db = DatabaseService.getInstance();
     const localId = db.getNodes().find(n => n.type === 'local')!.id;
@@ -173,7 +166,6 @@ describe('POST /api/fleet/labels/fleet-prune', () => {
   });
 
   it('marks a remote node unreachable when fetch throws and short-circuits later targets', async () => {
-    mockTier('paid');
     mockLocalPrune();
     const db = DatabaseService.getInstance();
     const remoteId = db.addNode({
@@ -204,7 +196,6 @@ describe('POST /api/fleet/labels/fleet-prune', () => {
   });
 
   it('parses remote node responses into per-target reclaimed bytes', async () => {
-    mockTier('paid');
     mockLocalPrune();
     const db = DatabaseService.getInstance();
     const remoteId = db.addNode({

--- a/backend/src/routes/fleet.ts
+++ b/backend/src/routes/fleet.ts
@@ -1037,9 +1037,8 @@ fleetRouter.delete('/update-status', authMiddleware, async (req: Request, res: R
 
 // Fleet-wide stop by label name. Matches each node's labels by name and runs
 // container stops on each matching stack.
-// Tier: requirePaid + requireAdmin.
+// Tier: requireAdmin (admin-only fleet plumbing; available on every license).
 fleetRouter.post('/labels/fleet-stop', authMiddleware, async (req: Request, res: Response): Promise<void> => {
-  if (!requirePaid(req, res)) return;
   if (!requireAdmin(req, res)) return;
   const body = req.body as { labelName?: unknown; dryRun?: unknown } | undefined;
   if (!body || typeof body !== 'object') {
@@ -1147,12 +1146,11 @@ fleetRouter.post('/labels/fleet-stop', authMiddleware, async (req: Request, res:
 // systemMaintenance.ts is safe because Docker's prune API is internally
 // serialized and idempotent (the worst case is a duplicate call returning 0
 // reclaimed bytes).
-// Tier: requirePaid + requireAdmin.
+// Tier: requireAdmin (admin-only fleet plumbing; available on every license).
 const FLEET_PRUNE_TARGETS = ['images', 'volumes', 'networks'] as const;
 type FleetPruneTarget = (typeof FLEET_PRUNE_TARGETS)[number];
 
 fleetRouter.post('/labels/fleet-prune', authMiddleware, async (req: Request, res: Response): Promise<void> => {
-  if (!requirePaid(req, res)) return;
   if (!requireAdmin(req, res)) return;
 
   const body = req.body as { targets?: unknown; scope?: unknown; dryRun?: unknown } | undefined;
@@ -1296,7 +1294,6 @@ fleetRouter.post('/labels/fleet-prune', authMiddleware, async (req: Request, res
 // assignments live in the central DB even for remote nodes, populated by the
 // nodes' own UIs and synced via Distributed API.
 fleetRouter.post('/labels/match-preview', authMiddleware, async (req: Request, res: Response): Promise<void> => {
-  if (!requirePaid(req, res)) return;
   if (!requireAdmin(req, res)) return;
   const body = req.body as { labelName?: unknown } | undefined;
   if (!body || typeof body !== 'object') {
@@ -1337,7 +1334,6 @@ fleetRouter.post('/labels/match-preview', authMiddleware, async (req: Request, r
 // fan-out shape as `/labels/fleet-prune` minus the locks (estimation is read
 // only).
 fleetRouter.post('/prune/estimate', authMiddleware, async (req: Request, res: Response): Promise<void> => {
-  if (!requirePaid(req, res)) return;
   if (!requireAdmin(req, res)) return;
 
   const body = req.body as { targets?: unknown; scope?: unknown } | undefined;

--- a/backend/src/routes/fleetActions.ts
+++ b/backend/src/routes/fleetActions.ts
@@ -1,7 +1,7 @@
 import { Router, type Request, type Response } from 'express';
 import { DatabaseService } from '../services/DatabaseService';
 import { authMiddleware } from '../middleware/auth';
-import { requirePaid, requireAdmin, requireBody } from '../middleware/tierGates';
+import { requireAdmin, requireBody } from '../middleware/tierGates';
 import { isValidStackName } from '../utils/validation';
 import { getErrorMessage } from '../utils/errors';
 
@@ -20,14 +20,14 @@ const MAX_ASSIGNMENTS = 1000;
 // Bulk label assignment for many stacks on a single node. The single-stack
 // endpoint at `PUT /api/stacks/:stackName/labels` covers one stack at a time;
 // this wrapper applies the same operation to many stacks atomically per HTTP
-// request. Tier: requirePaid + requireAdmin. The per-stack endpoint is
-// Community-tier organization metadata; this multi-stack wrapper is an
-// automation surface exposed only inside the Skipper+ Fleet Actions tab.
+// request. Tier: requireAdmin (admin-only fleet plumbing). The per-stack
+// endpoint is Community-tier organization metadata; this multi-stack wrapper
+// matches the surrounding Fleet Actions surface, which is admin-only but
+// available on every license.
 fleetActionsRouter.post(
   '/labels/bulk-assign',
   authMiddleware,
   async (req: Request, res: Response): Promise<void> => {
-    if (!requirePaid(req, res)) return;
     if (!requireAdmin(req, res)) return;
     if (!requireBody(req, res)) return;
     const { assignments } = req.body as { assignments?: unknown };

--- a/docs/features/fleet-actions.mdx
+++ b/docs/features/fleet-actions.mdx
@@ -130,7 +130,6 @@ Scope is a segmented control with two options:
 
 | Requirement | Why it matters |
 |---|---|
-| **Admin role for the active user** | Operator and viewer roles cannot apply any of the three cards. |
 | **Configured remote nodes in Settings → Nodes** | The two fan-out cards iterate the configured node list. A node missing its `api_url` or `api_token` shows up in the results with *Remote node not configured* per stack or per target. |
 | **Labels you intend to target** | Stop fleet by label and the autocomplete depend on labels existing on at least one node. See [Stack Labels](/features/stack-labels) for the authoring flow. |
 

--- a/docs/features/fleet-actions.mdx
+++ b/docs/features/fleet-actions.mdx
@@ -12,7 +12,7 @@ Three cards ship today: **Stop fleet by label**, **Bulk label assign**, and **Pr
 </Frame>
 
 <Note>
-Fleet Actions is a Skipper feature. Every card requires an admin user role.
+Fleet Actions runs admin-only. Operator and viewer roles see the tab but cannot apply the cards.
 </Note>
 
 ## What Fleet Actions covers (and what it doesn't)
@@ -29,7 +29,7 @@ Fleet Actions is the home for operations that span the fleet but don't fit anywh
 
 ## Three cards, three execution paths
 
-The cards share a tab and a tier gate, but they don't share an execution path. Knowing which path runs explains the result panels and the failure modes.
+The cards share a tab and a role gate, but they don't share an execution path. Knowing which path runs explains the result panels and the failure modes.
 
 | Card | Endpoint | Where it runs | Scope |
 |---|---|---|---|
@@ -130,8 +130,7 @@ Scope is a segmented control with two options:
 
 | Requirement | Why it matters |
 |---|---|
-| **Skipper or Admiral license on the control instance** | Every card gates on the control instance's tier. Remote nodes inherit the paid tier through the proxy's tier header, so a paid control plane covers the whole fleet. |
-| **Admin role for the active user** | Operator and viewer roles cannot reach any of the three endpoints. |
+| **Admin role for the active user** | Operator and viewer roles cannot apply any of the three cards. |
 | **Configured remote nodes in Settings → Nodes** | The two fan-out cards iterate the configured node list. A node missing its `api_url` or `api_token` shows up in the results with *Remote node not configured* per stack or per target. |
 | **Labels you intend to target** | Stop fleet by label and the autocomplete depend on labels existing on at least one node. See [Stack Labels](/features/stack-labels) for the authoring flow. |
 
@@ -189,8 +188,8 @@ Run **Prune Docker resources fleet-wide** with **Images** selected and **Managed
   <Accordion title="Prune across fleet reports 'A prune is already running on this node'">
     The per-node prune lock is held while the first prune is in flight. Wait for the first run to finish or click **Refresh** on the Fleet masthead to confirm it has cleared, then re-run. The lock is released automatically when the first run exits.
   </Accordion>
-  <Accordion title="The Fleet Actions tab opens but the cards aren't there">
-    Fleet Actions is a Skipper feature. On a Community license, the tab still opens and surfaces a calm explainer card pointing at the upgrade. Confirm the active license under **Settings → License**.
+  <Accordion title="The Apply button returns an error toast">
+    Fleet Actions runs admin-only. Confirm the active user has the admin role under **Settings → Users**. Operator and viewer roles see the cards but cannot apply them.
   </Accordion>
   <Accordion title="A node returns a transport error row for every stack or every target">
     The node is in **Settings → Nodes** but its `api_url` or `api_token` is missing, expired, or unreachable. Open **Settings → Nodes** on the control instance and click **Test connection** for the remote; fix the credential or the reachability, then re-run the action.
@@ -210,4 +209,4 @@ Fleet Actions is one slice of the Fleet view. Each adjacent surface answers a di
 | [Fleet Sync](/features/fleet-sync) | Push-only replication of security rules from a control instance to its replicas. | Fleet Sync replicates state; Fleet Actions runs operations. |
 | [Multi-Node Management](/features/multi-node) | How nodes get added to the fleet (proxy or pilot mode) and how the license tier propagates. | Multi-Node Management is the prerequisite; Fleet Actions runs against whatever Multi-Node Management already configured. |
 | [Fleet View](/features/fleet-view) | The masthead, tab strip, and node grid that host the Fleet Actions tab. | Fleet Actions is one tab inside Fleet View. |
-| [Licensing](/features/licensing) | The full tier matrix and what each tier unlocks. | The single source of truth for the Skipper requirement called out at the top of this page. |
+| [Licensing](/features/licensing) | The full tier matrix and what each tier unlocks. | Licensing covers tier coverage across the product; Fleet Actions only cites the admin role check above. |

--- a/docs/features/fleet-view.mdx
+++ b/docs/features/fleet-view.mdx
@@ -48,7 +48,7 @@ The Fleet view is a tab strip. Four tab triggers are visible to every tier; the 
 | **Deployments** | Skipper | Blueprint deployments and reconciler state. See [Blueprints](/features/blueprint-model). |
 | **Routing** | Admiral | Cross-node service routing via Sencho Mesh. See [Sencho Mesh](/features/sencho-mesh). |
 | **Federation** | Admiral | Cordon nodes and pin blueprints to specific hosts. See [Fleet Federation](/features/fleet-federation). |
-| **Fleet Actions** | Community trigger / Skipper content | The tab is visible to every tier; opening it on Community surfaces a Skipper upgrade prompt. See [Fleet Actions](/features/fleet-actions). |
+| **Fleet Actions** | Community (admin role) | Fleet-wide bulk operations: stop stacks by label, bulk-assign labels, prune Docker resources. See [Fleet Actions](/features/fleet-actions). |
 | **Secrets** | Skipper | Encrypted env-var bundles you push to labeled nodes. See [Fleet Secrets](/features/fleet-secrets). |
 
 ### Action buttons

--- a/docs/features/licensing.mdx
+++ b/docs/features/licensing.mdx
@@ -30,6 +30,7 @@ For larger deployments, an **Enterprise** tier is available with custom pricing,
 - Git sources for compose stacks
 - Multi-node management in both Proxy and Pilot Agent modes
 - Manual fleet snapshots (create, browse, restore, delete) and per-node Sencho updates
+- Fleet Actions tab (stop stacks fleet-wide by label, bulk-assign labels to many stacks on a node, prune Docker resources fleet-wide; admin role required)
 - Custom S3-compatible backup target (bring your own AWS S3, Cloudflare R2, MinIO, Backblaze B2, or Wasabi bucket)
 - Vulnerability scanning: install, update, and uninstall Trivy, on-demand scans for vulnerabilities, secrets, and misconfigurations, plus scan comparison
 - CVE suppressions
@@ -49,7 +50,7 @@ For larger deployments, an **Enterprise** tier is available with custom pricing,
 - Scan policies with `block_on_deploy` deploy enforcement, SBOM (SPDX, CycloneDX), and SARIF export
 - Bulk actions on a label (deploy, stop, or restart every stack tagged with it)
 - Remote OTA node updates from the control instance
-- Fleet Actions (bulk update all, bulk restart Sencho)
+- Fleet-wide Sencho self-update (bulk update all nodes, bulk restart Sencho)
 - Blueprints and Fleet Secrets
 - Preset SSO for Google, GitHub, and Okta
 - Viewer accounts (1 admin plus 3 viewers)

--- a/docs/features/overview.mdx
+++ b/docs/features/overview.mdx
@@ -117,7 +117,7 @@ Operator-driven placement controls for fleets running Blueprints. Cordon nodes t
 
 ### Fleet Actions
 
-Run fleet-wide bulk operations from one place: stop stacks across nodes by label selector, or bulk-assign labels to many stacks at once on a single node. Skipper or Admiral. [Learn more →](/features/fleet-actions)
+Run fleet-wide bulk operations from one place: stop stacks across nodes by label selector, bulk-assign labels to many stacks on a single node, or prune Docker resources fleet-wide. Admin-only on every tier. [Learn more →](/features/fleet-actions)
 
 ### Fleet Sync
 

--- a/docs/features/stack-labels.mdx
+++ b/docs/features/stack-labels.mdx
@@ -3,7 +3,7 @@ title: "Stack Labels"
 description: "Per-node tags that group your stacks by purpose, surface them under collapsible headers in the sidebar, and unlock cross-stack bulk actions across the fleet."
 ---
 
-A **Stack Label** is a per-node tag (name plus color) you can stick on any stack. Once a stack carries a label, the sidebar groups it under that label's header instead of dumping every stack into a flat list, and Fleet View can filter the overview by tag. Operators on a Skipper or Admiral license also get a pair of fleet-wide actions powered by labels: stop every stack labeled `prod` across every node, or replace the label set on a batch of stacks in one shot.
+A **Stack Label** is a per-node tag (name plus color) you can stick on any stack. Once a stack carries a label, the sidebar groups it under that label's header instead of dumping every stack into a flat list, and Fleet View can filter the overview by tag. Admins also get a pair of fleet-wide actions powered by labels: stop every stack labeled `prod` across every node, or replace the label set on a batch of stacks in one shot.
 
 <Frame>
   <img src="/images/stack-labels/sidebar-grouping.png" alt="Sidebar showing stacks grouped under three uppercase label headers (MEDIA 6, UTILITIES 5, NETWORK 3) and an UNLABELED 1 group at the bottom. Each stack row carries a small colored dot on the trailing edge that matches the group's color." />
@@ -111,7 +111,7 @@ The **Bulk label assign** card is per-node only by design. To re-tag stacks on a
 - **Names are unique per node**, case-sensitive. The same name on two nodes is two separate label rows. Cross-node fleet stop matches on name; bulk assign always operates on one node's labels at a time.
 - **Allowed name characters**: letters, digits, spaces, and hyphens. Empty names and names beyond 30 characters are rejected at the API.
 - **Bulk-action concurrency**: only one label-driven bulk action can run on a single node at a time. A second concurrent attempt against the same node returns HTTP 429 and the operator sees an error toast; the in-flight action keeps running.
-- **Role gate**: organizing with labels is open to every role. Sidebar grouping, trailing dots on stack rows, the **Settings · Advanced · Labels** panel, the inline create form in the stack menu, and the Fleet View **Tags** filter are available to every signed-in user. The **Fleet · Fleet Actions** cards (Stop-fleet-by-label and Bulk-label-assign) run admin-only; operator and viewer roles see the cards but cannot apply them.
+- **Role visibility**: label authoring is open to every signed-in role. Sidebar grouping, trailing dots on stack rows, the **Settings · Advanced · Labels** panel, the inline create form in the stack menu, and the Fleet View **Tags** filter all work for every user.
 
 ## Troubleshooting
 

--- a/docs/features/stack-labels.mdx
+++ b/docs/features/stack-labels.mdx
@@ -82,10 +82,10 @@ A stack can carry multiple labels and will then appear under each label's group 
 ## Fleet · Fleet Actions
 
 <Note>
-  Bulk actions on a label require a Sencho **Skipper** or **Admiral** license. Creating, assigning, and filtering by labels is available on every tier; only the cross-node bulk surface is paid.
+  The Fleet Actions cards run admin-only on every tier. Operator and viewer roles see the cards but cannot apply them.
 </Note>
 
-Two cards in the **Fleet · Fleet Actions** tab use labels to drive cross-node operations. Both endpoints are gated on a paid tier and an admin role: Community installs see the tab in the navigation but the body renders a single empty-state card explaining the gate, and a non-admin operator on a paid tier sees the cards rendered but receives a 403 from the backend on submit.
+Two cards in the **Fleet · Fleet Actions** tab use labels to drive cross-node operations. See [Fleet Actions](/features/fleet-actions) for the full reference.
 
 <Frame>
   <img src="/images/stack-labels/fleet-actions.png" alt="Fleet Actions tab with two cards side by side. Left card 'Stop fleet by label' (rose accent rail) has a Label name combobox containing 'Media' and a Stop matching stacks button beneath. Right card 'Bulk label assign' (purple accent rail) has a node selector reading Local (local), a stacks checklist showing plex and radarr ticked, a Labels row with a highlighted Media pill plus inactive Network and Utilities, and an Apply to 3 stacks button." />
@@ -111,7 +111,7 @@ The **Bulk label assign** card is per-node only by design. To re-tag stacks on a
 - **Names are unique per node**, case-sensitive. The same name on two nodes is two separate label rows. Cross-node fleet stop matches on name; bulk assign always operates on one node's labels at a time.
 - **Allowed name characters**: letters, digits, spaces, and hyphens. Empty names and names beyond 30 characters are rejected at the API.
 - **Bulk-action concurrency**: only one label-driven bulk action can run on a single node at a time. A second concurrent attempt against the same node returns HTTP 429 and the operator sees an error toast; the in-flight action keeps running.
-- **Tier visibility**: organizing with labels is Community. Sidebar grouping, trailing dots on stack rows, the **Settings · Advanced · Labels** panel, the inline create form in the stack menu, and the Fleet View **Tags** filter all light up on every tier. Only the **Fleet · Fleet Actions** body content (the Stop-fleet-by-label and Bulk-label-assign cards) is paid; Community installs see the tab in the navigation but the body renders a single upgrade-context empty state.
+- **Role gate**: organizing with labels is open to every role. Sidebar grouping, trailing dots on stack rows, the **Settings · Advanced · Labels** panel, the inline create form in the stack menu, and the Fleet View **Tags** filter are available to every signed-in user. The **Fleet · Fleet Actions** cards (Stop-fleet-by-label and Bulk-label-assign) run admin-only; operator and viewer roles see the cards but cannot apply them.
 
 ## Troubleshooting
 
@@ -137,8 +137,8 @@ The **Bulk label assign** card is per-node only by design. To re-tag stacks on a
   <Accordion title="Two stacks with the same name on different nodes only got relabeled on one">
     `Bulk label assign` is per-node by design. The node picker at the top is the source of truth and the stacks list only shows stacks on that node. Run the card a second time with the other node selected, or use **Stop fleet by label** instead if the goal is fleet-wide.
   </Accordion>
-  <Accordion title="The Fleet Actions tab body shows an upgrade card on Community">
-    Cross-node bulk actions stay on Skipper and Admiral. The tab itself is visible to every tier, but the body renders a single empty-state card on Community pointing at the upgrade. All other Stack Labels surfaces (sidebar grouping, trailing dots, the Settings panel, the inline create form, the Fleet View Tags filter) work the same on Community.
+  <Accordion title="The Fleet Actions cards return an error when I click Apply">
+    The cards run admin-only. Confirm the active user has the admin role under **Settings · Users**; operator and viewer roles see the cards rendered but cannot apply them. All other Stack Labels surfaces (sidebar grouping, trailing dots, the Settings panel, the inline create form, the Fleet View Tags filter) work for every role.
   </Accordion>
   <Accordion title="Deleting a label removed it from every stack">
     Working as designed. The destructive confirmation reads `Removes the label from every stack across the fleet.` The label row and every assignment row that pointed to it are dropped in a single transaction. There is no undo; recreate the label by name and color and reassign the affected stacks if you need to recover.

--- a/frontend/src/components/fleet/FleetActions/FleetActionsTab.tsx
+++ b/frontend/src/components/fleet/FleetActions/FleetActionsTab.tsx
@@ -1,5 +1,3 @@
-import { Tags } from 'lucide-react';
-import { useLicense } from '@/context/LicenseContext';
 import type { FleetNode } from '@/components/FleetView/types';
 import { LabelFleetStopCard } from './cards/LabelFleetStopCard';
 import { BulkLabelAssignCard } from './cards/BulkLabelAssignCard';
@@ -10,16 +8,10 @@ interface Props {
 }
 
 export function FleetActionsTab({ nodes }: Props) {
-  const { isPaid } = useLicense();
-
   if (nodes.length === 0) {
     return (
       <div className="text-sm text-stat-subtitle">Add a node to the fleet to use bulk actions.</div>
     );
-  }
-
-  if (!isPaid) {
-    return <EmptyState />;
   }
 
   // Grid: 1 col under lg, 2 cols at lg and above. auto-rows-fr distributes
@@ -33,23 +25,6 @@ export function FleetActionsTab({ nodes }: Props) {
       <FleetPruneCard nodes={nodes} />
       <BulkLabelAssignCard nodes={nodes} />
       <LabelFleetStopCard nodes={nodes} />
-    </div>
-  );
-}
-
-// Note: the §18.8 Community-tier "single full-width card with cyan rail + locked
-// footer (shell only, no upsell)" redesign is deferred to a follow-up PR.
-// Tracked in docs/internal/refactor/fleet-action-card-migration.md.
-function EmptyState() {
-  return (
-    <div className="rounded-lg border border-card-border/60 bg-card p-8 text-center">
-      <div className="mx-auto mb-3 inline-flex h-10 w-10 items-center justify-center rounded-md bg-glass-highlight">
-        <Tags className="h-5 w-5 text-stat-subtitle" strokeWidth={1.5} />
-      </div>
-      <h3 className="text-sm font-medium text-stat-value mb-1">Fleet-wide bulk actions</h3>
-      <p className="text-xs text-stat-subtitle max-w-md mx-auto">
-        Stop stacks across every node by label name, assign labels to many stacks at once, and reclaim Docker disk space fleet-wide. Available on Skipper and Admiral.
-      </p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Removes the `requirePaid` guard from the five Fleet Actions endpoints (fleet-stop, fleet-prune, match-preview, prune/estimate, bulk-assign). `requireAdmin` stays on every endpoint, so operator and viewer roles still 403 on apply.
- Drops the `isPaid` parent gate and the "Available on Skipper and Admiral." `EmptyState` from `FleetActionsTab.tsx`. Community admins now see the three cards directly; the tier strip is unchanged.
- Refreshes the operator-facing docs to state the admin-role requirement once and drop the prior Skipper framing, including a stale troubleshooting accordion that no longer describes a real scenario.

The Fleet Actions surface is admin-only fleet plumbing (stop stacks fleet-wide by label, mass-assign labels on a node, prune Docker resources). Per the Community-tier-generous philosophy and matching the precedent set by PR #930 ("basic fleet management" to Community), this opens the surface without weakening the admin gate.

## Gate parity

| Surface | Was | Now |
|---|---|---|
| `POST /api/fleet/labels/fleet-stop` | Skipper + admin | Community + admin |
| `POST /api/fleet/labels/fleet-prune` | Skipper + admin | Community + admin |
| `POST /api/fleet/labels/match-preview` | Skipper + admin | Community + admin |
| `POST /api/fleet/prune/estimate` | Skipper + admin | Community + admin |
| `POST /api/fleet-actions/labels/bulk-assign` | Skipper + admin | Community + admin |
| `FleetActionsTab` `isPaid` parent gate | Hid all cards on Community | Removed |
| `FleetActionsTab` `EmptyState` upsell copy | "Available on Skipper and Admiral." | Removed |
| `requireAdmin` on every endpoint | Enforced | Unchanged (operator/viewer still 403) |

## Test plan

- [x] Backend type-check: `cd backend && npx tsc --noEmit` — clean.
- [x] Frontend type-check: `cd frontend && npx tsc -b --noEmit` — clean.
- [x] Affected unit tests: `cd backend && npx vitest run fleet-actions fleet-prune fleet-action-card-endpoints fleet fleet-pilot-update fleet-pilot-dispatch-parity` — 102/102 pass after merging main. Tier tests inverted from "403 PAID_REQUIRED on community" to positive "reachable on community + admin" assertions.
- [x] Frontend lint: 0 errors (pre-existing warnings in untouched files only).
- [x] End-to-end on a Community + admin persona: signed in as admin on a fresh Community-tier dev instance, opened Fleet → Fleet Actions, confirmed all three cards render with no upsell copy. Live `/prune/estimate` returned 13.94 GB reclaimable; all five endpoints returned 200 when exercised directly.

## Follow-up commit: audit fixes

Independent review surfaced one blocking issue and two nits, all addressed in the follow-up commit:

- **stack-labels.mdx intro** still framed fleet label actions as "Operators on a Skipper or Admiral license". Rewritten to "Admins also get a pair of fleet-wide actions".
- **Redundant role statements** on fleet-actions.mdx (Note + Prerequisites row + troubleshooting accordion) and stack-labels.mdx (Note + bullet + troubleshooting) collapsed to the lead-in declaration plus the actionable troubleshooting entry.
- **Misleading `mockTier('paid')` calls** in non-tier tests stripped now that the routes no longer consult tier. If a future change re-adds `requirePaid` the tests will fail loudly instead of silently passing.

## Merge from main

Brought in PR #1149 (self-protect), #1150 (Trivy auto-update to Skipper), #1151 (Remote OTA to Community), #1152 (pilot-agent dispatch). One content conflict in `docs/features/licensing.mdx`, resolved to preserve both PRs' intents:

- **Community section:** kept both new bullets — the merged snapshots/OTA line from #1151 and the Fleet Actions bullet from this PR.
- **Skipper section:** collapsed to a single bullet `Fleet-wide bulk Sencho restart`. Reasoning: #1151 moved Remote OTA off Skipper into Community, leaving only bulk-restart-Sencho on Skipper from the previous "Fleet Actions (bulk update all, bulk restart Sencho)" line. After this PR, naming that bullet "Fleet Actions" is misleading because the Fleet Actions tab itself is now Community; renaming makes the residual scope unambiguous.

All other files (`backend/src/routes/fleet.ts`, `docs/features/fleet-view.mdx`, `docs/features/overview.mdx`) auto-merged cleanly with both branches' edits preserved.

## Notes

- The website tier matrix lives in a separate repo (`sencho-website`) and should be refreshed in a follow-up commit there to reflect the move.
- Per-label single-node bulk actions (`POST /api/labels/:id/action`) stay on Skipper; they are a different feature surface from the Fleet Actions tab cards.