### PR TITLE
fix(resources): subtract shared layers when accounting managed prune bytes

### DIFF
--- a/backend/src/__tests__/docker-controller.test.ts
+++ b/backend/src/__tests__/docker-controller.test.ts
@@ -367,9 +367,25 @@ describe('DockerController - managed image prune accounting', () => {
     expect(result.reclaimableBytes).toBe(1200);
   });
 
-  it('pruneManagedOnly subtracts SharedSize after each removal', async () => {
-    mockDocker.df.mockResolvedValue(sharedLayerDfMock);
-    mockDocker.listImages.mockResolvedValue(unusedManagedListMock);
+  it('pruneManagedOnly reports the LayersSize delta as the reclaimed total', async () => {
+    // df-before reports 5000 bytes on disk; df-after reports 3400. The
+    // honest reclaim is 1600, independent of per-image Size/SharedSize.
+    // Two prunable images that share a layer exclusively would be
+    // undercounted by the per-image formula (1200) but Docker actually
+    // frees the shared layer too.
+    mockDocker.df
+      .mockResolvedValueOnce({
+        LayersSize: 5000,
+        Images: [
+          { Id: 'img-a', SharedSize: 400 },
+          { Id: 'img-b', SharedSize: 400 },
+        ],
+      })
+      .mockResolvedValueOnce({ LayersSize: 3400, Images: [] });
+    mockDocker.listImages.mockResolvedValue([
+      { Id: 'img-a', Containers: 0, Size: 1000 },
+      { Id: 'img-b', Containers: 0, Size: 1000 },
+    ]);
     mockDocker.listContainers.mockResolvedValue([]);
     const removeFn = vi.fn().mockResolvedValue(undefined);
     mockDocker.getImage.mockReturnValue({ remove: removeFn });
@@ -377,8 +393,115 @@ describe('DockerController - managed image prune accounting', () => {
     const dc = DockerController.getInstance(1);
     const result = await dc.pruneManagedOnly('images', ['any-stack']);
 
-    expect(result).toEqual({ success: true, reclaimedBytes: 1200 });
+    expect(result).toEqual({ success: true, reclaimedBytes: 1600 });
     expect(removeFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('pruneManagedOnly falls back to per-image lower bound using before-snapshot when after-df fails', async () => {
+    // Before-snapshot succeeded (SharedSize known); after-snapshot failed.
+    // Fall back to Σ(Size - SharedSize) over the prunable set: a
+    // conservative lower bound, but defensible because each pruned image's
+    // SharedSize was known at the start.
+    mockDocker.df
+      .mockResolvedValueOnce({
+        Images: [
+          { Id: 'img-a', SharedSize: 400 },
+          { Id: 'img-b', SharedSize: 400 },
+        ],
+      })
+      .mockRejectedValueOnce(new Error('df unavailable after prune'));
+    mockDocker.listImages.mockResolvedValue([
+      { Id: 'img-a', Containers: 0, Size: 1000 },
+      { Id: 'img-b', Containers: 0, Size: 1000 },
+    ]);
+    mockDocker.listContainers.mockResolvedValue([]);
+    mockDocker.getImage.mockReturnValue({ remove: vi.fn().mockResolvedValue(undefined) });
+
+    const dc = DockerController.getInstance(1);
+    const result = await dc.pruneManagedOnly('images', ['any-stack']);
+
+    // (1000 - 400) + (1000 - 400) = 1200
+    expect(result).toEqual({ success: true, reclaimedBytes: 1200 });
+  });
+
+  it('pruneManagedOnly reports 0 reclaimed when both df snapshots fail', async () => {
+    // Without the before-snapshot we cannot build a meaningful per-image
+    // bound (after-only has stale image IDs missing from its view), so the
+    // destructive path completes the removes and reports 0 rather than a
+    // misleading approximation.
+    mockDocker.df
+      .mockRejectedValueOnce(new Error('df unavailable before'))
+      .mockRejectedValueOnce(new Error('df unavailable after'));
+    mockDocker.listImages.mockResolvedValue([
+      { Id: 'img-a', Containers: 0, Size: 1000 },
+    ]);
+    mockDocker.listContainers.mockResolvedValue([]);
+    const removeFn = vi.fn().mockResolvedValue(undefined);
+    mockDocker.getImage.mockReturnValue({ remove: removeFn });
+
+    const dc = DockerController.getInstance(1);
+    const result = await dc.pruneManagedOnly('images', ['any-stack']);
+
+    expect(result).toEqual({ success: true, reclaimedBytes: 0 });
+    expect(removeFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('estimateManagedReclaim under-reports when layers are shared exclusively between prunable images', async () => {
+    // Two prunable images that share a 400-byte layer with no retained
+    // image. Docker would free that layer once on prune (1600 bytes total:
+    // each image's unique 600 plus the shared 400). The estimate formula
+    // subtracts 400 from each image and reports 1200, a conservative
+    // lower bound documented in the JSDoc.
+    mockDocker.df.mockResolvedValue({
+      Images: [
+        { Id: 'img-a', SharedSize: 400 },
+        { Id: 'img-b', SharedSize: 400 },
+      ],
+    });
+    mockDocker.listImages.mockResolvedValue([
+      { Id: 'img-a', Containers: 0, Size: 1000 },
+      { Id: 'img-b', Containers: 0, Size: 1000 },
+    ]);
+    mockDocker.listContainers.mockResolvedValue([]);
+
+    const dc = DockerController.getInstance(1);
+    const result = await dc.estimateManagedReclaim('images', ['any-stack']);
+
+    expect(result.reclaimableBytes).toBe(1200);
+  });
+
+  it('invariant: pruneManagedOnly reports >= estimateManagedReclaim on the same inputs', async () => {
+    // The estimate is a conservative lower bound; the destructive path
+    // reports the truth (df-delta). On any input, destructive >= estimate.
+    // This locks the contract so future changes to either formula cannot
+    // accidentally flip the direction.
+    const dfBefore = {
+      LayersSize: 5000,
+      Images: [
+        { Id: 'img-a', SharedSize: 400 },
+        { Id: 'img-b', SharedSize: 400 },
+      ],
+    };
+    const dfAfter = { LayersSize: 3400, Images: [] };
+    const listImages = [
+      { Id: 'img-a', Containers: 0, Size: 1000 },
+      { Id: 'img-b', Containers: 0, Size: 1000 },
+    ];
+
+    // Estimate path: df called once.
+    mockDocker.df.mockResolvedValueOnce(dfBefore);
+    mockDocker.listImages.mockResolvedValue(listImages);
+    mockDocker.listContainers.mockResolvedValue([]);
+    const dc = DockerController.getInstance(1);
+    const estimate = await dc.estimateManagedReclaim('images', ['any-stack']);
+
+    // Reset the df mock for the destructive path: before then after.
+    mockDocker.df.mockReset();
+    mockDocker.df.mockResolvedValueOnce(dfBefore).mockResolvedValueOnce(dfAfter);
+    mockDocker.getImage.mockReturnValue({ remove: vi.fn().mockResolvedValue(undefined) });
+    const prune = await dc.pruneManagedOnly('images', ['any-stack']);
+
+    expect(prune.reclaimedBytes).toBeGreaterThanOrEqual(estimate.reclaimableBytes);
   });
 
   it('treats images missing from the df map as having no shared layers', async () => {

--- a/backend/src/__tests__/docker-controller.test.ts
+++ b/backend/src/__tests__/docker-controller.test.ts
@@ -335,6 +335,87 @@ describe('DockerController - getClassifiedResources', () => {
   });
 });
 
+// ── pruneManagedOnly / estimateManagedReclaim (images) ─────────────────
+
+describe('DockerController - managed image prune accounting', () => {
+  // Two unused images each report a 1000-byte rolled-up Size, but 400 of those
+  // bytes live in a layer shared with a third (in-use) image, so removing
+  // the unused pair only frees the 600 unique bytes from each. The buggy
+  // sum-of-Size accounting would have reported 2000; the fix should report
+  // 1200 (600 × 2).
+  const sharedLayerDfMock = {
+    Images: [
+      { Id: 'img-a', SharedSize: 400 },
+      { Id: 'img-b', SharedSize: 400 },
+      { Id: 'img-c', SharedSize: 400 },
+    ],
+  };
+  const unusedManagedListMock = [
+    { Id: 'img-a', Containers: 0, Size: 1000 },
+    { Id: 'img-b', Containers: 0, Size: 1000 },
+    { Id: 'img-c', Containers: 1, Size: 800 },  // in-use; filtered by Containers===0
+  ];
+
+  it('estimateManagedReclaim subtracts SharedSize per prunable image', async () => {
+    mockDocker.df.mockResolvedValue(sharedLayerDfMock);
+    mockDocker.listImages.mockResolvedValue(unusedManagedListMock);
+    mockDocker.listContainers.mockResolvedValue([]);
+
+    const dc = DockerController.getInstance(1);
+    const result = await dc.estimateManagedReclaim('images', ['any-stack']);
+
+    expect(result.reclaimableBytes).toBe(1200);
+  });
+
+  it('pruneManagedOnly subtracts SharedSize after each removal', async () => {
+    mockDocker.df.mockResolvedValue(sharedLayerDfMock);
+    mockDocker.listImages.mockResolvedValue(unusedManagedListMock);
+    mockDocker.listContainers.mockResolvedValue([]);
+    const removeFn = vi.fn().mockResolvedValue(undefined);
+    mockDocker.getImage.mockReturnValue({ remove: removeFn });
+
+    const dc = DockerController.getInstance(1);
+    const result = await dc.pruneManagedOnly('images', ['any-stack']);
+
+    expect(result).toEqual({ success: true, reclaimedBytes: 1200 });
+    expect(removeFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats images missing from the df map as having no shared layers', async () => {
+    // df reports only img-a; img-b is omitted (stale / race / older daemon).
+    // The accounting should still process img-b, defaulting its SharedSize to 0.
+    mockDocker.df.mockResolvedValue({ Images: [{ Id: 'img-a', SharedSize: 400 }] });
+    mockDocker.listImages.mockResolvedValue([
+      { Id: 'img-a', Containers: 0, Size: 1000 },
+      { Id: 'img-b', Containers: 0, Size: 1000 },
+    ]);
+    mockDocker.listContainers.mockResolvedValue([]);
+
+    const dc = DockerController.getInstance(1);
+    const result = await dc.estimateManagedReclaim('images', ['any-stack']);
+
+    // img-a: 1000-400=600; img-b: 1000-0=1000; total 1600
+    expect(result.reclaimableBytes).toBe(1600);
+  });
+
+  it('degrades to no-sharing assumption when df fails', async () => {
+    // If df throws, the helper returns an empty map and the accounting falls
+    // back to full per-image Size. This preserves prior behavior (over-report)
+    // rather than failing the prune.
+    mockDocker.df.mockRejectedValue(new Error('daemon df failed'));
+    mockDocker.listImages.mockResolvedValue([
+      { Id: 'img-a', Containers: 0, Size: 1000 },
+      { Id: 'img-b', Containers: 0, Size: 1000 },
+    ]);
+    mockDocker.listContainers.mockResolvedValue([]);
+
+    const dc = DockerController.getInstance(1);
+    const result = await dc.estimateManagedReclaim('images', ['any-stack']);
+
+    expect(result.reclaimableBytes).toBe(2000);
+  });
+});
+
 // ── getOrphanContainers ────────────────────────────────────────────────
 
 describe('DockerController - getOrphanContainers', () => {

--- a/backend/src/services/DockerController.ts
+++ b/backend/src/services/DockerController.ts
@@ -336,27 +336,39 @@ class DockerController {
   }
 
   /**
-   * Returns `Id -> SharedSize` (bytes) for every image the daemon currently
-   * knows about. Used by the managed-prune paths to subtract layers shared
-   * with other images when accounting for freed bytes, so the post-prune
-   * total reflects on-disk delta rather than a per-image roll-up. Returns an
-   * empty map if `docker df` fails so the caller degrades to "no sharing
-   * known" rather than throwing.
+   * Returns the `docker df` snapshot, or null if the call fails. The
+   * destructive prune path uses this for a `LayersSize` before/after delta;
+   * the estimate path uses it for a SharedSize lookup. Null on failure lets
+   * each caller decide how to degrade rather than throwing mid-prune.
    */
-  private async getImageSharedSizeMap(): Promise<Map<string, number>> {
+  private async safeDfSnapshot(): Promise<{
+    LayersSize?: number;
+    Images?: Array<{ Id?: string; SharedSize?: number }>;
+  } | null> {
     try {
-      const df = await this.docker.df();
-      const m = new Map<string, number>();
-      const images = (df.Images ?? []) as Array<{ Id?: string; SharedSize?: number }>;
-      for (const img of images) {
-        if (!img?.Id) continue;
-        const s = typeof img.SharedSize === 'number' && img.SharedSize >= 0 ? img.SharedSize : 0;
-        m.set(img.Id, s);
-      }
-      return m;
+      return await this.docker.df();
     } catch {
-      return new Map();
+      return null;
     }
+  }
+
+  /**
+   * Extracts `Id -> SharedSize` from a df snapshot. Treats missing or
+   * negative (Docker's "unknown" sentinel) SharedSize as 0 so the caller
+   * counts the image's full Size as unique, an under-report rather than an
+   * over-report.
+   */
+  private static mapSharedSizesFromDf(
+    df: { Images?: Array<{ Id?: string; SharedSize?: number }> } | null,
+  ): Map<string, number> {
+    const m = new Map<string, number>();
+    if (!df?.Images) return m;
+    for (const img of df.Images) {
+      if (!img?.Id) continue;
+      const s = typeof img.SharedSize === 'number' && img.SharedSize >= 0 ? img.SharedSize : 0;
+      m.set(img.Id, s);
+    }
+    return m;
   }
 
   public async pruneManagedOnly(
@@ -418,19 +430,37 @@ class DockerController {
         && !unmanagedImageIds.has(img.Id)
         && !selfIdentity.isOwnImage(img.Id)
       );
-      const sharedSizes = await this.getImageSharedSizeMap();
+      // df-before / df-after delta is the only honest measurement of bytes
+      // actually freed. Per-image (Size - SharedSize) undercounts layers
+      // shared exclusively between prunable images (Docker frees the layer
+      // once, but the per-image formula subtracts it from every referrer).
+      const beforeDf = await this.safeDfSnapshot();
       await Promise.all(prunable.map(async (img) => {
         try {
           await this.docker.getImage(img.Id).remove({ force: true });
-          // Subtract layers shared with other images. Those bytes stay on
-          // disk until every referrer is removed, so the visible reclaim is
-          // the image's unique slice, not its rolled-up Size.
-          const shared = sharedSizes.get(img.Id) ?? 0;
-          reclaimedBytes += Math.max(0, (img.Size ?? 0) - shared);
         } catch (e) {
           console.error(`[pruneManagedOnly] Failed to remove image ${img.Id}:`, e);
         }
       }));
+      const afterDf = await this.safeDfSnapshot();
+      if (typeof beforeDf?.LayersSize === 'number' && typeof afterDf?.LayersSize === 'number') {
+        // Clamp to 0: a concurrent pull during the prune can grow on-disk
+        // bytes, and attributing that growth to "reclaimed" would mislead.
+        reclaimedBytes = Math.max(0, beforeDf.LayersSize - afterDf.LayersSize);
+      } else if (beforeDf) {
+        // After-snapshot failed but we have the before-snapshot, so fall
+        // back to a per-image lower bound. (We deliberately do not fall back
+        // on after-only: after the prune those image IDs are gone from the
+        // daemon's view, so a SharedSize map built from afterDf would treat
+        // every pruned image as having no sharing and over-report.)
+        console.warn('[pruneManagedOnly] docker df after-snapshot unavailable; reporting per-image lower bound');
+        const shared = DockerController.mapSharedSizesFromDf(beforeDf);
+        for (const img of prunable) {
+          reclaimedBytes += Math.max(0, (img.Size ?? 0) - (shared.get(img.Id) ?? 0));
+        }
+      } else {
+        console.warn('[pruneManagedOnly] docker df unavailable on both ends; reporting 0 reclaimed');
+      }
     }
 
     return { success: true, reclaimedBytes };
@@ -441,6 +471,13 @@ class DockerController {
    * the `/api/system/prune/estimate` route. Walks the same filter rules but
    * does not call `.remove()`. Kept structurally parallel to the destructive
    * method so the two stay in lockstep when the enumeration logic changes.
+   *
+   * For images, the returned figure is a **conservative lower bound** on
+   * bytes that will actually be freed. The formula subtracts each prunable
+   * image's `SharedSize`, which double-counts layers shared between two
+   * prunable images (the layer would only be freed once on prune). The
+   * exact freed bytes can only be measured by the df-delta that
+   * `pruneManagedOnly` reports after the destructive action.
    */
   public async estimateManagedReclaim(
     target: 'images' | 'volumes' | 'networks',
@@ -480,10 +517,9 @@ class DockerController {
         && !unmanagedImageIds.has(img.Id)
         && !selfIdentity.isOwnImage(img.Id),
       );
-      const sharedSizes = await this.getImageSharedSizeMap();
+      const sharedSizes = DockerController.mapSharedSizesFromDf(await this.safeDfSnapshot());
       for (const img of prunable) {
-        const shared = sharedSizes.get(img.Id) ?? 0;
-        reclaimableBytes += Math.max(0, (img.Size ?? 0) - shared);
+        reclaimableBytes += Math.max(0, (img.Size ?? 0) - (sharedSizes.get(img.Id) ?? 0));
       }
     }
 

--- a/backend/src/services/DockerController.ts
+++ b/backend/src/services/DockerController.ts
@@ -335,6 +335,30 @@ class DockerController {
     return { images, volumes, networks };
   }
 
+  /**
+   * Returns `Id -> SharedSize` (bytes) for every image the daemon currently
+   * knows about. Used by the managed-prune paths to subtract layers shared
+   * with other images when accounting for freed bytes, so the post-prune
+   * total reflects on-disk delta rather than a per-image roll-up. Returns an
+   * empty map if `docker df` fails so the caller degrades to "no sharing
+   * known" rather than throwing.
+   */
+  private async getImageSharedSizeMap(): Promise<Map<string, number>> {
+    try {
+      const df = await this.docker.df();
+      const m = new Map<string, number>();
+      const images = (df.Images ?? []) as Array<{ Id?: string; SharedSize?: number }>;
+      for (const img of images) {
+        if (!img?.Id) continue;
+        const s = typeof img.SharedSize === 'number' && img.SharedSize >= 0 ? img.SharedSize : 0;
+        m.set(img.Id, s);
+      }
+      return m;
+    } catch {
+      return new Map();
+    }
+  }
+
   public async pruneManagedOnly(
     target: 'images' | 'volumes' | 'networks',
     knownStackNames: string[]
@@ -394,10 +418,15 @@ class DockerController {
         && !unmanagedImageIds.has(img.Id)
         && !selfIdentity.isOwnImage(img.Id)
       );
+      const sharedSizes = await this.getImageSharedSizeMap();
       await Promise.all(prunable.map(async (img) => {
         try {
           await this.docker.getImage(img.Id).remove({ force: true });
-          reclaimedBytes += img.Size ?? 0;
+          // Subtract layers shared with other images. Those bytes stay on
+          // disk until every referrer is removed, so the visible reclaim is
+          // the image's unique slice, not its rolled-up Size.
+          const shared = sharedSizes.get(img.Id) ?? 0;
+          reclaimedBytes += Math.max(0, (img.Size ?? 0) - shared);
         } catch (e) {
           console.error(`[pruneManagedOnly] Failed to remove image ${img.Id}:`, e);
         }
@@ -451,7 +480,11 @@ class DockerController {
         && !unmanagedImageIds.has(img.Id)
         && !selfIdentity.isOwnImage(img.Id),
       );
-      for (const img of prunable) reclaimableBytes += img.Size ?? 0;
+      const sharedSizes = await this.getImageSharedSizeMap();
+      for (const img of prunable) {
+        const shared = sharedSizes.get(img.Id) ?? 0;
+        reclaimableBytes += Math.max(0, (img.Size ?? 0) - shared);
+      }
     }
 
     return { reclaimableBytes };


### PR DESCRIPTION
## Summary

Companion to PR #1154 (system-scope banner fix). The Sencho-managed prune paths still summed per-image `Size` when totalling reclaimed/reclaimable bytes:

- `pruneManagedOnly` (destructive) — `reclaimedBytes += img.Size` after each removal.
- `estimateManagedReclaim` (dry-run) — `reclaimableBytes += img.Size` per prunable image.

That counts each image's shared base layers in full, so a 1 GB base layer shared across N managed images was reported as N GB freed.

After the Codex audit, the two paths are split because they answer different questions:

- **`pruneManagedOnly` (destructive)** snapshots `docker df` before and after the parallel removes and reports `max(0, before.LayersSize - after.LayersSize)`. That is the honest, layer-aware measurement of bytes freed: it counts shared layers once and naturally captures the case where two prunable images share a layer exclusively with each other (Docker frees the layer; df shrinks; we see it). The clamp absorbs concurrent pulls during the prune.

- **`estimateManagedReclaim` (dry-run)** keeps a per-image `Σ(Size - SharedSize)` formula but the JSDoc now calls it a **conservative lower bound** and explains why: layers shared exclusively between prunable images are subtracted twice. An exact estimate would need per-layer enumeration; the conservative bound is the right tradeoff for a non-destructive readout that should never inflate the banner.

The prior `getImageSharedSizeMap()` helper has been split into `safeDfSnapshot()` (I/O) and a private static `mapSharedSizesFromDf()` (pure parse), reused by both paths.

## Fallback chain on the destructive path

- before-df ✓, after-df ✓ → df-delta (truth).
- before-df ✓, after-df ✗ → per-image lower bound using before-snapshot SharedSize map; warn logged.
- before-df ✗ → report 0 reclaimed; warn logged. (After-only would build a SharedSize map missing the just-pruned image IDs, which would over-report by treating them as having no sharing.)

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npm test -- docker-controller` → 65 tests pass.
- [x] Invariant test: `pruneManagedOnly.reclaimedBytes >= estimateManagedReclaim.reclaimableBytes` on the same inputs.
- [x] After-only fallback test: before-df ✓, after-df ✗ → per-image lower bound.
- [x] Both-failed fallback test: report 0, do not approximate.
- [x] Live `POST /api/system/prune/estimate {target:'images', scope:'managed'}` returned the layer-aware lower bound on a real daemon (~7.84 GB vs the pre-fix ~13.94 GB on the same set).
- [x] Code review run; findings addressed (em dash removed, after-only over-report fix, fallback warn logging, invariant test added).

## Gate parity

No tier/role gate moved in this PR. Both touched methods are admin-only via the routes that call them (`requireAdmin` in `routes/systemMaintenance.ts:45,75,136`); behavior unchanged.

## Notes

- Closes the second half of the prune-accounting discrepancy. PR #1154 fixed the system-scope banner; this fixes the same shape of inflation in the managed-scope estimate + post-prune toast, with the additional honesty of using df-delta as the truth value for the destructive path.