### PR TITLE
fix(mesh): log boot state to console so docker logs surfaces mesh status

### DIFF
--- a/backend/src/__tests__/mesh-setup-error-classification.test.ts
+++ b/backend/src/__tests__/mesh-setup-error-classification.test.ts
@@ -441,3 +441,43 @@ describe('MeshService.setupMeshNetwork subnet auto-fallback', () => {
         expect(status.reason).toBe('subnet_mismatch');
     });
 });
+
+describe('MeshService console.log mirror (F-5)', () => {
+    it('mirrors a setup failure to console.error with the [Mesh] prefix', async () => {
+        process.env.SENCHO_MESH_SUBNET = '10.42.0.0/24';
+        process.env.HOSTNAME = 'sencho';
+        const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        mockDocker({
+            createNetwork: vi.fn().mockRejectedValue(
+                Object.assign(new Error('Pool overlaps with other one on this address space'), { statusCode: 500 }),
+            ),
+        });
+
+        const svc = MeshService.getInstance();
+        await callSetup(svc);
+
+        const meshLines = errSpy.mock.calls
+            .map((args) => String(args[0]))
+            .filter((line) => line.startsWith('[Mesh] data plane unavailable'));
+        expect(meshLines.length).toBeGreaterThan(0);
+        expect(meshLines[0]).toContain('subnet_overlap');
+        expect(meshLines[0]).toContain('10.42.0.0/24');
+        expect(meshLines[0]).toMatch(/overlap/i);
+    });
+
+    it('mirrors a not_in_docker condition to console.warn (expected dev-mode case)', async () => {
+        process.env.SENCHO_MESH_SUBNET = '10.42.0.0/24';
+        delete process.env.HOSTNAME;
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        mockDocker();
+
+        const svc = MeshService.getInstance();
+        await callSetup(svc);
+
+        const meshLines = warnSpy.mock.calls
+            .map((args) => String(args[0]))
+            .filter((line) => line.startsWith('[Mesh] data plane unavailable'));
+        expect(meshLines.length).toBeGreaterThan(0);
+        expect(meshLines[0]).toContain('not_in_docker');
+    });
+});

--- a/backend/src/services/MeshService.ts
+++ b/backend/src/services/MeshService.ts
@@ -422,13 +422,22 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
         const dpReason = this.dataPlaneStatus.reason;
         const dataPlane = this.senchoIp ? 'ok' : `unavailable (${dpReason}: ${this.networkSetupError ?? 'unknown'})`;
         const subnetSuffix = this.senchoIp ? `, subnet ${this.meshSubnet}` : '';
+        const ipSuffix = this.senchoIp ? `, self attached at ${this.senchoIp}` : '';
         const summaryLevel: MeshActivityLevel = dpReason === 'ok'
             ? 'info'
             : dpReason === 'not_in_docker' ? 'warn' : 'error';
+        const summaryMessage = `MeshService started (data plane ${dataPlane}${subnetSuffix}, self nodeId ${this.selfCentralNodeId})`;
         this.logActivity({
             source: 'mesh', level: summaryLevel, type: 'mesh.enable',
-            message: `MeshService started (data plane ${dataPlane}${subnetSuffix}, self nodeId ${this.selfCentralNodeId})`,
+            message: summaryMessage,
         });
+        // Mirror to console so `docker logs sencho` surfaces the boot state.
+        // The activity entry above feeds the Routing tab; this line feeds the
+        // operator's `docker logs` workflow. Same content, different surface.
+        const consoleLine = `[Mesh] data plane ${dataPlane}${ipSuffix}${subnetSuffix}`;
+        if (summaryLevel === 'error') console.error(consoleLine);
+        else if (summaryLevel === 'warn') console.warn(consoleLine);
+        else console.log(consoleLine);
     }
 
     public async stop(): Promise<void> {
@@ -554,13 +563,21 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
         this.networkSetupError = message;
         this.dataPlaneStatus = { ok: false, reason, message, subnet };
         this.senchoIp = null;
+        const sanitized = sanitizeForLog(message);
         this.logActivity({
             source: 'mesh',
             level,
             type: 'mesh.disable',
-            message: `mesh data plane unavailable (${reason}): ${sanitizeForLog(message)}`,
+            message: `mesh data plane unavailable (${reason}): ${sanitized}`,
             details: { reason, subnet },
         });
+        // Mirror to console so the failure shows in `docker logs sencho`. The
+        // start() summary will also emit a boot line after setupMeshNetwork
+        // returns; this per-failure line gives the specific reason + Docker
+        // error message for diagnostic purposes.
+        const consoleLine = `[Mesh] data plane unavailable (${reason}, subnet ${subnet}): ${sanitized}`;
+        if (level === 'warn') console.warn(consoleLine);
+        else console.error(consoleLine);
     }
 
     /**

--- a/docs/features/sencho-mesh.mdx
+++ b/docs/features/sencho-mesh.mdx
@@ -216,6 +216,8 @@ These are the explicit boundaries of the v1 mesh.
     - `attach_failed`: the Docker daemon refused the network attachment for a reason that does not match the patterns above. The full error appears in the activity log entry and on `/api/health`.
 
     The `mesh.dataPlane.subnet` field shows the CIDR Sencho settled on (or the last candidate it tried), so the operator can verify which subnet is configured before changing anything.
+
+    For the container-log view, `docker logs sencho 2>&1 | grep '\[Mesh\]'` shows the boot summary (one line) and any setup failures with the same reason discriminator: `[Mesh] data plane ok, self attached at 172.31.0.2, subnet 172.31.0.0/24` on success, or `[Mesh] data plane unavailable (subnet_overlap, subnet 172.30.0.0/24): Pool overlaps with other one on this address space` on failure.
   </Accordion>
 
   <Accordion title="Opt-in rejects with 'host-network service'">


### PR DESCRIPTION
## Summary

Resolves F-5 from the pre-1.0 audit (re-confirmed open during F-1 post-merge verification on `sencho-test-03` 2026-05-22). `MeshService` records its boot summary and setup failures only through `logActivity`, which feeds the Routing tab activity log and the dashboard banner via WS listeners. The `docker logs sencho` surface had no mesh lines, so operators running Sencho-in-Docker had no boot-time visibility into whether the data plane came up cleanly.

This PR mirrors the existing `logActivity` entries to console **without replacing them**. The activity entries continue to feed the Routing tab and the dashboard banner; the new console lines are purely additive for the `docker logs` workflow.

## Surfaces touched

- `MeshService.start()` boot summary — `console.log` for the `ok` case, `console.warn` for `not_in_docker` (expected dev-mode), `console.error` for real failures. Format: `[Mesh] data plane ok, self attached at 172.31.0.2, subnet 172.31.0.0/24`.
- `MeshService.recordSetupFailure()` — `console.warn` for the `not_in_docker` warn-level case, `console.error` otherwise. Format: `[Mesh] data plane unavailable (subnet_overlap, subnet 172.30.0.0/24): Pool overlaps with other one on this address space`.
- `docs/features/sencho-mesh.mdx` — added a one-liner showing the operator how to grep the new log lines (`docker logs sencho 2>&1 | grep '\[Mesh\]'`).

The two console lines are content-equivalent to the existing activity entries (same reason discriminator, same subnet, same Docker error message after `sanitizeForLog`). The mirror is one extra line per boot for the success case, plus one extra line per failure reason if setup fails.

## Test plan

- [x] `backend npx tsc --noEmit` — zero errors.
- [x] `backend npx vitest run mesh-setup-error-classification mesh-service` — 83/83 pass (22 classification + 61 service). Two new tests assert the `subnet_overlap` failure mirror lands on `console.error` and the `not_in_docker` mirror lands on `console.warn`, both with the `[Mesh]` prefix.
- [ ] Post-merge: deploy the new image to the workstation central and sencho-test-03; `docker logs sencho 2>&1 | grep '\[Mesh\]'` shows the boot summary line on both. Pair with the F-1 verification — central will read `subnet 172.31.0.0/24` (candidate iteration), peer will read `subnet 172.30.0.0/24` (adopt-existing).

## Risks

- **Double-logging.** The Routing tab activity feed and `docker logs` now both carry the same boot summary. By design — they target different audiences. The plan note from F-5's tracker entry explicitly required "mirror, do not replace."
- **Log volume on boot.** One additional line per process start, plus one per setup failure reason. Negligible.
- **No runtime transitions yet.** Sencho doesn't currently re-poll the data plane after boot (tracked separately as F-4). When F-4 lands, the same mirror pattern should be applied to whatever surface re-evaluates the data plane state.

## Non-goals

- F-4 (re-poll mesh data plane after boot). Separate fix, separate PR.
- Restructuring `logActivity` to also write to console. Keeping the two surfaces independent is the explicit design choice from F-5's tracker entry; conflating them would force every activity entry into `docker logs`, which is more noise than the F-5 issue calls for.
- New structured-log format (e.g. JSON via a winston/pino transport). Out of scope; matches the existing `[ServiceName]` plain-text pattern used by `SchedulerService`, `DockerEvents`, `BlueprintReconciler`, etc.