### PR TITLE
fix(mesh): bias Sencho static IP via IPAM IPRange (F-13)

### DIFF
--- a/backend/src/__tests__/mesh-setup-error-classification.test.ts
+++ b/backend/src/__tests__/mesh-setup-error-classification.test.ts
@@ -442,6 +442,155 @@ describe('MeshService.setupMeshNetwork subnet auto-fallback', () => {
     });
 });
 
+describe('MeshService static IP reservation (F-13)', () => {
+    it('emits AuxiliaryAddresses with the Sencho IP when creating the network with an explicit subnet', async () => {
+        process.env.SENCHO_MESH_SUBNET = '10.42.0.0/24';
+        process.env.HOSTNAME = 'sencho';
+        const createNetwork = vi.fn().mockResolvedValue(undefined);
+        const inspectNetwork = vi.fn().mockRejectedValue({ statusCode: 404, message: 'no such network' });
+        mockDocker({ createNetwork, inspectNetwork });
+
+        const svc = MeshService.getInstance();
+        await callSetup(svc);
+
+        expect(svc.getDataPlaneStatus().ok).toBe(true);
+        expect(createNetwork).toHaveBeenCalledTimes(1);
+        const payload = createNetwork.mock.calls[0][0] as {
+            IPAM?: { Config?: Array<{ Subnet?: string; AuxiliaryAddresses?: Record<string, string> }> };
+        };
+        expect(payload.IPAM?.Config?.[0]?.AuxiliaryAddresses).toEqual({ sencho: '10.42.0.2' });
+    });
+
+    it('emits the reservation on the winning candidate when env is unset and the first candidate overlaps', async () => {
+        delete process.env.SENCHO_MESH_SUBNET;
+        process.env.HOSTNAME = 'sencho';
+        const overlap = Object.assign(
+            new Error('Pool overlaps with other one on this address space'),
+            { statusCode: 500 },
+        );
+        const createNetwork = vi.fn()
+            .mockRejectedValueOnce(overlap)
+            .mockResolvedValueOnce(undefined);
+        const inspectNetwork = vi.fn().mockRejectedValue({ statusCode: 404, message: 'no such network' });
+        mockDocker({ createNetwork, inspectNetwork });
+
+        const svc = MeshService.getInstance();
+        await callSetup(svc);
+
+        expect(svc.getDataPlaneStatus().ok).toBe(true);
+        expect(svc.getDataPlaneStatus().subnet).toBe('172.31.0.0/24');
+        expect(createNetwork).toHaveBeenCalledTimes(2);
+        const winningPayload = createNetwork.mock.calls[1][0] as {
+            IPAM?: { Config?: Array<{ Subnet?: string; AuxiliaryAddresses?: Record<string, string> }> };
+        };
+        expect(winningPayload.IPAM?.Config?.[0]?.Subnet).toBe('172.31.0.0/24');
+        expect(winningPayload.IPAM?.Config?.[0]?.AuxiliaryAddresses).toEqual({ sencho: '172.31.0.2' });
+    });
+
+    it('emits a legacy warn when adopting a sencho_mesh without the aux reservation', async () => {
+        delete process.env.SENCHO_MESH_SUBNET;
+        process.env.HOSTNAME = 'sencho';
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const createNetwork = vi.fn();
+        // Legacy network: subnet only, no AuxiliaryAddresses.
+        const inspectNetwork = vi.fn().mockResolvedValue({
+            IPAM: { Config: [{ Subnet: '172.30.0.0/24' }] },
+        });
+        mockDocker({ createNetwork, inspectNetwork });
+
+        const svc = MeshService.getInstance();
+        await callSetup(svc);
+
+        const status = svc.getDataPlaneStatus();
+        expect(status.ok).toBe(true);
+        expect(status.subnet).toBe('172.30.0.0/24');
+        expect(createNetwork).not.toHaveBeenCalled();
+
+        const all = (svc as unknown as { activity: MeshActivityEvent[] }).activity;
+        const warns = all.filter((e) => e.level === 'warn' && /without an IPAM auxiliary reservation/.test(e.message));
+        expect(warns).toHaveLength(1);
+        expect(warns[0].details).toMatchObject({
+            subnet: '172.30.0.0/24',
+            expectedAuxSenchoIp: '172.30.0.2',
+            actualAuxSenchoIp: null,
+        });
+
+        const meshLines = warnSpy.mock.calls
+            .map((args) => String(args[0]))
+            .filter((line) => /\[Mesh\] sencho_mesh adopted without an IPAM auxiliary reservation/.test(line));
+        expect(meshLines.length).toBeGreaterThan(0);
+    });
+
+    it('stays silent on the adopt path when the existing sencho_mesh already carries the reservation', async () => {
+        delete process.env.SENCHO_MESH_SUBNET;
+        process.env.HOSTNAME = 'sencho';
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const createNetwork = vi.fn();
+        const inspectNetwork = vi.fn().mockResolvedValue({
+            IPAM: {
+                Config: [{
+                    Subnet: '172.30.0.0/24',
+                    AuxiliaryAddresses: { sencho: '172.30.0.2' },
+                }],
+            },
+        });
+        mockDocker({ createNetwork, inspectNetwork });
+
+        const svc = MeshService.getInstance();
+        await callSetup(svc);
+
+        const status = svc.getDataPlaneStatus();
+        expect(status.ok).toBe(true);
+
+        const all = (svc as unknown as { activity: MeshActivityEvent[] }).activity;
+        const warns = all.filter((e) => e.level === 'warn' && /auxiliary reservation/.test(e.message));
+        expect(warns).toHaveLength(0);
+
+        const meshLines = warnSpy.mock.calls
+            .map((args) => String(args[0]))
+            .filter((line) => /auxiliary reservation/.test(line));
+        expect(meshLines).toHaveLength(0);
+    });
+
+    it('emits the legacy warn when a TOCTOU 409 race-winner is a legacy network', async () => {
+        // Operator-explicit subnet matches a race-winner that pre-dates the
+        // aux reservation: another process created sencho_mesh between our
+        // initial inspect and our create. We adopt it, the data plane comes
+        // up, and the warn fires because the race-winner's IPAM block has
+        // no AuxiliaryAddresses entry. This exercises the subtle assignment
+        // in setupMeshNetwork that reassigns existingSubnet = raceWinner.
+        process.env.SENCHO_MESH_SUBNET = '10.42.0.0/24';
+        process.env.HOSTNAME = 'sencho';
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const conflict = Object.assign(
+            new Error('network with name sencho_mesh already exists'),
+            { statusCode: 409 },
+        );
+        const createNetwork = vi.fn().mockRejectedValue(conflict);
+        const inspectNetwork = vi.fn()
+            .mockRejectedValueOnce({ statusCode: 404, message: 'no such network' })
+            .mockResolvedValueOnce({ IPAM: { Config: [{ Subnet: '10.42.0.0/24' }] } });
+        mockDocker({ createNetwork, inspectNetwork });
+
+        const svc = MeshService.getInstance();
+        await callSetup(svc);
+
+        expect(svc.getDataPlaneStatus().ok).toBe(true);
+        const all = (svc as unknown as { activity: MeshActivityEvent[] }).activity;
+        const warns = all.filter((e) => e.level === 'warn' && /without an IPAM auxiliary reservation/.test(e.message));
+        expect(warns).toHaveLength(1);
+        expect(warns[0].details).toMatchObject({
+            subnet: '10.42.0.0/24',
+            expectedAuxSenchoIp: '10.42.0.2',
+            actualAuxSenchoIp: null,
+        });
+        const meshLines = warnSpy.mock.calls
+            .map((args) => String(args[0]))
+            .filter((line) => /\[Mesh\] sencho_mesh adopted without an IPAM auxiliary reservation/.test(line));
+        expect(meshLines.length).toBeGreaterThan(0);
+    });
+});
+
 describe('MeshService console.log mirror (F-5)', () => {
     it('mirrors a setup failure to console.error with the [Mesh] prefix', async () => {
         process.env.SENCHO_MESH_SUBNET = '10.42.0.0/24';

--- a/backend/src/__tests__/mesh-setup-error-classification.test.ts
+++ b/backend/src/__tests__/mesh-setup-error-classification.test.ts
@@ -443,7 +443,7 @@ describe('MeshService.setupMeshNetwork subnet auto-fallback', () => {
 });
 
 describe('MeshService static IP reservation (F-13)', () => {
-    it('emits AuxiliaryAddresses with the Sencho IP when creating the network with an explicit subnet', async () => {
+    it('emits IPRange for the upper half of the subnet when creating with an explicit env subnet', async () => {
         process.env.SENCHO_MESH_SUBNET = '10.42.0.0/24';
         process.env.HOSTNAME = 'sencho';
         const createNetwork = vi.fn().mockResolvedValue(undefined);
@@ -456,12 +456,13 @@ describe('MeshService static IP reservation (F-13)', () => {
         expect(svc.getDataPlaneStatus().ok).toBe(true);
         expect(createNetwork).toHaveBeenCalledTimes(1);
         const payload = createNetwork.mock.calls[0][0] as {
-            IPAM?: { Config?: Array<{ Subnet?: string; AuxiliaryAddresses?: Record<string, string> }> };
+            IPAM?: { Config?: Array<{ Subnet?: string; IPRange?: string }> };
         };
-        expect(payload.IPAM?.Config?.[0]?.AuxiliaryAddresses).toEqual({ sencho: '10.42.0.2' });
+        expect(payload.IPAM?.Config?.[0]?.Subnet).toBe('10.42.0.0/24');
+        expect(payload.IPAM?.Config?.[0]?.IPRange).toBe('10.42.0.128/25');
     });
 
-    it('emits the reservation on the winning candidate when env is unset and the first candidate overlaps', async () => {
+    it('emits the IPRange on the winning candidate when env is unset and the first candidate overlaps', async () => {
         delete process.env.SENCHO_MESH_SUBNET;
         process.env.HOSTNAME = 'sencho';
         const overlap = Object.assign(
@@ -481,18 +482,19 @@ describe('MeshService static IP reservation (F-13)', () => {
         expect(svc.getDataPlaneStatus().subnet).toBe('172.31.0.0/24');
         expect(createNetwork).toHaveBeenCalledTimes(2);
         const winningPayload = createNetwork.mock.calls[1][0] as {
-            IPAM?: { Config?: Array<{ Subnet?: string; AuxiliaryAddresses?: Record<string, string> }> };
+            IPAM?: { Config?: Array<{ Subnet?: string; IPRange?: string }> };
         };
         expect(winningPayload.IPAM?.Config?.[0]?.Subnet).toBe('172.31.0.0/24');
-        expect(winningPayload.IPAM?.Config?.[0]?.AuxiliaryAddresses).toEqual({ sencho: '172.31.0.2' });
+        expect(winningPayload.IPAM?.Config?.[0]?.IPRange).toBe('172.31.0.128/25');
     });
 
-    it('emits a legacy warn when adopting a sencho_mesh without the aux reservation', async () => {
+    it('emits a legacy warn when adopting a sencho_mesh without the upper-half IPRange', async () => {
         delete process.env.SENCHO_MESH_SUBNET;
         process.env.HOSTNAME = 'sencho';
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
         const createNetwork = vi.fn();
-        // Legacy network: subnet only, no AuxiliaryAddresses.
+        // Legacy network: Subnet only, no IPRange (Docker defaults auto-
+        // allocation to the entire subnet, including .2).
         const inspectNetwork = vi.fn().mockResolvedValue({
             IPAM: { Config: [{ Subnet: '172.30.0.0/24' }] },
         });
@@ -507,21 +509,21 @@ describe('MeshService static IP reservation (F-13)', () => {
         expect(createNetwork).not.toHaveBeenCalled();
 
         const all = (svc as unknown as { activity: MeshActivityEvent[] }).activity;
-        const warns = all.filter((e) => e.level === 'warn' && /without an IPAM auxiliary reservation/.test(e.message));
+        const warns = all.filter((e) => e.level === 'warn' && /without the upper-half IPAM IPRange/.test(e.message));
         expect(warns).toHaveLength(1);
         expect(warns[0].details).toMatchObject({
             subnet: '172.30.0.0/24',
-            expectedAuxSenchoIp: '172.30.0.2',
-            actualAuxSenchoIp: null,
+            expectedIpRange: '172.30.0.128/25',
+            actualIpRange: null,
         });
 
         const meshLines = warnSpy.mock.calls
             .map((args) => String(args[0]))
-            .filter((line) => /\[Mesh\] sencho_mesh adopted without an IPAM auxiliary reservation/.test(line));
+            .filter((line) => /\[Mesh\] sencho_mesh adopted without the upper-half IPAM IPRange/.test(line));
         expect(meshLines.length).toBeGreaterThan(0);
     });
 
-    it('stays silent on the adopt path when the existing sencho_mesh already carries the reservation', async () => {
+    it('stays silent on the adopt path when the existing sencho_mesh already carries the upper-half IPRange', async () => {
         delete process.env.SENCHO_MESH_SUBNET;
         process.env.HOSTNAME = 'sencho';
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -530,7 +532,7 @@ describe('MeshService static IP reservation (F-13)', () => {
             IPAM: {
                 Config: [{
                     Subnet: '172.30.0.0/24',
-                    AuxiliaryAddresses: { sencho: '172.30.0.2' },
+                    IPRange: '172.30.0.128/25',
                 }],
             },
         });
@@ -543,22 +545,22 @@ describe('MeshService static IP reservation (F-13)', () => {
         expect(status.ok).toBe(true);
 
         const all = (svc as unknown as { activity: MeshActivityEvent[] }).activity;
-        const warns = all.filter((e) => e.level === 'warn' && /auxiliary reservation/.test(e.message));
+        const warns = all.filter((e) => e.level === 'warn' && /IPAM IPRange/.test(e.message));
         expect(warns).toHaveLength(0);
 
         const meshLines = warnSpy.mock.calls
             .map((args) => String(args[0]))
-            .filter((line) => /auxiliary reservation/.test(line));
+            .filter((line) => /IPAM IPRange/.test(line));
         expect(meshLines).toHaveLength(0);
     });
 
     it('emits the legacy warn when a TOCTOU 409 race-winner is a legacy network', async () => {
         // Operator-explicit subnet matches a race-winner that pre-dates the
-        // aux reservation: another process created sencho_mesh between our
-        // initial inspect and our create. We adopt it, the data plane comes
-        // up, and the warn fires because the race-winner's IPAM block has
-        // no AuxiliaryAddresses entry. This exercises the subtle assignment
-        // in setupMeshNetwork that reassigns existingSubnet = raceWinner.
+        // upper-half IPRange bias: another process created sencho_mesh
+        // between our initial inspect and our create. We adopt it, the data
+        // plane comes up, and the warn fires because the race-winner's IPAM
+        // block has no IPRange entry. Exercises the subtle assignment in
+        // setupMeshNetwork that reassigns existingSubnet = raceWinner.
         process.env.SENCHO_MESH_SUBNET = '10.42.0.0/24';
         process.env.HOSTNAME = 'sencho';
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -577,16 +579,16 @@ describe('MeshService static IP reservation (F-13)', () => {
 
         expect(svc.getDataPlaneStatus().ok).toBe(true);
         const all = (svc as unknown as { activity: MeshActivityEvent[] }).activity;
-        const warns = all.filter((e) => e.level === 'warn' && /without an IPAM auxiliary reservation/.test(e.message));
+        const warns = all.filter((e) => e.level === 'warn' && /without the upper-half IPAM IPRange/.test(e.message));
         expect(warns).toHaveLength(1);
         expect(warns[0].details).toMatchObject({
             subnet: '10.42.0.0/24',
-            expectedAuxSenchoIp: '10.42.0.2',
-            actualAuxSenchoIp: null,
+            expectedIpRange: '10.42.0.128/25',
+            actualIpRange: null,
         });
         const meshLines = warnSpy.mock.calls
             .map((args) => String(args[0]))
-            .filter((line) => /\[Mesh\] sencho_mesh adopted without an IPAM auxiliary reservation/.test(line));
+            .filter((line) => /\[Mesh\] sencho_mesh adopted without the upper-half IPAM IPRange/.test(line));
         expect(meshLines.length).toBeGreaterThan(0);
     });
 });

--- a/backend/src/services/DockerController.ts
+++ b/backend/src/services/DockerController.ts
@@ -100,7 +100,7 @@ export interface CreateNetworkOptions {
     Config: Array<{
       Subnet?: string;
       Gateway?: string;
-      AuxiliaryAddresses?: Record<string, string>;
+      IPRange?: string;
     }>;
   };
   Labels?: Record<string, string>;

--- a/backend/src/services/DockerController.ts
+++ b/backend/src/services/DockerController.ts
@@ -96,7 +96,13 @@ export type NetworkDriver = 'bridge' | 'overlay' | 'macvlan' | 'host' | 'none';
 export interface CreateNetworkOptions {
   Name: string;
   Driver?: NetworkDriver;
-  IPAM?: { Config: Array<{ Subnet?: string; Gateway?: string }> };
+  IPAM?: {
+    Config: Array<{
+      Subnet?: string;
+      Gateway?: string;
+      AuxiliaryAddresses?: Record<string, string>;
+    }>;
+  };
   Labels?: Record<string, string>;
   Internal?: boolean;
   Attachable?: boolean;

--- a/backend/src/services/MeshService.ts
+++ b/backend/src/services/MeshService.ts
@@ -80,6 +80,42 @@ export function getSenchoIpFromSubnet(subnet: string): string {
 }
 
 /**
+ * Returns the `IPRange` CIDR that biases Docker's IPAM auto-allocation to
+ * the upper half of `subnet`, leaving the lower half (which contains
+ * Sencho's static `<network>+2`) free for explicit pins only. For the
+ * default `172.30.0.0/24` this is `172.30.0.128/25`.
+ *
+ * The IPRange constrains auto-allocation only: workload containers without
+ * an explicit `ipv4Address` get `<network>+128` and up, never the reserved
+ * low addresses. Explicit pins inside the Subnet but outside the IPRange
+ * still succeed (libnetwork's `RequestAddress` checks the bitmap, not the
+ * IPRange, when the caller supplies a preferred address), so Sencho's own
+ * `ensureSelfAttached` can still bind `<network>+2`.
+ *
+ * Throws on invalid CIDR or a prefix narrower than `/30` (no upper half to
+ * carve). The candidate list is `/24` so this never trips in practice.
+ */
+export function getMeshIpRangeFromSubnet(subnet: string): string {
+    const cidr = subnet.trim().match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)\/(\d+)$/);
+    if (!cidr) throw new Error(`Invalid mesh subnet CIDR: ${subnet}`);
+    const octets = [Number(cidr[1]), Number(cidr[2]), Number(cidr[3]), Number(cidr[4])];
+    const prefix = Number(cidr[5]);
+    if (octets.some((o) => o < 0 || o > 255) || prefix < 8 || prefix > 29) {
+        throw new Error(`Invalid mesh subnet CIDR: ${subnet}`);
+    }
+    const ipInt = (octets[0] << 24) | (octets[1] << 16) | (octets[2] << 8) | octets[3];
+    const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
+    const network = (ipInt & mask) >>> 0;
+    const upperHalfStart = (network + (1 << (32 - prefix - 1))) >>> 0;
+    return [
+        (upperHalfStart >>> 24) & 0xff,
+        (upperHalfStart >>> 16) & 0xff,
+        (upperHalfStart >>> 8) & 0xff,
+        upperHalfStart & 0xff,
+    ].join('.') + '/' + (prefix + 1);
+}
+
+/**
  * Discriminator for why the mesh data plane is or is not healthy. Set by
  * `setupMeshNetwork` and exposed through `getDataPlaneStatus()` so
  * `/api/health` and `/api/meta` can surface the state without parsing the
@@ -646,7 +682,7 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
             }
         }
 
-        let existingSubnet: { subnet: string; auxSenchoIp: string | null } | null;
+        let existingSubnet: { subnet: string; ipRange: string | null } | null;
         try {
             existingSubnet = await this.inspectExistingMeshSubnet();
         } catch (err) {
@@ -782,15 +818,19 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
 
         // Legacy-network advisory: if we adopted an existing `sencho_mesh`
         // (rather than creating a fresh one) AND its IPAM block lacks the
-        // `AuxiliaryAddresses.sencho` entry that pins the data-plane IP, warn
-        // the operator that a meshed workload restarting while Sencho is
-        // offline can squat that IP (F-13 failure mode). The data plane still
-        // comes up; the warn is advisory and rides at `level: 'warn'` on the
-        // existing `mesh.enable` activity type plus a console mirror so it
-        // appears in `docker logs sencho`. Fresh-created networks always
-        // carry the reservation (see `createMeshNetwork`).
-        if (existingSubnet && this.senchoIp && existingSubnet.auxSenchoIp !== this.senchoIp) {
-            this.warnLegacyMeshReservation(existingSubnet.auxSenchoIp);
+        // upper-half IPRange that biases Docker's auto-allocation away from
+        // `<network>+2`, warn the operator that a meshed workload
+        // restarting while Sencho is offline can squat that IP (F-13
+        // failure mode). The data plane still comes up; the warn is
+        // advisory and rides at `level: 'warn'` on the existing
+        // `mesh.enable` activity type plus a console mirror so it appears
+        // in `docker logs sencho`. Fresh-created networks always carry
+        // the bias (see `createMeshNetwork`).
+        if (existingSubnet && this.senchoIp) {
+            const expectedIpRange = getMeshIpRangeFromSubnet(this.meshSubnet);
+            if (existingSubnet.ipRange !== expectedIpRange) {
+                this.warnLegacyMeshReservation(existingSubnet.ipRange);
+            }
         }
 
         try {
@@ -818,16 +858,19 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
 
     /**
      * Emit the F-13 advisory: the operator is running on a `sencho_mesh`
-     * that pre-dates the IPAM auxiliary-address reservation, so another
-     * container can grab Sencho's `<network>+2` IP while Sencho is offline.
-     * Logged once per process at boot (this is only called from
-     * `setupMeshNetwork`, which itself runs once per `start()`). Mirrored to
-     * `console.warn` so it appears in `docker logs sencho`.
+     * that pre-dates the upper-half IPRange bias, so Docker's auto-
+     * allocation can still hand Sencho's `<network>+2` IP to another
+     * meshed workload while Sencho is offline. Logged once per process at
+     * boot (this is only called from `setupMeshNetwork`, which itself
+     * runs once per `start()`). Mirrored to `console.warn` so it appears
+     * in `docker logs sencho`.
      */
-    private warnLegacyMeshReservation(actualAuxSenchoIp: string | null): void {
-        const msg = `${SENCHO_MESH_NETWORK} adopted without an IPAM auxiliary reservation for ${this.senchoIp}; `
-            + `another container can squat this IP while Sencho is offline. To apply the reservation: `
-            + `stop every meshed stack, run \`docker network rm ${SENCHO_MESH_NETWORK}\`, then restart Sencho.`;
+    private warnLegacyMeshReservation(actualIpRange: string | null): void {
+        const expected = this.senchoIp ? getMeshIpRangeFromSubnet(this.meshSubnet) : null;
+        const msg = `${SENCHO_MESH_NETWORK} adopted without the upper-half IPAM IPRange `
+            + `(expected ${expected ?? 'a constrained IPRange'}); another container can squat ${this.senchoIp} `
+            + `while Sencho is offline. To apply the bias: stop every meshed stack, `
+            + `run \`docker network rm ${SENCHO_MESH_NETWORK}\`, then restart Sencho.`;
         this.logActivity({
             source: 'mesh',
             level: 'warn',
@@ -835,26 +878,27 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
             message: msg,
             details: {
                 subnet: this.meshSubnet,
-                expectedAuxSenchoIp: this.senchoIp,
-                actualAuxSenchoIp,
+                expectedIpRange: expected,
+                actualIpRange,
             },
         });
         console.warn(`[Mesh] ${msg}`);
     }
 
     /**
-     * Return the subnet and the Sencho aux-address reservation of an existing
-     * `sencho_mesh` network, or null if the network does not exist. The
-     * `auxSenchoIp` field reflects `IPAM.Config[0].AuxiliaryAddresses.sencho`
-     * on the daemon: null when the network pre-dates the reservation, the
-     * pinned IP otherwise. The adopt-existing path uses this to surface a
-     * one-time warn when running on a legacy network that is vulnerable to
-     * IP squatting while Sencho is offline. Docker's inspect endpoint
-     * surfaces 404 for the missing-network case; any other error is
-     * re-raised so the caller can classify it as `attach_failed`.
+     * Return the subnet and the IPRange of an existing `sencho_mesh`
+     * network, or null if the network does not exist. The `ipRange` field
+     * reflects `IPAM.Config[0].IPRange` on the daemon: null when the
+     * network pre-dates the upper-half bias or the operator chose not to
+     * set one, the configured CIDR otherwise. The adopt-existing path
+     * uses this to surface a one-time warn when running on a legacy
+     * network that is vulnerable to IP squatting while Sencho is offline.
+     * Docker's inspect endpoint surfaces 404 for the missing-network
+     * case; any other error is re-raised so the caller can classify it
+     * as `attach_failed`.
      */
     private async inspectExistingMeshSubnet(): Promise<
-        { subnet: string; auxSenchoIp: string | null } | null
+        { subnet: string; ipRange: string | null } | null
     > {
         const dc = DockerController.getInstance(NodeRegistry.getInstance().getDefaultNodeId());
         try {
@@ -862,7 +906,7 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
                 IPAM?: {
                     Config?: Array<{
                         Subnet?: string;
-                        AuxiliaryAddresses?: Record<string, string>;
+                        IPRange?: string;
                     }>;
                 };
             } | undefined;
@@ -870,7 +914,7 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
             if (!cfg?.Subnet) return null;
             return {
                 subnet: cfg.Subnet,
-                auxSenchoIp: cfg.AuxiliaryAddresses?.sencho ?? null,
+                ipRange: cfg.IPRange ?? null,
             };
         } catch (err) {
             const e = err as { statusCode?: number };
@@ -885,16 +929,21 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
      * `classifyMeshNetworkError` recognises) so callers can decide whether
      * to retry on another candidate or bail.
      *
-     * The IPAM block reserves Sencho's static `<network>+2` via
-     * `AuxiliaryAddresses`. Aux-listed addresses are removed from the
-     * auto-allocatable pool, so Docker refuses to hand `.2` to any other
-     * container while Sencho is offline. Sencho's own attach via
-     * `connectContainerToNetwork({ ipv4Address })` is unaffected because
-     * explicit pins still bind aux-reserved addresses.
+     * The IPAM block sets `IPRange` to the upper half of the subnet so
+     * Docker's auto-allocation pulls from `<network>+128` and up, leaving
+     * the lower half (which contains Sencho's static `<network>+2`) free
+     * for explicit pins only. This stops a meshed workload that restarts
+     * while Sencho is offline from grabbing `.2` by default. Sencho's own
+     * attach via `connectContainerToNetwork({ ipv4Address })` still binds
+     * `.2` because explicit pins can land anywhere in the subnet, not
+     * just inside the IPRange. (Aux-address reservation would also block
+     * the IP from auto-allocation, but libnetwork's `RequestAddress`
+     * rejects explicit pins to aux-reserved addresses too, which would
+     * defeat Sencho's own self-attach — verified against Docker 29.4.3.)
      */
     private async createMeshNetwork(subnet: string): Promise<void> {
         const dc = DockerController.getInstance(NodeRegistry.getInstance().getDefaultNodeId());
-        const senchoIp = getSenchoIpFromSubnet(subnet);
+        const ipRange = getMeshIpRangeFromSubnet(subnet);
         await dc.createNetwork({
             Name: SENCHO_MESH_NETWORK,
             Driver: 'bridge',
@@ -902,7 +951,7 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
             IPAM: {
                 Config: [{
                     Subnet: subnet,
-                    AuxiliaryAddresses: { sencho: senchoIp },
+                    IPRange: ipRange,
                 }],
             },
             Labels: { 'io.sencho.mesh': 'true' },

--- a/backend/src/services/MeshService.ts
+++ b/backend/src/services/MeshService.ts
@@ -646,7 +646,7 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
             }
         }
 
-        let existingSubnet: string | null;
+        let existingSubnet: { subnet: string; auxSenchoIp: string | null } | null;
         try {
             existingSubnet = await this.inspectExistingMeshSubnet();
         } catch (err) {
@@ -663,11 +663,11 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
         }
 
         if (envSubnet) {
-            if (existingSubnet && existingSubnet !== envSubnet) {
+            if (existingSubnet && existingSubnet.subnet !== envSubnet) {
                 this.recordSetupFailure(
                     'subnet_mismatch',
                     new Error(
-                        `${SENCHO_MESH_NETWORK} exists with subnet ${existingSubnet}, ` +
+                        `${SENCHO_MESH_NETWORK} exists with subnet ${existingSubnet.subnet}, ` +
                         `expected ${envSubnet}. Remove the network or set SENCHO_MESH_SUBNET to match.`,
                     ),
                     'error',
@@ -690,13 +690,17 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
                     const dockerErr = err as { statusCode?: number };
                     if (dockerErr?.statusCode === 409) {
                         const raceWinner = await this.inspectExistingMeshSubnet().catch(() => null);
-                        if (raceWinner === envSubnet) {
+                        if (raceWinner && raceWinner.subnet === envSubnet) {
                             // Adopt the race-winner's network; proceed to attach.
+                            // Defer the legacy-reservation check to the shared
+                            // helper below so the warn message is identical
+                            // regardless of which branch arrived here.
+                            existingSubnet = raceWinner;
                         } else if (raceWinner) {
                             this.recordSetupFailure(
                                 'subnet_mismatch',
                                 new Error(
-                                    `${SENCHO_MESH_NETWORK} exists with subnet ${raceWinner}, ` +
+                                    `${SENCHO_MESH_NETWORK} exists with subnet ${raceWinner.subnet}, ` +
                                     `expected ${envSubnet}. Remove the network or set SENCHO_MESH_SUBNET to match.`,
                                 ),
                                 'error',
@@ -720,10 +724,10 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
             }
         } else if (existingSubnet) {
             try {
-                this.senchoIp = getSenchoIpFromSubnet(existingSubnet);
-                this.meshSubnet = existingSubnet;
+                this.senchoIp = getSenchoIpFromSubnet(existingSubnet.subnet);
+                this.meshSubnet = existingSubnet.subnet;
             } catch (err) {
-                this.recordSetupFailure('subnet_invalid', err, 'error', existingSubnet);
+                this.recordSetupFailure('subnet_invalid', err, 'error', existingSubnet.subnet);
                 return;
             }
         } else {
@@ -776,6 +780,19 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
             }
         }
 
+        // Legacy-network advisory: if we adopted an existing `sencho_mesh`
+        // (rather than creating a fresh one) AND its IPAM block lacks the
+        // `AuxiliaryAddresses.sencho` entry that pins the data-plane IP, warn
+        // the operator that a meshed workload restarting while Sencho is
+        // offline can squat that IP (F-13 failure mode). The data plane still
+        // comes up; the warn is advisory and rides at `level: 'warn'` on the
+        // existing `mesh.enable` activity type plus a console mirror so it
+        // appears in `docker logs sencho`. Fresh-created networks always
+        // carry the reservation (see `createMeshNetwork`).
+        if (existingSubnet && this.senchoIp && existingSubnet.auxSenchoIp !== this.senchoIp) {
+            this.warnLegacyMeshReservation(existingSubnet.auxSenchoIp);
+        }
+
         try {
             await this.ensureSelfAttached();
         } catch (err) {
@@ -800,18 +817,61 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
     }
 
     /**
-     * Return the subnet of an existing `sencho_mesh` network, or null if the
-     * network does not exist. Docker's inspect endpoint surfaces 404 for
-     * the missing case; any other error is re-raised so the caller can
-     * classify it as `attach_failed`.
+     * Emit the F-13 advisory: the operator is running on a `sencho_mesh`
+     * that pre-dates the IPAM auxiliary-address reservation, so another
+     * container can grab Sencho's `<network>+2` IP while Sencho is offline.
+     * Logged once per process at boot (this is only called from
+     * `setupMeshNetwork`, which itself runs once per `start()`). Mirrored to
+     * `console.warn` so it appears in `docker logs sencho`.
      */
-    private async inspectExistingMeshSubnet(): Promise<string | null> {
+    private warnLegacyMeshReservation(actualAuxSenchoIp: string | null): void {
+        const msg = `${SENCHO_MESH_NETWORK} adopted without an IPAM auxiliary reservation for ${this.senchoIp}; `
+            + `another container can squat this IP while Sencho is offline. To apply the reservation: `
+            + `stop every meshed stack, run \`docker network rm ${SENCHO_MESH_NETWORK}\`, then restart Sencho.`;
+        this.logActivity({
+            source: 'mesh',
+            level: 'warn',
+            type: 'mesh.enable',
+            message: msg,
+            details: {
+                subnet: this.meshSubnet,
+                expectedAuxSenchoIp: this.senchoIp,
+                actualAuxSenchoIp,
+            },
+        });
+        console.warn(`[Mesh] ${msg}`);
+    }
+
+    /**
+     * Return the subnet and the Sencho aux-address reservation of an existing
+     * `sencho_mesh` network, or null if the network does not exist. The
+     * `auxSenchoIp` field reflects `IPAM.Config[0].AuxiliaryAddresses.sencho`
+     * on the daemon: null when the network pre-dates the reservation, the
+     * pinned IP otherwise. The adopt-existing path uses this to surface a
+     * one-time warn when running on a legacy network that is vulnerable to
+     * IP squatting while Sencho is offline. Docker's inspect endpoint
+     * surfaces 404 for the missing-network case; any other error is
+     * re-raised so the caller can classify it as `attach_failed`.
+     */
+    private async inspectExistingMeshSubnet(): Promise<
+        { subnet: string; auxSenchoIp: string | null } | null
+    > {
         const dc = DockerController.getInstance(NodeRegistry.getInstance().getDefaultNodeId());
         try {
             const info = await dc.inspectNetwork(SENCHO_MESH_NETWORK) as {
-                IPAM?: { Config?: Array<{ Subnet?: string }> };
+                IPAM?: {
+                    Config?: Array<{
+                        Subnet?: string;
+                        AuxiliaryAddresses?: Record<string, string>;
+                    }>;
+                };
             } | undefined;
-            return info?.IPAM?.Config?.[0]?.Subnet ?? null;
+            const cfg = info?.IPAM?.Config?.[0];
+            if (!cfg?.Subnet) return null;
+            return {
+                subnet: cfg.Subnet,
+                auxSenchoIp: cfg.AuxiliaryAddresses?.sencho ?? null,
+            };
         } catch (err) {
             const e = err as { statusCode?: number };
             if (e?.statusCode === 404) return null;
@@ -824,14 +884,27 @@ export class MeshService extends EventEmitter implements MeshForwarderHost {
      * the raw Dockerode error (including the 500 pool-overlap that
      * `classifyMeshNetworkError` recognises) so callers can decide whether
      * to retry on another candidate or bail.
+     *
+     * The IPAM block reserves Sencho's static `<network>+2` via
+     * `AuxiliaryAddresses`. Aux-listed addresses are removed from the
+     * auto-allocatable pool, so Docker refuses to hand `.2` to any other
+     * container while Sencho is offline. Sencho's own attach via
+     * `connectContainerToNetwork({ ipv4Address })` is unaffected because
+     * explicit pins still bind aux-reserved addresses.
      */
     private async createMeshNetwork(subnet: string): Promise<void> {
         const dc = DockerController.getInstance(NodeRegistry.getInstance().getDefaultNodeId());
+        const senchoIp = getSenchoIpFromSubnet(subnet);
         await dc.createNetwork({
             Name: SENCHO_MESH_NETWORK,
             Driver: 'bridge',
             Attachable: true,
-            IPAM: { Config: [{ Subnet: subnet }] },
+            IPAM: {
+                Config: [{
+                    Subnet: subnet,
+                    AuxiliaryAddresses: { sencho: senchoIp },
+                }],
+            },
             Labels: { 'io.sencho.mesh': 'true' },
         });
     }

--- a/docs/features/sencho-mesh.mdx
+++ b/docs/features/sencho-mesh.mdx
@@ -163,7 +163,7 @@ services:
       - SENCHO_MESH_SUBNET=10.42.0.0/24
 ```
 
-Sencho pins itself to `<network address> + 2` (so `10.42.0.2` for the example above; the bridge's `+1` gateway sits between). Each node is configured independently; the alias registry pushes the correct local IP to each node's override file.
+Sencho pins itself to `<network address> + 2` (so `10.42.0.2` for the example above; the bridge's `+1` gateway sits between). The same address is registered as an IPAM auxiliary reservation on `sencho_mesh`, so Docker will refuse to hand it to any other container even while Sencho is offline; meshed workloads without a pinned IP get `<network> + 3` and up. Each node is configured independently; the alias registry pushes the correct local IP to each node's override file.
 
 ## Security and trust boundaries
 

--- a/docs/features/sencho-mesh.mdx
+++ b/docs/features/sencho-mesh.mdx
@@ -163,7 +163,7 @@ services:
       - SENCHO_MESH_SUBNET=10.42.0.0/24
 ```
 
-Sencho pins itself to `<network address> + 2` (so `10.42.0.2` for the example above; the bridge's `+1` gateway sits between). The same address is registered as an IPAM auxiliary reservation on `sencho_mesh`, so Docker will refuse to hand it to any other container even while Sencho is offline; meshed workloads without a pinned IP get `<network> + 3` and up. Each node is configured independently; the alias registry pushes the correct local IP to each node's override file.
+Sencho pins itself to `<network address> + 2` (so `10.42.0.2` for the example above; the bridge's `+1` gateway sits between). The `sencho_mesh` network is created with an IPRange covering the upper half of the subnet, so Docker's auto-allocation hands meshed workloads `<network> + 128` and up by default and never grabs Sencho's static IP while Sencho is offline. Each node is configured independently; the alias registry pushes the correct local IP to each node's override file.
 
 ## Security and trust boundaries
 


### PR DESCRIPTION
## Summary

`sencho_mesh` was created with only `Subnet` in the IPAM block, so Docker freely handed `<network>+2` (Sencho's static IP) to any meshed workload that restarted while Sencho was offline. A real-world hit during a Sencho upgrade had a workload grab `172.30.0.2`, blocking the new container's mesh attach with `Address already in use` and leaving compose in a half-state needing manual `docker network disconnect`.

This PR sets `IPRange` to the upper half of the subnet (e.g. `172.30.0.128/25` for `172.30.0.0/24`) when creating `sencho_mesh`. Docker's auto-allocation pulls from the IPRange, so workload containers without an explicit `ipv4Address` land at `<network>+128` and up and cannot grab Sencho's `.2` by default. Sencho's own attach via `connectContainerToNetwork({ ipv4Address })` still binds `.2` because libnetwork's `RequestAddress(prefAddress)` consults the subnet-wide bitmap (not the IPRange) when the caller supplies a preferred address.

**Why IPRange and not `AuxiliaryAddresses`:** the first iteration of this PR used `AuxiliaryAddresses: { sencho: <ip> }` in the IPAM Config. Independent review challenged the assumption that explicit pins bypass aux reservations; an empirical probe against Docker 29.4.3 confirmed the challenge:

```
$ docker network create --subnet 10.99.99.0/24 --aux-address sencho=10.99.99.2 N
$ docker run --rm --network N --ip 10.99.99.2 alpine:3
docker: Error response from daemon: failed to set up container networking:
Address already in use
```

The aux reservation blocks libnetwork's `RequestAddress` for both auto-allocation and explicit pins. The IPRange approach was tested on the same daemon and behaves correctly:

```
$ docker network create --subnet 10.99.99.0/24 --ip-range 10.99.99.128/25 M
$ docker run --rm --network M --ip 10.99.99.2 alpine:3      # explicit pin OK
$ docker run --rm --network M alpine:3 | grep inet           # auto-allocation
inet 10.99.99.129/24
```

**Adopt-existing path:** when Sencho boots against a `sencho_mesh` whose IPAM block lacks the upper-half IPRange (or carries a different IPRange), the data plane still comes up but a one-time warn fires (`mesh.enable` activity entry at `level: 'warn'` plus a `[Mesh]` console line so `docker logs` surfaces it).

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npm test -- mesh-setup-error-classification` — 27 cases pass (5 new for F-13).
- [x] Empirical Docker 29.4.3 probe (workstation): aux blocks explicit pin (reproduces audit), IPRange permits explicit pin and biases auto-allocation correctly.
- [ ] **Post-release verification (workstation):** pull `saelix/sencho:<next-version>`, spawn fresh after `docker network rm sencho_mesh`, confirm `docker network inspect sencho_mesh` shows `IPRange: <network>+128/25`. Squatter probe: `docker run --rm --network sencho_mesh alpine:3 ip -4 addr show eth0` lands on `<network>+128` or higher, never `.2`.
- [ ] **Post-release verification (workstation, adopt-legacy):** pre-create `sencho_mesh` with subnet only (no IPRange), spawn Sencho, confirm `docker logs sencho 2>&1 | grep 'upper-half IPAM IPRange'` returns the warn line and `/api/health` still reports `mesh.dataPlane.ok=true`.
- [ ] **Post-release verification (cross-node, proxy peer):** drive the adopt-warn case on the proxy peer too, since its `sencho_mesh` pre-dates this change.
- [ ] **Regression check:** F-1 candidate-iteration still picks an open subnet AND emits the IPRange; F-5 boot summary `[Mesh] data plane ok, self attached at ...` still present.

## Gate parity

No tier, role, capability, or feature-flag gates touched. Backend-only change with no frontend counterpart. `git diff --cached --name-only` against the matching grep returns empty, as expected.

## Notes

- `createMeshNetwork` now derives the IPRange via a new `getMeshIpRangeFromSubnet(subnet)` helper. For a `/<n>` subnet it returns `<network>+(2^(31-n))/<n+1>` (the upper half). Restricted to subnets `/8` through `/29`.
- The five test cases cover: explicit-env create payload carries the expected IPRange; candidate-iteration winner carries it; adopt-legacy emits the warn; adopt-already-IPRanged stays silent; TOCTOU 409 race-winner adoption emits the warn (subtle path that reassigns `existingSubnet = raceWinner` in `setupMeshNetwork`).
- One docs sentence in `docs/features/sencho-mesh.mdx` under "Customising the mesh subnet" describing the upper-half IPRange in positive customer-facing terms (no fence-spec, no legacy framing).
- Internal docs map exempt (Directive 26): pure bug fix, no rewiring of nodes or flows.

## History

- `d39ea00` initial fix using `AuxiliaryAddresses` (incorrect per Docker 29.4.3 semantics).
- `c2a7325` pivot to `IPRange` after audit + empirical probe.