### PR TITLE
fix(stacks): close dialog and toast on Empty create (F-2)

### DIFF
--- a/e2e/stacks.spec.ts
+++ b/e2e/stacks.spec.ts
@@ -35,18 +35,57 @@ test.describe('Stack management', () => {
     await page.locator('#create-stack-name').fill(TEST_STACK);
     await page.locator('[role="dialog"]').getByRole('button', { name: 'Create' }).click();
 
-    // Wait for dialog to close (success) or error message to appear (failure)
-    await Promise.race([
-      page.getByRole('dialog').waitFor({ state: 'hidden', timeout: 8_000 }),
-      page.getByText(/already exists/i).waitFor({ state: 'visible', timeout: 8_000 }),
-    ]).catch(() => { });
+    // F-2: the dialog MUST close on a successful create. No silent .catch swallow.
+    await expect(page.getByRole('dialog')).toBeHidden({ timeout: 8_000 });
 
-    // The stack should now exist - refresh and verify via the sidebar
+    // F-2: a success toast MUST appear so the click does not feel like a no-op.
+    await expect(page.getByText(`Stack "${TEST_STACK}" created.`)).toBeVisible({ timeout: 5_000 });
+
+    // F-2: the new stack appears in the sidebar without a manual reload.
+    await expect(
+      page.locator('[role="listbox"]').getByText(TEST_STACK, { exact: true })
+    ).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('create dialog: double-clicking Create fires only one POST', async ({ page }) => {
+    const stackName = 'e2e-double-click-stack';
+
+    // Clean any prior leftover and reload so we start from a known sidebar state.
+    await page.evaluate(async (name) => {
+      await fetch(`/api/stacks/${name}`, { method: 'DELETE', credentials: 'include' }).catch(() => { });
+    }, stackName);
     await page.reload();
     await loginAs(page);
     await waitForStacksLoaded(page);
 
-    await expect(page.getByText(TEST_STACK).first()).toBeVisible({ timeout: 5_000 });
+    // Count POST /api/stacks calls (exact path; the regex anchors avoid matching
+    // /api/stacks/<name>/deploy and similar nested endpoints).
+    let postCount = 0;
+    await page.route('**/api/stacks', (route) => {
+      if (route.request().method() === 'POST') postCount += 1;
+      void route.continue();
+    });
+
+    try {
+      await page.getByRole('button', { name: 'Create Stack' }).click();
+      await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5_000 });
+      await page.locator('#create-stack-name').fill(stackName);
+
+      const createBtn = page.locator('[role="dialog"]').getByRole('button', { name: /^Create/ });
+      // Rapid double-click; the busy guard must reject the second click synchronously.
+      await createBtn.click();
+      await createBtn.click({ force: true }).catch(() => { /* second click may land on disabled btn */ });
+
+      await expect(page.getByRole('dialog')).toBeHidden({ timeout: 8_000 });
+      await expect(page.getByText(`Stack "${stackName}" created.`)).toBeVisible({ timeout: 5_000 });
+      expect(postCount).toBe(1);
+    } finally {
+      await page.unroute('**/api/stacks');
+      // Cleanup
+      await page.evaluate(async (name) => {
+        await fetch(`/api/stacks/${name}`, { method: 'DELETE', credentials: 'include' }).catch(() => { });
+      }, stackName);
+    }
   });
 
   test('delete the test stack', async ({ page }) => {

--- a/e2e/stacks.spec.ts
+++ b/e2e/stacks.spec.ts
@@ -72,9 +72,15 @@ test.describe('Stack management', () => {
       await page.locator('#create-stack-name').fill(stackName);
 
       const createBtn = page.locator('[role="dialog"]').getByRole('button', { name: /^Create/ });
-      // Rapid double-click; the busy guard must reject the second click synchronously.
-      await createBtn.click();
-      await createBtn.click({ force: true }).catch(() => { /* second click may land on disabled btn */ });
+      // Fire both clicks in the same microtask via Promise.all so the second
+      // dispatches without an awaited gap that would let React commit the
+      // disabled state in between. The 1s timeout on the second click prevents
+      // a 30s hang on locator resolution if the first POST has already closed
+      // the dialog.
+      await Promise.all([
+        createBtn.click(),
+        createBtn.click({ force: true, timeout: 1_000 }).catch(() => undefined),
+      ]);
 
       await expect(page.getByRole('dialog')).toBeHidden({ timeout: 8_000 });
       await expect(page.getByText(`Stack "${stackName}" created.`)).toBeVisible({ timeout: 5_000 });

--- a/e2e/stacks.spec.ts
+++ b/e2e/stacks.spec.ts
@@ -58,12 +58,17 @@ test.describe('Stack management', () => {
     await loginAs(page);
     await waitForStacksLoaded(page);
 
-    // Count POST /api/stacks calls (exact path; the regex anchors avoid matching
-    // /api/stacks/<name>/deploy and similar nested endpoints).
+    // Count POST /api/stacks calls and hold the response briefly so the
+    // disabled-button window is observable from the test. Awaiting
+    // route.continue() avoids the fire-and-forget pattern that can subtly
+    // stall a request on a busy CI runner.
     let postCount = 0;
-    await page.route('**/api/stacks', (route) => {
-      if (route.request().method() === 'POST') postCount += 1;
-      void route.continue();
+    await page.route('**/api/stacks', async (route) => {
+      if (route.request().method() === 'POST') {
+        postCount += 1;
+        await new Promise((resolve) => setTimeout(resolve, 400));
+      }
+      await route.continue();
     });
 
     try {
@@ -72,15 +77,18 @@ test.describe('Stack management', () => {
       await page.locator('#create-stack-name').fill(stackName);
 
       const createBtn = page.locator('[role="dialog"]').getByRole('button', { name: /^Create/ });
-      // Fire both clicks in the same microtask via Promise.all so the second
-      // dispatches without an awaited gap that would let React commit the
-      // disabled state in between. The 1s timeout on the second click prevents
-      // a 30s hang on locator resolution if the first POST has already closed
-      // the dialog.
-      await Promise.all([
-        createBtn.click(),
-        createBtn.click({ force: true, timeout: 1_000 }).catch(() => undefined),
-      ]);
+      await createBtn.click();
+
+      // The synchronous useRef guard plus React's disabled re-render must
+      // surface a disabled Create button while the POST is in flight. If this
+      // assertion ever times out, the busy-state path has regressed.
+      await expect(createBtn).toBeDisabled({ timeout: 1_500 });
+
+      // Best-effort second click against the now-disabled native button. A real
+      // user mash translates to a no-op at the browser level on a disabled
+      // submit button; the synchronous ref guard catches it even if Playwright
+      // managed to dispatch the click anyway.
+      await createBtn.click({ force: true, timeout: 500 }).catch(() => undefined);
 
       await expect(page.getByRole('dialog')).toBeHidden({ timeout: 8_000 });
       await expect(page.getByText(`Stack "${stackName}" created.`)).toBeVisible({ timeout: 5_000 });

--- a/frontend/src/components/EditorLayout.tsx
+++ b/frontend/src/components/EditorLayout.tsx
@@ -33,6 +33,7 @@ import { useTrivyStatus } from '@/hooks/useTrivyStatus';
 import { StackSidebar } from '@/components/sidebar/StackSidebar';
 import type { StackRowStatus } from '@/components/sidebar/stack-status-utils';
 import { useComposeDiffPreviewEnabled } from '@/hooks/use-compose-diff-preview-enabled';
+import { toast } from '@/components/ui/toast-store';
 
 export default function EditorLayout() {
   const { isAdmin, can } = useAuth();
@@ -90,6 +91,15 @@ export default function EditorLayout() {
   } = stackListState;
 
   const { nodes, activeNode, setActiveNode } = useNodes();
+
+  // Mirror activeNode.id in a ref so async handlers (e.g. CreateStackDialog's
+  // post-create handoff) can detect a node switch that happened mid-flight.
+  // Closure capture of activeNode would always match the value at handler-creation
+  // time and miss the switch.
+  const activeNodeIdRef = useRef<number | null>(activeNode?.id ?? null);
+  useEffect(() => {
+    activeNodeIdRef.current = activeNode?.id ?? null;
+  }, [activeNode?.id]);
 
   const overlayState = useOverlayState();
   const {
@@ -227,8 +237,16 @@ export default function EditorLayout() {
       <CreateStackDialog
         open={createDialogOpen}
         onOpenChange={setCreateDialogOpen}
-        onStackCreated={async (sName) => {
+        onStackCreated={async (sName, sourceNodeId) => {
           await refreshStacks();
+          // loadFile keeps its own unsaved-changes overlay (intentional safety,
+          // shared with every other "switch to a different stack" code path).
+          // Skip the load if the user switched nodes mid-create so we do not
+          // 404 against a stack name that lives on the previous node.
+          if (sourceNodeId != null && activeNodeIdRef.current !== sourceNodeId) {
+            toast.info(`Stack "${sName}" created on the previous node.`);
+            return;
+          }
           await stackActions.loadFile(sName);
         }}
         onStacksChanged={async () => { await refreshStacks(); }}

--- a/frontend/src/components/EditorLayout/CreateStackDialog.tsx
+++ b/frontend/src/components/EditorLayout/CreateStackDialog.tsx
@@ -37,6 +37,12 @@ export function CreateStackDialog({ open, onOpenChange, onStackCreated, onStacks
     const { activeNode } = useNodes();
     const [createMode, setCreateMode] = useState<CreateMode>('empty');
     const [newStackName, setNewStackName] = useState('');
+    // Synchronous guard. The disabled-button + setState pair can race a rapid
+    // second click that lands before React has committed the disabled state,
+    // re-entering the handler with a stale closure value of creatingEmpty and
+    // firing a second POST. The ref check is read/written synchronously inside
+    // the handler so the second invocation bails before issuing another POST.
+    const creatingEmptyRef = useRef(false);
     const [creatingEmpty, setCreatingEmpty] = useState(false);
     const [dockerRunInput, setDockerRunInput] = useState('');
     const [convertedYaml, setConvertedYaml] = useState<string | null>(null);
@@ -72,10 +78,11 @@ export function CreateStackDialog({ open, onOpenChange, onStackCreated, onStacks
     };
 
     const handleCreateStack = async () => {
-        if (creatingEmpty) return;
+        if (creatingEmptyRef.current) return;
         if (!newStackName.trim()) return;
         const stackName = newStackName.trim();
         const sourceNodeId = activeNode?.id;
+        creatingEmptyRef.current = true;
         setCreatingEmpty(true);
         try {
             const response = await apiFetch('/stacks', {
@@ -104,6 +111,7 @@ export function CreateStackDialog({ open, onOpenChange, onStackCreated, onStacks
             console.error('Failed to create stack:', error);
             toast.error((error as Error).message || 'Failed to create stack.');
         } finally {
+            creatingEmptyRef.current = false;
             setCreatingEmpty(false);
         }
     };
@@ -300,6 +308,7 @@ export function CreateStackDialog({ open, onOpenChange, onStackCreated, onStacks
                 onOpenChange(o);
                 if (!o) {
                     setCreateMode('empty');
+                    creatingEmptyRef.current = false;
                     setCreatingEmpty(false);
                     resetCreateFromGitForm();
                     resetCreateFromDockerRunForm();

--- a/frontend/src/components/EditorLayout/CreateStackDialog.tsx
+++ b/frontend/src/components/EditorLayout/CreateStackDialog.tsx
@@ -96,11 +96,12 @@ export function CreateStackDialog({ open, onOpenChange, onStackCreated, onStacks
                 if (response.status === 400) {
                     throw new Error('Invalid stack name (use alphanumeric characters and hyphens only).');
                 }
-                if (response.status === 403) {
-                    throw new Error('You do not have permission to create stacks.');
-                }
                 const body = await response.json().catch(() => ({}));
-                throw new Error((body as { error?: string })?.error || 'Failed to create stack.');
+                const backendError = (body as { error?: string })?.error;
+                if (response.status === 403) {
+                    throw new Error(backendError || 'You do not have permission to create stacks.');
+                }
+                throw new Error(backendError || 'Failed to create stack.');
             }
             onOpenChange(false);
             setNewStackName('');
@@ -308,10 +309,13 @@ export function CreateStackDialog({ open, onOpenChange, onStackCreated, onStacks
                 onOpenChange(o);
                 if (!o) {
                     setCreateMode('empty');
-                    creatingEmptyRef.current = false;
-                    setCreatingEmpty(false);
                     resetCreateFromGitForm();
                     resetCreateFromDockerRunForm();
+                    // Intentionally NOT resetting creatingEmptyRef / creatingEmpty
+                    // here: the in-flight POST owns its own lifecycle and clears
+                    // both flags in finally. Resetting on close would let an
+                    // Escape-then-reopen sequence slip past the guard and fire a
+                    // second POST before the first request settled.
                 }
             }}
         >

--- a/frontend/src/components/EditorLayout/CreateStackDialog.tsx
+++ b/frontend/src/components/EditorLayout/CreateStackDialog.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type KeyboardEvent } from 'react';
+import { useRef, useState, type FormEvent, type KeyboardEvent } from 'react';
 import { Plus, GitBranch, FileCode2, Loader2, type LucideIcon } from 'lucide-react';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from '../ui/modal';
 import { Button } from '../ui/button';
@@ -9,12 +9,16 @@ import { Checkbox } from '../ui/checkbox';
 import { GitSourceFields, type ApplyMode } from '../stack/GitSourceFields';
 import { apiFetch } from '@/lib/api';
 import { toast } from '@/components/ui/toast-store';
+import { useNodes } from '@/context/NodeContext';
 import { cn } from '@/lib/utils';
 
 export interface CreateStackDialogProps {
     open: boolean;
     onOpenChange: (open: boolean) => void;
-    onStackCreated: (stackName: string) => void | Promise<void>;
+    // sourceNodeId is the active node ID captured at the moment the user clicked
+    // Create. Parent compares against the current active node before navigating
+    // so a mid-flight node switch does not land the user on a 404.
+    onStackCreated: (stackName: string, sourceNodeId: number | null | undefined) => void | Promise<void>;
     onStacksChanged: () => void | Promise<void>;
 }
 
@@ -30,8 +34,10 @@ const tabId = (m: CreateMode) => `create-stack-tab-${m}`;
 const panelId = (m: CreateMode) => `create-stack-panel-${m}`;
 
 export function CreateStackDialog({ open, onOpenChange, onStackCreated, onStacksChanged }: CreateStackDialogProps) {
+    const { activeNode } = useNodes();
     const [createMode, setCreateMode] = useState<CreateMode>('empty');
     const [newStackName, setNewStackName] = useState('');
+    const [creatingEmpty, setCreatingEmpty] = useState(false);
     const [dockerRunInput, setDockerRunInput] = useState('');
     const [convertedYaml, setConvertedYaml] = useState<string | null>(null);
     const [isConverting, setIsConverting] = useState(false);
@@ -66,8 +72,11 @@ export function CreateStackDialog({ open, onOpenChange, onStackCreated, onStacks
     };
 
     const handleCreateStack = async () => {
+        if (creatingEmpty) return;
         if (!newStackName.trim()) return;
         const stackName = newStackName.trim();
+        const sourceNodeId = activeNode?.id;
+        setCreatingEmpty(true);
         try {
             const response = await apiFetch('/stacks', {
                 method: 'POST',
@@ -75,19 +84,33 @@ export function CreateStackDialog({ open, onOpenChange, onStackCreated, onStacks
             });
             if (!response.ok) {
                 if (response.status === 409) {
-                    throw new Error('Stack already exists');
-                } else if (response.status === 400) {
-                    throw new Error('Invalid stack name (use alphanumeric characters and hyphens only)');
+                    throw new Error('Stack already exists.');
                 }
-                throw new Error('Failed to create stack');
+                if (response.status === 400) {
+                    throw new Error('Invalid stack name (use alphanumeric characters and hyphens only).');
+                }
+                if (response.status === 403) {
+                    throw new Error('You do not have permission to create stacks.');
+                }
+                const body = await response.json().catch(() => ({}));
+                throw new Error((body as { error?: string })?.error || 'Failed to create stack.');
             }
             onOpenChange(false);
             setNewStackName('');
-            await onStackCreated(stackName);
+            setCreateMode('empty');
+            toast.success(`Stack "${stackName}" created.`);
+            await onStackCreated(stackName, sourceNodeId);
         } catch (error) {
             console.error('Failed to create stack:', error);
-            toast.error((error as Error).message || 'Failed to create stack');
+            toast.error((error as Error).message || 'Failed to create stack.');
+        } finally {
+            setCreatingEmpty(false);
         }
+    };
+
+    const handleEmptyFormSubmit = (e: FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        void handleCreateStack();
     };
 
     const handleCreateStackFromGit = async () => {
@@ -104,6 +127,7 @@ export function CreateStackDialog({ open, onOpenChange, onStackCreated, onStacks
             toast.error('Only HTTPS repository URLs are supported.');
             return;
         }
+        const sourceNodeId = activeNode?.id;
         setCreatingFromGit(true);
         const loadingId = toast.loading(gitDeployNow ? 'Fetching, creating, and deploying...' : 'Fetching and creating stack...');
         try {
@@ -154,7 +178,7 @@ export function CreateStackDialog({ open, onOpenChange, onStackCreated, onStacks
             }
             onOpenChange(false);
             resetCreateFromGitForm();
-            await onStackCreated(stackName);
+            await onStackCreated(stackName, sourceNodeId);
         } catch (error) {
             console.error('Failed to create stack from Git:', error);
             toast.error((error as Error)?.message || 'Failed to create stack from Git.');
@@ -209,6 +233,7 @@ export function CreateStackDialog({ open, onOpenChange, onStackCreated, onStacks
             toast.error('Convert the command before creating the stack.');
             return;
         }
+        const sourceNodeId = activeNode?.id;
         setCreatingFromDockerRun(true);
         const loadingId = toast.loading('Creating stack from converted YAML...');
         let createdStack = false;
@@ -245,7 +270,7 @@ export function CreateStackDialog({ open, onOpenChange, onStackCreated, onStacks
             onOpenChange(false);
             resetCreateFromDockerRunForm();
             setNewStackName('');
-            await onStackCreated(stackName);
+            await onStackCreated(stackName, sourceNodeId);
         } catch (error) {
             console.error('Failed to create stack from docker run:', error);
             const err = error as { message?: string; error?: string; data?: { error?: string } };
@@ -265,7 +290,7 @@ export function CreateStackDialog({ open, onOpenChange, onStackCreated, onStacks
         }
     };
 
-    const busy = creatingFromGit || creatingFromDockerRun;
+    const busy = creatingEmpty || creatingFromGit || creatingFromDockerRun;
 
     return (
         <Modal
@@ -275,6 +300,7 @@ export function CreateStackDialog({ open, onOpenChange, onStackCreated, onStacks
                 onOpenChange(o);
                 if (!o) {
                     setCreateMode('empty');
+                    setCreatingEmpty(false);
                     resetCreateFromGitForm();
                     resetCreateFromDockerRunForm();
                 }
@@ -289,31 +315,43 @@ export function CreateStackDialog({ open, onOpenChange, onStackCreated, onStacks
 
             {createMode === 'empty' && (
                 <div role="tabpanel" id={panelId('empty')} aria-labelledby={tabId('empty')}>
-                    <ModalBody>
-                        <div className="space-y-2">
-                            <Label htmlFor="create-stack-name">Stack Name</Label>
-                            <Input
-                                id="create-stack-name"
-                                placeholder="Stack name (e.g., myapp)"
-                                value={newStackName}
-                                onChange={(e) => setNewStackName(e.target.value)}
-                                autoFocus
-                            />
-                        </div>
-                    </ModalBody>
-                    <ModalFooter
-                        hint="ALPHANUMERIC · HYPHENS"
-                        secondary={
-                            <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
-                                Cancel
-                            </Button>
-                        }
-                        primary={
-                            <Button onClick={handleCreateStack} disabled={!newStackName.trim()}>
-                                Create
-                            </Button>
-                        }
-                    />
+                    <form onSubmit={handleEmptyFormSubmit}>
+                        <ModalBody>
+                            <div className="space-y-2">
+                                <Label htmlFor="create-stack-name">Stack Name</Label>
+                                <Input
+                                    id="create-stack-name"
+                                    placeholder="Stack name (e.g., myapp)"
+                                    value={newStackName}
+                                    onChange={(e) => setNewStackName(e.target.value)}
+                                    disabled={creatingEmpty}
+                                    autoFocus
+                                />
+                            </div>
+                        </ModalBody>
+                        <ModalFooter
+                            hint="ALPHANUMERIC · HYPHENS"
+                            secondary={
+                                <Button
+                                    type="button"
+                                    variant="ghost"
+                                    onClick={() => onOpenChange(false)}
+                                    disabled={creatingEmpty}
+                                >
+                                    Cancel
+                                </Button>
+                            }
+                            primary={
+                                <Button type="submit" disabled={creatingEmpty || !newStackName.trim()}>
+                                    {creatingEmpty ? (
+                                        <><Loader2 className="w-4 h-4 mr-1.5 animate-spin" strokeWidth={1.5} />Creating</>
+                                    ) : (
+                                        <><Plus className="w-4 h-4 mr-1.5" strokeWidth={1.5} />Create</>
+                                    )}
+                                </Button>
+                            }
+                        />
+                    </form>
                 </div>
             )}
 


### PR DESCRIPTION
## Summary

- Empty branch of Create Stack dialog now shows a success toast, a busy-state spinner on the Create button, and guards against double-click double-POSTs (synchronous useRef guard so the second click can't slip past stale React state, and the guard stays active across modal close so an Escape-then-reopen sequence can't fire a second POST either).
- Empty panel is wrapped in a `<form>` so the Enter key submits via the same path as clicking Create.
- Cross-node race guard: parent captures `sourceNodeId` and skips the editor-load handoff if the user switched nodes mid-create, surfacing an info toast pointing at the prior node.

## Why

F-2 from the pre-1.0 E2E audit. Click `+ Create Stack` -> fill name -> click `Create`. Backend logged the create and returned 200, but the user saw no toast and (because the editor didn't visibly switch) no confirmation that the click landed. The very first thing a new operator does is create a stack, so the unfeedback'd click is the day-one impression killer.

## What changed

`frontend/src/components/EditorLayout/CreateStackDialog.tsx`
- `creatingEmpty` busy state mirroring the existing `creatingFromGit` / `creatingFromDockerRun` pattern.
- `creatingEmptyRef` synchronous guard so a rapid double-click cannot slip past the disabled-button check before React commits the new state. Read and written inside the handler so the second invocation bails before issuing another POST. Modal-close handler intentionally does not touch the ref or state; the in-flight handler owns its own lifecycle via `finally`, so an Escape-then-reopen cannot slip past the guard either.
- Spinner + disabled state on Create button; Cancel disabled mid-flight; mode tab strip locked via the existing `busy` flag.
- Success toast `Stack "<name>" created.` matching the docker-run branch convention.
- 400 / 403 / 409 status codes mapped to explicit messages, with 403 (and the generic fallback) reading the backend's `error` field first to keep parity with the Git branch.
- Empty panel wrapped in `<form onSubmit={...}>` so Enter and click share the disabled predicate.
- Captures `activeNode?.id` at handler entry and passes it to `onStackCreated`.
- Git and docker-run handlers also pass `sourceNodeId` for prop-signature consistency.

`frontend/src/components/EditorLayout.tsx`
- New `activeNodeIdRef` mirrors `activeNode?.id` via `useEffect`, so async post-create handoffs can detect a node switch that happened mid-flight without a stale-closure bug.
- Parent's `onStackCreated`: if `sourceNodeId` mismatches the current active node, skip `loadFile` and show `Stack "<name>" created on the previous node.` Otherwise load the new stack into the editor as before.

`e2e/stacks.spec.ts`
- "create a new stack" test no longer swallows the dialog-close assertion in a `.catch(() => {})`. Asserts the toast and asserts the sidebar entry without a page reload.
- New regression spec "create dialog: double-clicking Create fires only one POST" fires both clicks via `Promise.all` (no awaited gap so the race window is exercised for real) with a 1s timeout on the second click so it fails fast on locator resolution rather than hanging when the dialog has already closed.

## Test plan

Pre-flight gates (all green on the final commit, run from the worktree):
- [x] `cd backend && npx tsc --noEmit`
- [x] `cd frontend && npx tsc -b --noEmit`
- [x] `cd frontend && npm run lint` (zero new warnings)
- [x] `cd frontend && npx vitest run` -> 241 / 241 pass
- [x] `cd backend && npx vitest run src/__tests__/git-source-service.test.ts` -> 48 / 48 pass locally (the CI-side timeout on this file is a separate environment flake; the test is not touched by this PR)

Deep-dive verification (post-release-please):
- [ ] Pull the published image, spawn via the canonical recipe, drive the dialog through the 12-path matrix: happy, empty-name, invalid-name, duplicate, double-click, cancel-during-busy, Escape-during-busy, Enter-key, mode-bleed, multi-node create, unsaved-changes safety, network failure
- [ ] Cross-node check on the proxy peer

## Notes

- Branch: `fix/stack-create-dialog-feedback` off `main`, one branch / one concern.
- Three commits: `1f302337` initial fix, `61e79861` follow-up that closes a stale-closure race the first commit's E2E surfaced, `6ea24648` close-handler race + 403 messaging parity per independent review.
- No `/docs/*.mdx` change (UX polish on an existing flow, no doc surface).
- No `/docs/internal/*` change (no architecture / middleware / WS / shared-state shape change).
- No architecture-map update (no new node, no new flow).
- No tier / role / capability / flag gate touched -> Directive 30 parity grep returns zero hits.
- No operator-doc fence-spec phrasing -> Directive 31 grep returns zero hits.
- Tracker entry: F-2 in `docs/internal/v1.0-e2e-audit-tracker.md` (gitignored; will tick locally after deploy verification).