### PR TITLE
chore(stacks): explicit stack:read RBAC on list endpoints

### DIFF
--- a/backend/src/routes/stacks.ts
+++ b/backend/src/routes/stacks.ts
@@ -148,6 +148,7 @@ stacksRouter.param('stackName', (req, res, next, stackName) => {
 });
 
 stacksRouter.get('/', async (req: Request, res: Response) => {
+  if (!requirePermission(req, res, 'stack:read')) return;
   try {
     const stacks = await FileSystemService.getInstance(req.nodeId).getStacks();
     res.json(stacks);
@@ -157,6 +158,7 @@ stacksRouter.get('/', async (req: Request, res: Response) => {
 });
 
 stacksRouter.get('/statuses', async (req: Request, res: Response) => {
+  if (!requirePermission(req, res, 'stack:read')) return;
   try {
     const result = await CacheService.getInstance().getOrFetch(
       `stack-statuses:${req.nodeId}`,


### PR DESCRIPTION
## Summary
- Adds explicit \`requirePermission('stack:read')\` on \`GET /api/stacks\` and \`GET /api/stacks/statuses\`. Every other endpoint in this router already declares its permission; these two were the only silent ones.
- Resolves the L-5 finding from the stack-management audit.

## Implementation
Two-line change. The gate is a no-op for every existing role (admin, node-admin, deployer, viewer, auditor all hold \`stack:read\`), so runtime behavior is identical today. The value is forward-looking: a future role or an Admiral per-stack scoped grant without \`stack:read\` will now be rejected at this endpoint without needing another patch, and the permission model is uniformly declared for audit-readability.

## Test plan
- [x] No new test added: no current role fails the gate, so behavioral assertions would be trivially identical to existing tests. The stack suite already exercises both endpoints via every test that lists stacks; 65 tests pass.
- [x] \`tsc --noEmit\` clean.
- [x] Targeted: \`stack-management.test.ts\`, \`stack-files-routes.test.ts\`, \`stack-actions-missing-stack.test.ts\` all green.

## Notes
- No tier-gate change; Directive 30 not triggered.
- No new dependencies.