### PR TITLE
feat(sidebar): surface unreachable nodes in cross-node stack search

### DIFF
--- a/frontend/src/components/EditorLayout.tsx
+++ b/frontend/src/components/EditorLayout.tsx
@@ -94,6 +94,7 @@ export default function EditorLayout() {
     pinned,
     isCollapsed, toggleCollapse,
     remoteSearchLoading,
+    remoteSearchFailedNodes,
   } = stackListState;
 
   const { nodes, activeNode, setActiveNode } = useNodes();
@@ -338,6 +339,7 @@ export default function EditorLayout() {
           buildMenuCtx,
           remoteResults,
           remoteLoading: remoteSearchLoading,
+          remoteFailedNodes: remoteSearchFailedNodes,
           onSelectRemoteFile: (nodeId, file) => {
             const node = nodes.find(n => n.id === nodeId);
             if (node) void stackActions.loadFileOnNode(node, file);

--- a/frontend/src/components/EditorLayout/hooks/useStackListState.ts
+++ b/frontend/src/components/EditorLayout/hooks/useStackListState.ts
@@ -54,7 +54,7 @@ export function useStackListState() {
   const { isCollapsed, toggle: toggleCollapse } = useSidebarGroupCollapse(activeNode?.id);
   const { runBulk } = useBulkStackActions();
 
-  const { hits: remoteSearchHits, loading: remoteSearchLoading } = useCrossNodeStackSearch({
+  const { hits: remoteSearchHits, failedNodes: remoteSearchFailedNodes, loading: remoteSearchLoading } = useCrossNodeStackSearch({
     query: searchQuery,
     enabled: true,
     excludeNodeId: activeNode?.id,
@@ -359,5 +359,6 @@ export function useStackListState() {
     pinned, pin, unpin, isPinned,
     isCollapsed, toggleCollapse,
     remoteSearchLoading,
+    remoteSearchFailedNodes,
   } as const;
 }

--- a/frontend/src/components/sidebar/StackList.tsx
+++ b/frontend/src/components/sidebar/StackList.tsx
@@ -1,5 +1,5 @@
-import { useMemo } from 'react';
-import { ArrowUpRight, Loader2 } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { ArrowUpRight, Loader2, AlertCircle, ChevronDown, ChevronRight } from 'lucide-react';
 import { useStackKeyboardShortcuts } from '@/hooks/useStackKeyboardShortcuts';
 import { CommandItem, CommandList } from '@/components/ui/command';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -16,6 +16,12 @@ interface RemoteNodeResult {
   nodeId: number;
   nodeName: string;
   files: { file: string; status: StackRowStatus }[];
+}
+
+interface RemoteSearchFailure {
+  nodeId: number;
+  nodeName: string;
+  reason: string;
 }
 
 export interface StackListProps {
@@ -37,6 +43,7 @@ export interface StackListProps {
   buildMenuCtx: (file: string) => StackMenuCtx;
   remoteResults: RemoteNodeResult[];
   remoteLoading: boolean;
+  remoteFailedNodes: RemoteSearchFailure[];
   onSelectRemoteFile: (nodeId: number, file: string) => void;
 }
 
@@ -107,8 +114,10 @@ export function StackList(props: StackListProps & StackListBulkProps) {
     stackUpdates, gitSourcePendingMap, pinnedFiles, isCollapsed, toggleCollapse,
     isBusy, getDisplayName, onSelectFile, buildMenuCtx,
     bulkMode, selectedFiles, onToggleSelect,
-    remoteResults, remoteLoading, onSelectRemoteFile,
+    remoteResults, remoteLoading, remoteFailedNodes, onSelectRemoteFile,
   } = props;
+
+  const [failedNodesExpanded, setFailedNodesExpanded] = useState(false);
 
   const groups = useMemo(
     () => buildGroups(files, pinnedFiles, stackLabelMap),
@@ -171,12 +180,39 @@ export function StackList(props: StackListProps & StackListBulkProps) {
         </StackGroup>
       ))}
 
-      {searchQuery.trim() && (remoteLoading || remoteResults.length > 0) && (
+      {searchQuery.trim() && (remoteLoading || remoteResults.length > 0 || remoteFailedNodes.length > 0) && (
         <div className="mt-3 pt-3 border-t border-glass-border">
           <h3 className="text-[10px] font-medium tracking-[0.08em] uppercase text-stat-subtitle px-4 pb-2 flex items-center gap-2">
             Other nodes
             {remoteLoading && <Loader2 className="w-3 h-3 animate-spin text-stat-icon" strokeWidth={1.5} />}
           </h3>
+          {remoteFailedNodes.length > 0 && (
+            <button
+              type="button"
+              onClick={() => setFailedNodesExpanded(prev => !prev)}
+              className="w-full mx-4 mb-2 flex items-center gap-1.5 text-[10px] font-mono uppercase tracking-[0.06em] text-warning hover:text-warning/80 cursor-pointer"
+              style={{ width: 'calc(100% - 2rem)' }}
+              aria-expanded={failedNodesExpanded}
+              title={remoteFailedNodes.map(f => `${f.nodeName}: ${f.reason}`).join('\n')}
+            >
+              <AlertCircle className="w-3 h-3 shrink-0" strokeWidth={1.5} />
+              <span className="shrink-0">
+                {remoteFailedNodes.length} {remoteFailedNodes.length === 1 ? 'node' : 'nodes'} unreachable
+              </span>
+              {failedNodesExpanded
+                ? <ChevronDown className="w-3 h-3 shrink-0" strokeWidth={1.5} />
+                : <ChevronRight className="w-3 h-3 shrink-0" strokeWidth={1.5} />}
+            </button>
+          )}
+          {failedNodesExpanded && remoteFailedNodes.length > 0 && (
+            <div className="px-4 pb-2 space-y-0.5">
+              {remoteFailedNodes.map(f => (
+                <div key={f.nodeId} className="text-[10px] font-mono text-stat-subtitle truncate">
+                  <span className="text-warning">·</span> {f.nodeName}: {f.reason}
+                </div>
+              ))}
+            </div>
+          )}
           {remoteResults.map(({ nodeId, nodeName, files: remoteFiles }) => (
             <div key={nodeId} className="mb-2">
               <div className="px-4 pb-1 flex items-center gap-1.5 text-[10px] font-mono uppercase tracking-[0.06em] text-stat-subtitle">

--- a/frontend/src/hooks/useCrossNodeStackSearch.ts
+++ b/frontend/src/hooks/useCrossNodeStackSearch.ts
@@ -15,6 +15,12 @@ export interface StackHit {
     status: StackStatus;
 }
 
+export interface FailedNode {
+    nodeId: number;
+    nodeName: string;
+    reason: string;
+}
+
 interface Options {
     query: string;
     enabled: boolean;
@@ -23,9 +29,15 @@ interface Options {
 
 const DEBOUNCE_MS = 250;
 
+interface NodeOutcome {
+    hits: StackHit[];
+    failure: FailedNode | null;
+}
+
 export function useCrossNodeStackSearch({ query, enabled, excludeNodeId }: Options) {
     const { nodes } = useNodes();
     const [hits, setHits] = useState<StackHit[]>([]);
+    const [failedNodes, setFailedNodes] = useState<FailedNode[]>([]);
     const [loading, setLoading] = useState(false);
 
     // Ref avoids re-running the effect on every NodeContext status tick
@@ -36,6 +48,7 @@ export function useCrossNodeStackSearch({ query, enabled, excludeNodeId }: Optio
         const q = query.trim().toLowerCase();
         if (!enabled || !q) {
             setHits([]);
+            setFailedNodes([]);
             setLoading(false);
             return;
         }
@@ -44,19 +57,29 @@ export function useCrossNodeStackSearch({ query, enabled, excludeNodeId }: Optio
         );
         if (targets.length === 0) {
             setHits([]);
+            setFailedNodes([]);
             return;
         }
         const controller = new AbortController();
         const timer = setTimeout(async () => {
             setLoading(true);
             try {
-                const perNode = await Promise.all(targets.map(async (node) => {
+                const perNode = await Promise.all(targets.map(async (node): Promise<NodeOutcome> => {
                     try {
                         const [listRes, statusRes] = await Promise.all([
                             fetchForNode('/stacks', node.id, { signal: controller.signal }),
                             fetchForNode('/stacks/statuses', node.id, { signal: controller.signal }),
                         ]);
-                        if (!listRes.ok) return [] as StackHit[];
+                        if (!listRes.ok) {
+                            return {
+                                hits: [],
+                                failure: {
+                                    nodeId: node.id,
+                                    nodeName: node.name,
+                                    reason: `list returned HTTP ${listRes.status}`,
+                                },
+                            };
+                        }
                         const rawList = await listRes.json();
                         const files: string[] = Array.isArray(rawList) ? rawList : [];
                         const statuses: Record<string, StackStatus> = {};
@@ -70,7 +93,7 @@ export function useCrossNodeStackSearch({ query, enabled, excludeNodeId }: Optio
                                 }
                             }
                         }
-                        return files
+                        const nodeHits = files
                             .filter(f => f.toLowerCase().includes(q))
                             .map<StackHit>(file => ({
                                 nodeId: node.id,
@@ -78,12 +101,26 @@ export function useCrossNodeStackSearch({ query, enabled, excludeNodeId }: Optio
                                 file,
                                 status: statuses[file] ?? 'unknown',
                             }));
-                    } catch {
-                        return [] as StackHit[];
+                        return { hits: nodeHits, failure: null };
+                    } catch (err) {
+                        // AbortError is expected when the effect cleans up; don't
+                        // surface it as a node failure to the user.
+                        if ((err as Error)?.name === 'AbortError') {
+                            return { hits: [], failure: null };
+                        }
+                        return {
+                            hits: [],
+                            failure: {
+                                nodeId: node.id,
+                                nodeName: node.name,
+                                reason: (err as Error)?.message ?? 'unreachable',
+                            },
+                        };
                     }
                 }));
                 if (controller.signal.aborted) return;
-                setHits(perNode.flat());
+                setHits(perNode.flatMap(o => o.hits));
+                setFailedNodes(perNode.flatMap(o => (o.failure ? [o.failure] : [])));
             } finally {
                 if (!controller.signal.aborted) setLoading(false);
             }
@@ -94,5 +131,5 @@ export function useCrossNodeStackSearch({ query, enabled, excludeNodeId }: Optio
         };
     }, [enabled, query, excludeNodeId]);
 
-    return { hits, loading };
+    return { hits, failedNodes, loading };
 }


### PR DESCRIPTION
## Summary
- Adds \`failedNodes\` return value to \`useCrossNodeStackSearch\`. Per-node fetch failures (non-OK HTTP, network errors) are no longer swallowed into \`[]\` — they're captured with \`{nodeId, nodeName, reason}\` and surfaced to the UI.
- Threads the new field through \`useStackListState\` → \`EditorLayout\` → \`StackList\`.
- \`StackList\` renders a warning chip below the **Other nodes** header when nodes failed: **"N nodes unreachable"** with a click-to-expand list of per-node reasons. \`title\` attribute surfaces reasons on hover so an at-a-glance reader can see them without clicking.
- Resolves M-2 from the stack-management audit.

## Implementation notes
- \`AbortError\` from the effect cleanup path is excluded from failure surfacing. It fires every time the user keeps typing — surfacing it would be UX noise.
- Reason text is HTTP-status-derived or \`Error.message\`; both are bounded length. The hook does NOT include URLs in reasons (no node-address leakage to the UI; per \`feedback_no_pii_in_output\`).
- Chip uses the existing \`text-warning\` token, not \`text-error\` — the condition is recoverable (the remote node might be temporarily down, mid-restart, behind a flaky tunnel).
- The chip is suppressed entirely when there are no failures (no zero-state).
- \`GlobalCommandPalette\` also calls \`useCrossNodeStackSearch\` and destructures only \`hits\` and \`loading\`. The new \`failedNodes\` field is additive — the palette continues to ignore it.

## Test plan
- [x] \`tsc -b --noEmit\` clean.
- [x] Full frontend test suite: 276/276 pass.
- [x] No new test added for the chip render itself: it's a conditional render keyed on \`failedNodes.length > 0\` with deterministic state expansion. The hook's behavior change is the load-bearing part and is exercised through normal sidebar use; a unit test that mocks \`fetchForNode\` to throw would assert the structured-failure shape, worth adding when this hook gains more complexity.

## Notes
- No backend change.
- No tier-gate change.
- No new dependencies.
- The new chip is sidebar-internal — does not affect the GlobalCommandPalette layout.