### PR TITLE
chore(deps): bump containerd to v2.2.4 to clear CVE-2026-46680

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -144,6 +144,13 @@ RUN cp vendor.mod go.mod && cp vendor.sum go.sum && \
 # v0.29.0. The go get step below bumps otel to v1.43.0 to resolve
 # CVE-2026-39883 (BSD kenv) and CVE-2026-39882 (OTLP response OOM) so that
 # the compose binary scans completely clean.
+#
+# Compose v5.1.3 also pins github.com/containerd/containerd/v2 v2.2.3, which
+# carries CVE-2026-46680 (runAsNonRoot evasion in containerd's runtime
+# executor). The same go get step bumps containerd/v2 to v2.2.4 to clear it.
+# v2.2.3 to v2.2.4 is a patch-level fix; the release notes name CVE-2026-46680
+# as the headline item. The vulnerable code path is daemon-side and not reached
+# by compose at all, so this is defense-in-depth rather than a live exposure.
 # Base image pinned by digest (same image as cli-builder above) so both
 # source builds share an identical, immutable Go toolchain.
 FROM --platform=$BUILDPLATFORM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS compose-builder
@@ -166,8 +173,9 @@ WORKDIR /src/docker-compose
 RUN mkdir -p /build
 
 # Patch otel/sdk and exporters from v1.42.0 → v1.43.0 to clear CVE-2026-39883
-# and CVE-2026-39882. This is a targeted security bump; otel 1.42→1.43 is a
-# patch-level fix with no breaking API changes.
+# and CVE-2026-39882, and bump containerd/v2 from v2.2.3 → v2.2.4 to clear
+# CVE-2026-46680. Both are targeted patch-level security bumps with no
+# breaking API changes.
 RUN --mount=type=cache,id=go-mod,sharing=locked,target=/go/pkg/mod \
     go get go.opentelemetry.io/otel@v1.43.0 \
            go.opentelemetry.io/otel/sdk@v1.43.0 \
@@ -178,7 +186,8 @@ RUN --mount=type=cache,id=go-mod,sharing=locked,target=/go/pkg/mod \
            go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.43.0 \
            go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp@v1.43.0 \
            go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc@v1.43.0 \
-           go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp@v1.43.0 && \
+           go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp@v1.43.0 \
+           github.com/containerd/containerd/v2@v2.2.4 && \
     go mod tidy
 
 # Build target is ./cmd (the package main with plugin.Run), per docker/compose's

--- a/security/vex/sencho.openvex.json
+++ b/security/vex/sencho.openvex.json
@@ -4,8 +4,8 @@
   "author": "Studio Saelix",
   "role": "Vendor",
   "timestamp": "2026-05-18T00:00:00Z",
-  "last_updated": "2026-05-22T00:00:00Z",
-  "version": 6,
+  "last_updated": "2026-05-24T00:00:00Z",
+  "version": 7,
   "statements": [
     {
       "vulnerability": {
@@ -51,21 +51,6 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "The race condition is in the Docker Engine daemon-side bind-mount resolution path that backs `docker cp`, where a concurrent rename can redirect a copy operation onto a host path. docker-compose v5.1.3 statically bundles docker/docker v28.5.2+incompatible as a client-side library for API types and codecs; it never serves the daemon-side cp endpoint and never resolves bind mounts on the host. Sencho invokes compose only for up/down/ps operations against local user-authored compose files and does not invoke `docker cp` through compose. The vulnerable daemon-side code path is not reachable. The fix lives on the github.com/moby/moby/v2 module path; until upstream compose migrates to the v2 import path, v28.5.2+incompatible is the only Go-module-resolvable version of the affected library that compose can reference."
-    },
-    {
-      "vulnerability": {
-        "@id": "https://www.cve.org/CVERecord?id=CVE-2026-46680",
-        "name": "CVE-2026-46680",
-        "description": "containerd user ID handling bypass allows runAsNonRoot evasion"
-      },
-      "products": [
-        {
-          "@id": "pkg:golang/github.com/containerd/containerd/v2@v2.2.3"
-        }
-      ],
-      "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "The vulnerability is in containerd's runtime executor: when starting a container whose OCI spec carries a Kubernetes `runAsNonRoot: true` security context, a crafted user ID handling sequence lets the process run as root despite the enforcement check. The vulnerable code path is reached only by containerd-shim invoking runc with a populated runtime spec, i.e., daemon-side execution by the containerd runtime itself. docker-compose v5.1.3 statically bundles `github.com/containerd/containerd/v2 v2.2.3` as a client-side library for gRPC types, API stubs, and shared utilities used to talk to a containerd daemon; it does not execute containers and does not enforce `runAsNonRoot`. Sencho invokes compose only for up/down/ps operations against user-authored compose files, which do not carry Kubernetes pod security contexts. The runtime-executor code path is not reachable. Upstream compose will pick up the fixed containerd (v2.2.4 / v2.3.1) on a future tag; until then v2.2.3 is the resolved version in compose v5.1.3's module graph."
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Bump `github.com/containerd/containerd/v2` from v2.2.3 to v2.2.4 inside the `compose-builder` stage of `Dockerfile`, alongside the existing otel security bumps.
- Remove the matching CVE-2026-46680 statement from `security/vex/sencho.openvex.json`; bump `version` 6 → 7 and `last_updated` to 2026-05-24.

## Why

docker/compose v5.1.3 pins `containerd/v2 v2.2.3`, which carries [CVE-2026-46680](https://github.com/containerd/containerd/security/advisories/GHSA-fqw6-gf59-qr4w) (runAsNonRoot evasion in the containerd runtime executor). The vulnerable code path is daemon-side and was never reachable from compose, so the previous VEX entry suppressed it as `not_affected / vulnerable_code_not_in_execute_path`.

Now that upstream has cut a patch release (v2.2.4 published 2026-05-20, headline fix for this exact CVE), we can resolve it at the dependency level rather than via suppression. Compose v5.1.4 has not picked the bump up yet, so we patch it ourselves with `go get` in the same step that already bumps otel.

## Why the three remaining VEX statements stay

CVE-2026-34040, CVE-2026-41567, and CVE-2026-42306 affect `github.com/docker/docker v28.5.2+incompatible` (indirect dep). Upstream's fix lives on a new module path (`github.com/moby/moby/v2`) on the docker-29.x branch. Compose has not migrated imports yet (verified against `v5.1.4` and `main` go.mod), so there is no resolvable version bump for these. They remain correctly suppressed as not-affected.

## Test plan

- [x] `docker build --target compose-builder` builds end-to-end against the patched go.mod.
- [x] ELF magic sanity check in the Dockerfile (`7f454c46`) still passes.
- [x] `go version -m /build/docker-compose` confirms the bundled binary embeds `containerd/v2 v2.2.4` (no MVS fallback to v2.2.3).
- [x] `otel/sdk v1.43.0` still embedded.
- [x] JSON validity check on the updated VEX file; 3 statements remain, all docker/docker CVEs.

## Notes

- Full-image build skipped on this workstation (memory constraint). CI builds the full multi-arch image on PR.
- Trivy scan of the published image after merge should show CVE-2026-46680 as fully resolved (no VEX needed).