### PR TITLE
fix(stacks): require stack:read on file explorer GET routes

### DIFF
--- a/backend/src/__tests__/stack-files-routes.test.ts
+++ b/backend/src/__tests__/stack-files-routes.test.ts
@@ -595,4 +595,39 @@ describe('permission gating', () => {
       .send({ mode: 0o644 });
     expect(res.status).toBe(403);
   });
+
+  it('viewer with global stack:read can GET /files', async () => {
+    const res = await request(app)
+      .get(`/api/stacks/${STACK}/files`)
+      .set('Cookie', viewerCookie);
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  it('viewer with global stack:read can GET /files/content', async () => {
+    const res = await request(app)
+      .get(`/api/stacks/${STACK}/files/content`)
+      .query({ path: 'compose.yaml' })
+      .set('Cookie', viewerCookie);
+    expect(res.status).toBe(200);
+    expect(typeof res.body.content).toBe('string');
+  });
+
+  it('viewer with global stack:read can GET /files/download', async () => {
+    const res = await request(app)
+      .get(`/api/stacks/${STACK}/files/download`)
+      .query({ path: 'compose.yaml' })
+      .set('Cookie', viewerCookie);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-disposition']).toMatch(/attachment/);
+  });
+
+  it('viewer with global stack:read can GET /files/permissions', async () => {
+    const res = await request(app)
+      .get(`/api/stacks/${STACK}/files/permissions`)
+      .query({ path: 'compose.yaml' })
+      .set('Cookie', viewerCookie);
+    expect(res.status).toBe(200);
+    expect(typeof res.body.octal).toBe('string');
+  });
 });

--- a/backend/src/routes/stacks.ts
+++ b/backend/src/routes/stacks.ts
@@ -1370,6 +1370,7 @@ function isSafeUploadFilename(rawName: string): boolean {
 
 stacksRouter.get('/:stackName/files', async (req: Request, res: Response) => {
   const stackName = req.params.stackName as string;
+  if (!requirePermission(req, res, 'stack:read', 'stack', stackName)) return;
   const relPath = getRelPath(req);
   if (relPath !== '' && !isValidRelativeStackPath(relPath)) {
     return res.status(400).json({ error: 'Invalid path', code: 'INVALID_PATH' });
@@ -1388,6 +1389,7 @@ stacksRouter.get('/:stackName/files', async (req: Request, res: Response) => {
 
 stacksRouter.get('/:stackName/files/content', async (req: Request, res: Response) => {
   const stackName = req.params.stackName as string;
+  if (!requirePermission(req, res, 'stack:read', 'stack', stackName)) return;
   const relPath = getRelPath(req);
   if (!relPath) return res.status(400).json({ error: 'path query parameter is required', code: 'INVALID_PATH' });
   if (!isValidRelativeStackPath(relPath)) {
@@ -1415,6 +1417,7 @@ stacksRouter.get('/:stackName/files/content', async (req: Request, res: Response
 
 stacksRouter.get('/:stackName/files/download', async (req: Request, res: Response) => {
   const stackName = req.params.stackName as string;
+  if (!requirePermission(req, res, 'stack:read', 'stack', stackName)) return;
   const relPath = getRelPath(req);
   if (!relPath) return res.status(400).json({ error: 'path query parameter is required', code: 'INVALID_PATH' });
   if (!isValidRelativeStackPath(relPath)) {
@@ -1583,6 +1586,7 @@ stacksRouter.patch('/:stackName/files/rename', async (req: Request, res: Respons
 
 stacksRouter.get('/:stackName/files/permissions', async (req: Request, res: Response) => {
   const stackName = req.params.stackName as string;
+  if (!requirePermission(req, res, 'stack:read', 'stack', stackName)) return;
   const relPath = getRelPath(req);
   if (!relPath) return res.status(400).json({ error: 'path query parameter is required', code: 'INVALID_PATH' });
   if (!isValidRelativeStackPath(relPath)) {

--- a/frontend/src/components/EditorLayout/EditorView.tsx
+++ b/frontend/src/components/EditorLayout/EditorView.tsx
@@ -319,6 +319,13 @@ export function EditorView({
     const safeContent = content || '';
     const safeEnvContent = envContent || '';
     const isRunning = safeContainers.some(c => c.State === 'running');
+    const canRead = can('stack:read', 'stack', stackName);
+
+    useEffect(() => {
+        if (activeTab === 'files' && !canRead) {
+            setActiveTab('compose');
+        }
+    }, [activeTab, canRead, setActiveTab]);
 
     return (
         <ErrorBoundary>
@@ -712,12 +719,14 @@ export function EditorView({
                                             <TabsHighlightItem value="env">
                                                 <TabsTrigger value="env" disabled={!envExists}>.env</TabsTrigger>
                                             </TabsHighlightItem>
-                                            <TabsHighlightItem value="files">
-                                                <TabsTrigger value="files">
-                                                    <FolderOpen className="w-3.5 h-3.5 mr-1" strokeWidth={1.5} />
-                                                    Files
-                                                </TabsTrigger>
-                                            </TabsHighlightItem>
+                                            {canRead && (
+                                                <TabsHighlightItem value="files">
+                                                    <TabsTrigger value="files">
+                                                        <FolderOpen className="w-3.5 h-3.5 mr-1" strokeWidth={1.5} />
+                                                        Files
+                                                    </TabsTrigger>
+                                                </TabsHighlightItem>
+                                            )}
                                         </TabsHighlight>
                                     </TabsList>
                                 </Tabs>
@@ -801,7 +810,7 @@ export function EditorView({
                             </div>
                         </div>
                         <div className="flex-1 min-h-0 flex flex-col">
-                            {activeTab === 'files' ? (
+                            {activeTab === 'files' && canRead ? (
                                 <StackFileExplorer
                                     stackName={stackName}
                                     canEdit={can('stack:edit', 'stack', stackName)}
@@ -864,7 +873,7 @@ export function EditorView({
                         selectedEnvFile={selectedEnvFile}
                         gitSourcePending={Boolean(gitSourcePendingMap[stackName])}
                         onEditCompose={() => { setEditingCompose(true); setActiveTab('compose'); }}
-                        onOpenFiles={() => { setEditingCompose(true); setActiveTab('files'); }}
+                        onOpenFiles={canRead ? () => { setEditingCompose(true); setActiveTab('files'); } : undefined}
                         onOpenGitSource={() => setGitSourceOpen(true)}
                         onApplyUpdate={() => { void updateStack(); }}
                         canEdit={can('stack:edit', 'stack', stackName)}


### PR DESCRIPTION
## Summary

- Add `requirePermission(req, res, 'stack:read', 'stack', stackName)` to the four file-explorer GET routes in `backend/src/routes/stacks.ts` (list, content, download, permissions). The write-side siblings already required `stack:edit`; this brings the read path to the same shape and matches the pattern used in `gitSources.ts` and `stackActivity.ts`.
- Gate the Files tab trigger, the Files panel, and the StackAnatomyPanel "Open Files" affordance in `frontend/src/components/EditorLayout/EditorView.tsx` on `can('stack:read', 'stack', stackName)`. An effect canonicalises `activeTab` away from `'files'` if the user ends up there without permission.
- Append four regression tests under the existing `permission gating` describe block in `backend/src/__tests__/stack-files-routes.test.ts` confirming a `viewer` (who holds global `stack:read`) keeps 200s across all four routes.

## Behaviour change

All five shipped roles (admin, node-admin, deployer, viewer, auditor) carry `stack:read` globally in `ROLE_PERMISSIONS`. End-user behaviour today is unchanged. The value of this PR is forward-compat: a future role definition that omits `stack:read` (or a scoped Admiral assignment that grants `stack:edit` without `stack:read`) would previously have left the read routes wide open. With the guard in place, the read scope tracks the capability explicitly.

## Gate parity

| Route | Backend guard | Frontend surface |
|---|---|---|
| `GET /api/stacks/:name/files` | `stack:read` (new) | StackFileExplorer mount, Files tab trigger, anatomy "Open Files" |
| `GET /api/stacks/:name/files/content` | `stack:read` (new) | FileViewer fetch |
| `GET /api/stacks/:name/files/download` | `stack:read` (new) | StackFileExplorer download button |
| `GET /api/stacks/:name/files/permissions` | `stack:read` (new) | FilePermissionsDialog |

No other UI surface (command palette, sidebar, drawer, deep-link) hits these routes; `apiFetch` call sites are confined to `frontend/src/lib/stackFilesApi.ts` and only invoked from within the gated panel.

## Test plan

- [x] `cd backend && npx tsc --noEmit` clean
- [x] `cd frontend && npx tsc -b --noEmit` clean
- [x] `cd backend && npx vitest run src/__tests__/stack-files-routes.test.ts` — 49 passed, 2 skipped
- [x] `cd frontend && npx vitest run src/components/files src/lib/__tests__/stackFilesApi.test.ts` — 28 passed
- [ ] Manual UI walk: admin sees Files tab and panel; viewer sees Files tab and panel (current default behaviour, no regression); a hypothetical role without `stack:read` would see neither and direct API access returns 403
- [ ] Remote-node walk: same as above with `x-node-id` pointing to a peer

## Notes

This is PR 1 of a 12-PR Stack File Explorer audit pass. Subsequent PRs add server-side enforcement of protected files (compose.yaml, .env), atomic writes with tmp+rename, mtime concurrency on PUT, upload overwrite confirmation, and other hardening. Each ships on its own branch.