### PR TITLE
fix(stack-files): confirm before overwriting an existing upload target

### DIFF
--- a/backend/src/__tests__/stack-files-routes.test.ts
+++ b/backend/src/__tests__/stack-files-routes.test.ts
@@ -350,7 +350,7 @@ describe('POST /api/stacks/:stackName/files/upload', () => {
     await fs.unlink(target);
   });
 
-  it('returns 409 FILE_EXISTS when overwriting an entry that is a directory', async () => {
+  it('returns 409 DIR_EXISTS when a directory occupies the upload target name', async () => {
     const dir = path.join(stacksDir, STACK, 'collide-dir');
     await fs.mkdir(dir, { recursive: true });
     const res = await request(app)
@@ -358,7 +358,23 @@ describe('POST /api/stacks/:stackName/files/upload', () => {
       .set('Cookie', adminCookie)
       .attach('file', Buffer.from('whatever'), 'collide-dir');
     expect(res.status).toBe(409);
-    expect(res.body.code).toBe('FILE_EXISTS');
+    expect(res.body.code).toBe('DIR_EXISTS');
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('still returns 409 DIR_EXISTS even when ?overwrite=1 is set (directories are never replaced)', async () => {
+    const dir = path.join(stacksDir, STACK, 'collide-dir-2');
+    await fs.mkdir(dir, { recursive: true });
+    const res = await request(app)
+      .post(`/api/stacks/${STACK}/files/upload`)
+      .query({ overwrite: '1' })
+      .set('Cookie', adminCookie)
+      .attach('file', Buffer.from('whatever'), 'collide-dir-2');
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('DIR_EXISTS');
+    // The directory must still exist after the rejected upload.
+    const stat = await fs.stat(dir);
+    expect(stat.isDirectory()).toBe(true);
     await fs.rm(dir, { recursive: true, force: true });
   });
 });

--- a/backend/src/__tests__/stack-files-routes.test.ts
+++ b/backend/src/__tests__/stack-files-routes.test.ts
@@ -320,6 +320,47 @@ describe('POST /api/stacks/:stackName/files/upload', () => {
     const content = await fs.readFile(path.join(stacksDir, STACK, 'subdir', 'sub.txt'), 'utf-8');
     expect(content).toBe('subdir content');
   });
+
+  it('returns 409 FILE_EXISTS when the target name already exists and overwrite is not set', async () => {
+    const target = path.join(stacksDir, STACK, 'existing.txt');
+    await fs.writeFile(target, 'original');
+    const res = await request(app)
+      .post(`/api/stacks/${STACK}/files/upload`)
+      .set('Cookie', adminCookie)
+      .attach('file', Buffer.from('replacement'), 'existing.txt');
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('FILE_EXISTS');
+    // Original content must be preserved when the upload is rejected.
+    const after = await fs.readFile(target, 'utf-8');
+    expect(after).toBe('original');
+    await fs.unlink(target);
+  });
+
+  it('overwrites when ?overwrite=1 is set', async () => {
+    const target = path.join(stacksDir, STACK, 'replaceme.txt');
+    await fs.writeFile(target, 'before');
+    const res = await request(app)
+      .post(`/api/stacks/${STACK}/files/upload`)
+      .query({ overwrite: '1' })
+      .set('Cookie', adminCookie)
+      .attach('file', Buffer.from('after'), 'replaceme.txt');
+    expect(res.status).toBe(204);
+    const after = await fs.readFile(target, 'utf-8');
+    expect(after).toBe('after');
+    await fs.unlink(target);
+  });
+
+  it('returns 409 FILE_EXISTS when overwriting an entry that is a directory', async () => {
+    const dir = path.join(stacksDir, STACK, 'collide-dir');
+    await fs.mkdir(dir, { recursive: true });
+    const res = await request(app)
+      .post(`/api/stacks/${STACK}/files/upload`)
+      .set('Cookie', adminCookie)
+      .attach('file', Buffer.from('whatever'), 'collide-dir');
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('FILE_EXISTS');
+    await fs.rm(dir, { recursive: true, force: true });
+  });
 });
 
 // ── PUT /:stackName/files/content ─────────────────────────────────────────────

--- a/backend/src/routes/stacks.ts
+++ b/backend/src/routes/stacks.ts
@@ -1309,7 +1309,8 @@ type FsErrorCode =
   | 'NOT_EMPTY'
   | 'NOT_FOUND'
   | 'TOO_LARGE'
-  | 'ALREADY_EXISTS';
+  | 'ALREADY_EXISTS'
+  | 'FILE_EXISTS';
 
 function sendFsError(
   res: Response,
@@ -1470,11 +1471,21 @@ stacksRouter.post(
       return res.status(400).json({ error: 'Invalid filename' });
     }
     const targetRelPath = relPath ? `${relPath}/${originalName}` : originalName;
+    const overwrite = req.query.overwrite === '1';
     const startedAt = Date.now();
-    logFileDiag('upload start', { stackName, relPath: targetRelPath, nodeId: req.nodeId, size: req.file.size });
+    logFileDiag('upload start', { stackName, relPath: targetRelPath, nodeId: req.nodeId, size: req.file.size, overwrite });
     try {
+      if (!overwrite) {
+        const exists = await FileSystemService.getInstance(req.nodeId).pathExists(stackName, targetRelPath);
+        if (exists) {
+          return res.status(409).json({
+            error: `${originalName} already exists in this folder. Confirm to replace.`,
+            code: 'FILE_EXISTS',
+          });
+        }
+      }
       await FileSystemService.getInstance(req.nodeId).writeStackFileBuffer(stackName, targetRelPath, req.file.buffer);
-      logFileOperation('info', 'upload complete', { nodeId: req.nodeId, size: req.file.size });
+      logFileOperation('info', 'upload complete', { nodeId: req.nodeId, size: req.file.size, overwrite });
       logFileDiag('upload timing', { stackName, relPath: targetRelPath, nodeId: req.nodeId, elapsedMs: Date.now() - startedAt });
       return res.status(204).send();
     } catch (err: unknown) {

--- a/backend/src/routes/stacks.ts
+++ b/backend/src/routes/stacks.ts
@@ -1310,7 +1310,8 @@ type FsErrorCode =
   | 'NOT_FOUND'
   | 'TOO_LARGE'
   | 'ALREADY_EXISTS'
-  | 'FILE_EXISTS';
+  | 'FILE_EXISTS'
+  | 'DIR_EXISTS';
 
 function sendFsError(
   res: Response,
@@ -1471,18 +1472,24 @@ stacksRouter.post(
       return res.status(400).json({ error: 'Invalid filename' });
     }
     const targetRelPath = relPath ? `${relPath}/${originalName}` : originalName;
-    const overwrite = req.query.overwrite === '1';
+    const overwrite = String(req.query.overwrite) === '1';
     const startedAt = Date.now();
     logFileDiag('upload start', { stackName, relPath: targetRelPath, nodeId: req.nodeId, size: req.file.size, overwrite });
     try {
-      if (!overwrite) {
-        const exists = await FileSystemService.getInstance(req.nodeId).pathExists(stackName, targetRelPath);
-        if (exists) {
-          return res.status(409).json({
-            error: `${originalName} already exists in this folder. Confirm to replace.`,
-            code: 'FILE_EXISTS',
-          });
-        }
+      const existing = await FileSystemService.getInstance(req.nodeId).pathKind(stackName, targetRelPath);
+      if (existing === 'directory') {
+        // A directory can never be replaced by an upload; surface a distinct code
+        // so the UI does not offer a useless "Replace" button.
+        return res.status(409).json({
+          error: `A folder named ${originalName} already exists in this folder. Rename the upload or remove the folder first.`,
+          code: 'DIR_EXISTS',
+        });
+      }
+      if (existing === 'file' && !overwrite) {
+        return res.status(409).json({
+          error: `${originalName} already exists in this folder. Confirm to replace.`,
+          code: 'FILE_EXISTS',
+        });
       }
       await FileSystemService.getInstance(req.nodeId).writeStackFileBuffer(stackName, targetRelPath, req.file.buffer);
       logFileOperation('info', 'upload complete', { nodeId: req.nodeId, size: req.file.size, overwrite });

--- a/backend/src/services/FileSystemService.ts
+++ b/backend/src/services/FileSystemService.ts
@@ -684,6 +684,18 @@ export class FileSystemService {
     await fsPromises.writeFile(safePath, buffer);
   }
 
+  async pathExists(stackName: string, relPath: string): Promise<boolean> {
+    try {
+      const safePath = await this.resolveSafeStackPath(stackName, relPath);
+      await fsPromises.access(safePath);
+      return true;
+    } catch (err: unknown) {
+      const e = err as NodeJS.ErrnoException;
+      if (e.code === 'ENOENT' || e.code === 'INVALID_PATH' || e.code === 'SYMLINK_ESCAPE') return false;
+      throw err;
+    }
+  }
+
   async deleteStackPath(stackName: string, relPath: string, recursive: boolean = false): Promise<void> {
     const safePath = await this.resolveSafeStackPath(stackName, relPath);
 

--- a/backend/src/services/FileSystemService.ts
+++ b/backend/src/services/FileSystemService.ts
@@ -684,14 +684,21 @@ export class FileSystemService {
     await fsPromises.writeFile(safePath, buffer);
   }
 
-  async pathExists(stackName: string, relPath: string): Promise<boolean> {
+  /**
+   * Returns 'file' or 'directory' if the resolved path exists, null if it
+   * does not. Path-resolution errors (INVALID_PATH, SYMLINK_ESCAPE) propagate
+   * so callers do not silently treat a malformed path as 'available for write'.
+   * Callers should validate inputs upstream before invoking this helper.
+   */
+  async pathKind(stackName: string, relPath: string): Promise<'file' | 'directory' | null> {
+    const safePath = await this.resolveSafeStackPath(stackName, relPath);
     try {
-      const safePath = await this.resolveSafeStackPath(stackName, relPath);
-      await fsPromises.access(safePath);
-      return true;
+      const stat = await fsPromises.lstat(safePath);
+      if (stat.isDirectory()) return 'directory';
+      return 'file';
     } catch (err: unknown) {
       const e = err as NodeJS.ErrnoException;
-      if (e.code === 'ENOENT' || e.code === 'INVALID_PATH' || e.code === 'SYMLINK_ESCAPE') return false;
+      if (e.code === 'ENOENT') return null;
       throw err;
     }
   }

--- a/frontend/src/components/files/FileUploadDropzone.tsx
+++ b/frontend/src/components/files/FileUploadDropzone.tsx
@@ -1,7 +1,8 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { UploadCloud } from 'lucide-react';
+import { ConfirmModal } from '@/components/ui/modal';
 import { toast } from '@/components/ui/toast-store';
-import { uploadStackFile } from '@/lib/stackFilesApi';
+import { uploadStackFile, UploadConflictError } from '@/lib/stackFilesApi';
 
 const MAX_BYTES = 25 * 1024 * 1024; // 25 MB
 
@@ -19,29 +20,38 @@ export function FileUploadDropzone({
   onUploaded,
 }: FileUploadDropzoneProps) {
   const inputRef = useRef<HTMLInputElement>(null);
+  const [conflict, setConflict] = useState<File | null>(null);
 
   if (!canEdit) return null;
 
-  const handleFile = async (file: File) => {
-    if (file.size > MAX_BYTES) {
-      toast.error('File exceeds 25 MB.');
-      return;
-    }
+  const runUpload = async (file: File, overwrite: boolean): Promise<void> => {
     const loadingId = toast.loading(`Uploading ${file.name}...`);
     try {
-      await uploadStackFile(stackName, currentDir, file);
-      toast.success('Uploaded.');
+      await uploadStackFile(stackName, currentDir, file, { overwrite });
+      toast.success(overwrite ? 'Replaced.' : 'Uploaded.');
       onUploaded();
     } catch (e: unknown) {
+      if (e instanceof UploadConflictError) {
+        setConflict(file);
+        return;
+      }
       toast.error(e instanceof Error ? e.message : 'Upload failed.');
     } finally {
       toast.dismiss(loadingId);
     }
   };
 
+  const handleFile = (file: File) => {
+    if (file.size > MAX_BYTES) {
+      toast.error('File exceeds 25 MB.');
+      return;
+    }
+    void runUpload(file, false);
+  };
+
   const handleChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
     const file = ev.target.files?.[0];
-    if (file) void handleFile(file);
+    if (file) handleFile(file);
     ev.target.value = '';
   };
 
@@ -69,6 +79,25 @@ export function FileUploadDropzone({
         <UploadCloud className="w-3.5 h-3.5 shrink-0" strokeWidth={1.5} />
         Upload file
       </div>
+
+      <ConfirmModal
+        open={conflict !== null}
+        onOpenChange={(next) => { if (!next) setConflict(null); }}
+        onCancel={() => setConflict(null)}
+        kicker="FILES · REPLACE EXISTING"
+        title="Replace existing file?"
+        description={conflict ? `${conflict.name} already exists in this folder.` : ''}
+        confirmLabel="Replace"
+        onConfirm={() => {
+          const file = conflict;
+          setConflict(null);
+          if (file) void runUpload(file, true);
+        }}
+      >
+        <p className="text-sm text-muted-foreground">
+          {conflict?.name ?? 'The file'} already exists. Replacing it overwrites the current contents and cannot be undone.
+        </p>
+      </ConfirmModal>
     </>
   );
 }

--- a/frontend/src/components/files/__tests__/FileUploadDropzone.test.tsx
+++ b/frontend/src/components/files/__tests__/FileUploadDropzone.test.tsx
@@ -1,10 +1,22 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { FileUploadDropzone } from '../FileUploadDropzone';
+import userEvent from '@testing-library/user-event';
 
-vi.mock('@/lib/stackFilesApi', () => ({
-  uploadStackFile: vi.fn(),
-}));
+// Mock the API module FIRST so the real class export is replaced before
+// FileUploadDropzone imports it.
+vi.mock('@/lib/stackFilesApi', () => {
+  class MockUploadConflictError extends Error {
+    readonly code = 'FILE_EXISTS' as const;
+    constructor(message: string) {
+      super(message);
+      this.name = 'UploadConflictError';
+    }
+  }
+  return {
+    uploadStackFile: vi.fn(),
+    UploadConflictError: MockUploadConflictError,
+  };
+});
 
 vi.mock('@/components/ui/toast-store', () => ({
   toast: {
@@ -14,6 +26,15 @@ vi.mock('@/components/ui/toast-store', () => ({
     dismiss: vi.fn(),
   },
 }));
+
+import { FileUploadDropzone } from '../FileUploadDropzone';
+import { uploadStackFile, UploadConflictError } from '@/lib/stackFilesApi';
+
+const mockUpload = uploadStackFile as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mockUpload.mockReset();
+});
 
 describe('FileUploadDropzone', () => {
   it('renders upload control for users with stack edit permission', () => {
@@ -40,5 +61,51 @@ describe('FileUploadDropzone', () => {
     );
 
     expect(screen.queryByRole('button', { name: /upload file/i })).not.toBeInTheDocument();
+  });
+
+  it('opens the replace dialog on FILE_EXISTS and retries with overwrite on confirm', async () => {
+    const user = userEvent.setup();
+    const onUploaded = vi.fn();
+    mockUpload
+      .mockRejectedValueOnce(new UploadConflictError('foo.txt already exists.'))
+      .mockResolvedValueOnce(undefined);
+
+    render(
+      <FileUploadDropzone stackName="app" currentDir="" canEdit onUploaded={onUploaded} />,
+    );
+
+    const input = screen.getByLabelText(/upload file/i) as HTMLInputElement;
+    const file = new File(['payload'], 'foo.txt', { type: 'text/plain' });
+    await user.upload(input, file);
+
+    expect(await screen.findByText(/replace existing file/i)).toBeInTheDocument();
+    expect(mockUpload).toHaveBeenCalledTimes(1);
+    expect(mockUpload).toHaveBeenNthCalledWith(1, 'app', '', file, { overwrite: false });
+
+    await user.click(screen.getByRole('button', { name: /^replace$/i }));
+
+    expect(mockUpload).toHaveBeenCalledTimes(2);
+    expect(mockUpload).toHaveBeenNthCalledWith(2, 'app', '', file, { overwrite: true });
+    expect(onUploaded).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the original file untouched when the user cancels the replace dialog', async () => {
+    const user = userEvent.setup();
+    const onUploaded = vi.fn();
+    mockUpload.mockRejectedValueOnce(new UploadConflictError('foo.txt already exists.'));
+
+    render(
+      <FileUploadDropzone stackName="app" currentDir="" canEdit onUploaded={onUploaded} />,
+    );
+
+    const input = screen.getByLabelText(/upload file/i) as HTMLInputElement;
+    const file = new File(['payload'], 'foo.txt', { type: 'text/plain' });
+    await user.upload(input, file);
+
+    expect(await screen.findByText(/replace existing file/i)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /^cancel$/i }));
+
+    expect(mockUpload).toHaveBeenCalledTimes(1);
+    expect(onUploaded).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/lib/stackFilesApi.ts
+++ b/frontend/src/lib/stackFilesApi.ts
@@ -135,6 +135,9 @@ export async function uploadStackFile(
     if (body.code === 'FILE_EXISTS') {
       throw new UploadConflictError(body.error ?? `${file.name} already exists.`);
     }
+    // DIR_EXISTS and any other 409 fall through to the generic Error path so the
+    // dropzone surfaces the server message as a toast and does NOT offer a Replace
+    // confirmation (a directory cannot be replaced by a file upload).
   }
 
   if (!res.ok) {

--- a/frontend/src/lib/stackFilesApi.ts
+++ b/frontend/src/lib/stackFilesApi.ts
@@ -84,11 +84,24 @@ export async function downloadStackFile(
   return apiFetch(stackFilesUrl(stackName, `/download?path=${encodeURIComponent(relPath)}`));
 }
 
+/**
+ * Thrown by uploadStackFile when the target filename already exists in the
+ * directory and the caller did not opt into overwrite. The FileUploadDropzone
+ * surfaces a confirm dialog on this signal and retries with overwrite=true.
+ */
+export class UploadConflictError extends Error {
+  readonly code = 'FILE_EXISTS' as const;
+  constructor(message: string) {
+    super(message);
+    this.name = 'UploadConflictError';
+  }
+}
+
 export async function uploadStackFile(
   stackName: string,
   targetDir: string,
   file: File,
-  options?: { localOnly?: boolean }
+  options?: { localOnly?: boolean; overwrite?: boolean }
 ): Promise<void> {
   assertSafeRelPath(targetDir, 'target directory');
   const fd = new FormData();
@@ -100,11 +113,12 @@ export async function uploadStackFile(
     headers['x-node-id'] = activeNodeId;
   }
 
+  const overwriteSuffix = options?.overwrite ? '&overwrite=1' : '';
   // Use fetch directly: apiFetch always sets Content-Type: application/json,
   // which breaks multipart boundary negotiation. The 401 side-effects are
   // replicated manually below.
   const res = await fetch(
-    `/api${stackFilesUrl(stackName, `/upload?path=${encodeURIComponent(targetDir)}`)}`,
+    `/api${stackFilesUrl(stackName, `/upload?path=${encodeURIComponent(targetDir)}${overwriteSuffix}`)}`,
     { method: 'POST', credentials: 'include', headers, body: fd }
   );
 
@@ -113,6 +127,14 @@ export async function uploadStackFile(
       window.dispatchEvent(new Event('sencho-unauthorized'));
     }
     throw new Error('Unauthorized');
+  }
+
+  if (res.status === 409) {
+    let body: { code?: string; error?: string } = {};
+    try { body = await res.clone().json(); } catch { /* ignore */ }
+    if (body.code === 'FILE_EXISTS') {
+      throw new UploadConflictError(body.error ?? `${file.name} already exists.`);
+    }
   }
 
   if (!res.ok) {


### PR DESCRIPTION
## Summary

Same-name uploads previously truncated the existing file silently. A user dragging a file with a name that matched an in-place file destroyed the original with no warning and no undo.

- Backend POST /files/upload reads `?overwrite=0|1`. When the target exists as a file and overwrite is not set, returns `409 FILE_EXISTS`. When the target is a directory, returns `409 DIR_EXISTS` regardless of overwrite (directories are never replaced by an upload).
- A new `pathKind(stackName, relPath)` helper on FileSystemService returns `'file' | 'directory' | null` through the same path-resolution barrier the write uses. Path-resolution errors propagate so callers cannot accidentally treat a malformed path as 'available for write'.
- Frontend `uploadStackFile` accepts `{ overwrite?: boolean }` and throws a new `UploadConflictError` on the FILE_EXISTS code so the dropzone can distinguish the conflict case from generic upload failures. DIR_EXISTS falls through to the generic toast path (no Replace dialog, since replacing a folder by upload is never the right action).
- `FileUploadDropzone` opens a ConfirmModal ("Replace existing file?") on UploadConflictError; confirm retries with `overwrite=true`; cancel discards and leaves the original untouched.

## Test plan

- [x] `cd backend && npx tsc --noEmit` clean
- [x] `cd frontend && npx tsc -b --noEmit` clean
- [x] `cd backend && npx vitest run src/__tests__/stack-files-routes.test.ts` — 49 passed, 2 skipped (5 new upload tests: 409 with content preservation, ?overwrite=1 replaces, directory collision returns DIR_EXISTS, DIR_EXISTS even with overwrite=1, original directory preserved)
- [x] `cd frontend && npx vitest run src/components/files src/lib/__tests__/stackFilesApi.test.ts` — 30 passed (2 new dropzone tests: confirm retries with overwrite=true; cancel preserves original and skips onUploaded)
- [ ] Manual UI: drag a same-named file onto the dropzone, observe Replace dialog; Cancel leaves the original; Replace overwrites
- [ ] Manual: try to upload to a name that collides with an existing folder, observe a non-replaceable toast

## Notes

PR 4 of 12. Race window between `pathKind` and the actual write: best-effort UX guidance, not authoritative. The next PR (H-3 atomic writes) will introduce a tmp+rename pattern; consider adding `flag: 'wx'` on the non-overwrite path so the existence check becomes race-free.