### PR TITLE
fix(stack-files): atomic write via tmp+rename with optional exclusive mode

### DIFF
--- a/backend/src/__tests__/filesystem-stack-paths.test.ts
+++ b/backend/src/__tests__/filesystem-stack-paths.test.ts
@@ -300,6 +300,53 @@ describe('FileSystemService stack methods', () => {
       const leftovers = dirEntries.filter(name => name.startsWith('taken.txt.sencho-tmp-'));
       expect(leftovers).toEqual([]);
     });
+
+    it('cleans up the tmp file when the write step throws', async () => {
+      const fsModule = await import('fs');
+      const originalOpen = fsModule.promises.open;
+      const openSpy = vi
+        .spyOn(fsModule.promises, 'open')
+        .mockImplementationOnce(async (...args) => {
+          const fh = await originalOpen.apply(fsModule.promises, args as Parameters<typeof originalOpen>);
+          // Patch writeFile to throw, the close still runs via the inner finally.
+          (fh as unknown as { writeFile: () => Promise<void> }).writeFile = () =>
+            Promise.reject(Object.assign(new Error('write blew up'), { code: 'EIO' }));
+          return fh;
+        });
+
+      const service = FileSystemService.getInstance();
+      await expect(service.writeStackFile(STACK, 'wfail.txt', 'NEW')).rejects.toThrow(/write blew up/);
+
+      // Target was never created and the tmp was cleaned.
+      const dirEntries = await fs.readdir(stackDir);
+      expect(dirEntries).not.toContain('wfail.txt');
+      const leftovers = dirEntries.filter(name => name.startsWith('wfail.txt.sencho-tmp-'));
+      expect(leftovers).toEqual([]);
+
+      openSpy.mockRestore();
+    });
+
+    it('concurrent non-exclusive writers to the same path leave one winning content and no tmp leaks', async () => {
+      const service = FileSystemService.getInstance();
+      const inputs = ['A', 'B', 'C', 'D', 'E'].map(l => l.repeat(32));
+      // POSIX rename is atomic and silently overwrites: every writer succeeds and
+      // the last-to-rename wins. Windows rename throws EPERM if the destination
+      // is open or being renamed by another process. Both are acceptable: the
+      // contract is "the final file is always exactly one of the inputs, never
+      // torn, and no tmp files leak". Settle individually and require at least
+      // one writer to have succeeded.
+      const results = await Promise.allSettled(
+        inputs.map(content => service.writeStackFile(STACK, 'race.txt', content)),
+      );
+      expect(results.some(r => r.status === 'fulfilled')).toBe(true);
+
+      const finalContent = await fs.readFile(path.join(stackDir, 'race.txt'), 'utf-8');
+      expect(inputs).toContain(finalContent);
+
+      const dirEntries = await fs.readdir(stackDir);
+      const leftovers = dirEntries.filter(name => name.startsWith('race.txt.sencho-tmp-'));
+      expect(leftovers).toEqual([]);
+    });
   });
 
   // ── deleteStackPath ─────────────────────────────────────────────────────

--- a/backend/src/__tests__/filesystem-stack-paths.test.ts
+++ b/backend/src/__tests__/filesystem-stack-paths.test.ts
@@ -237,6 +237,71 @@ describe('FileSystemService stack methods', () => {
     });
   });
 
+  // ── atomic write semantics ──────────────────────────────────────────────
+
+  describe('atomic write semantics', () => {
+    it('does not leak .sencho-tmp-* files after a successful write', async () => {
+      const service = FileSystemService.getInstance();
+      await service.writeStackFile(STACK, 'clean.txt', 'final');
+      const dirEntries = await fs.readdir(stackDir);
+      const leftovers = dirEntries.filter(name => name.startsWith('clean.txt.sencho-tmp-'));
+      expect(leftovers).toEqual([]);
+    });
+
+    it('preserves the original target when the rename step throws', async () => {
+      const target = path.join(stackDir, 'crash.txt');
+      await fs.writeFile(target, 'ORIGINAL');
+
+      const fsModule = await import('fs');
+      const renameSpy = vi
+        .spyOn(fsModule.promises, 'rename')
+        .mockRejectedValueOnce(Object.assign(new Error('disk yanked'), { code: 'EIO' }));
+
+      const service = FileSystemService.getInstance();
+      await expect(service.writeStackFile(STACK, 'crash.txt', 'NEW')).rejects.toThrow(/disk yanked/);
+
+      // Target keeps its original content.
+      const content = await fs.readFile(target, 'utf-8');
+      expect(content).toBe('ORIGINAL');
+
+      // Tmp file is cleaned up.
+      const dirEntries = await fs.readdir(stackDir);
+      const leftovers = dirEntries.filter(name => name.startsWith('crash.txt.sencho-tmp-'));
+      expect(leftovers).toEqual([]);
+
+      renameSpy.mockRestore();
+    });
+
+    it('exclusive write to a fresh target succeeds', async () => {
+      const service = FileSystemService.getInstance();
+      await service.writeStackFile(STACK, 'first.txt', 'hello', { exclusive: true });
+      const content = await fs.readFile(path.join(stackDir, 'first.txt'), 'utf-8');
+      expect(content).toBe('hello');
+    });
+
+    it('exclusive write to an existing target throws FILE_EXISTS and preserves the original', async () => {
+      const target = path.join(stackDir, 'taken.txt');
+      await fs.writeFile(target, 'KEEP');
+
+      const service = FileSystemService.getInstance();
+      let caught: unknown = null;
+      try {
+        await service.writeStackFile(STACK, 'taken.txt', 'OVERWRITE', { exclusive: true });
+      } catch (err) {
+        caught = err;
+      }
+      expect((caught as { code?: string })?.code).toBe('FILE_EXISTS');
+
+      const content = await fs.readFile(target, 'utf-8');
+      expect(content).toBe('KEEP');
+
+      // Tmp file cleaned up after the link failure.
+      const dirEntries = await fs.readdir(stackDir);
+      const leftovers = dirEntries.filter(name => name.startsWith('taken.txt.sencho-tmp-'));
+      expect(leftovers).toEqual([]);
+    });
+  });
+
   // ── deleteStackPath ─────────────────────────────────────────────────────
 
   describe('deleteStackPath', () => {

--- a/backend/src/services/FileSystemService.ts
+++ b/backend/src/services/FileSystemService.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import os from 'os';
+import crypto from 'crypto';
 import { promises as fsPromises, createReadStream } from 'fs';
 import type { Readable } from 'stream';
 import { NodeRegistry } from './NodeRegistry';
@@ -691,7 +692,9 @@ export class FileSystemService {
     opts: { exclusive?: boolean } = {},
   ): Promise<void> {
     await fsPromises.mkdir(path.dirname(safePath), { recursive: true });
-    const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    // crypto.randomBytes gives a guaranteed-length high-entropy suffix; Math.random
+    // can drop leading zeros which narrows entropy unpredictably.
+    const suffix = `${process.pid}-${Date.now()}-${crypto.randomBytes(6).toString('hex')}`;
     const tmpPath = `${safePath}.sencho-tmp-${suffix}`;
     let stagedTmp = false;
     try {
@@ -704,6 +707,9 @@ export class FileSystemService {
         await fh.close();
       }
       if (opts.exclusive) {
+        // link() is atomic against EEXIST. Tmp and target are guaranteed to live
+        // in the same directory (same filesystem); link works on NTFS and any
+        // POSIX FS without elevated privileges.
         try {
           await fsPromises.link(tmpPath, safePath);
         } catch (err: unknown) {

--- a/backend/src/services/FileSystemService.ts
+++ b/backend/src/services/FileSystemService.ts
@@ -672,16 +672,75 @@ export class FileSystemService {
     };
   }
 
-  async writeStackFile(stackName: string, relPath: string, content: string): Promise<void> {
-    const safePath = await this.resolveSafeStackPath(stackName, relPath);
+  /**
+   * Atomic write: stages the content in a sibling .tmp file in the same
+   * directory, fsyncs, then promotes it to the final path. A crash between
+   * the open and the rename leaves either the original target intact or a
+   * leftover .tmp file (cleaned up on next failure path), never a truncated
+   * target.
+   *
+   * `exclusive: true` uses link+unlink instead of rename so the create is
+   * race-free atomic: link fails with EEXIST if the target already exists,
+   * giving the caller a definitive "did not exist when we wrote it" signal.
+   * The non-exclusive default uses rename, which is atomic against partial
+   * reads but clobbers any existing target.
+   */
+  private async writeStackFileAtomic(
+    safePath: string,
+    data: string | Buffer,
+    opts: { exclusive?: boolean } = {},
+  ): Promise<void> {
     await fsPromises.mkdir(path.dirname(safePath), { recursive: true });
-    await fsPromises.writeFile(safePath, content, 'utf-8');
+    const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const tmpPath = `${safePath}.sencho-tmp-${suffix}`;
+    let stagedTmp = false;
+    try {
+      const fh = await fsPromises.open(tmpPath, 'wx');
+      stagedTmp = true;
+      try {
+        await fh.writeFile(data);
+        await fh.sync();
+      } finally {
+        await fh.close();
+      }
+      if (opts.exclusive) {
+        try {
+          await fsPromises.link(tmpPath, safePath);
+        } catch (err: unknown) {
+          if ((err as NodeJS.ErrnoException).code === 'EEXIST') {
+            throw Object.assign(new Error('File already exists'), { code: 'FILE_EXISTS' as const });
+          }
+          throw err;
+        }
+      } else {
+        await fsPromises.rename(tmpPath, safePath);
+        stagedTmp = false;
+      }
+    } finally {
+      if (stagedTmp) {
+        await fsPromises.unlink(tmpPath).catch(() => {});
+      }
+    }
   }
 
-  async writeStackFileBuffer(stackName: string, relPath: string, buffer: Buffer): Promise<void> {
+  async writeStackFile(
+    stackName: string,
+    relPath: string,
+    content: string,
+    opts?: { exclusive?: boolean },
+  ): Promise<void> {
     const safePath = await this.resolveSafeStackPath(stackName, relPath);
-    await fsPromises.mkdir(path.dirname(safePath), { recursive: true });
-    await fsPromises.writeFile(safePath, buffer);
+    await this.writeStackFileAtomic(safePath, content, opts);
+  }
+
+  async writeStackFileBuffer(
+    stackName: string,
+    relPath: string,
+    buffer: Buffer,
+    opts?: { exclusive?: boolean },
+  ): Promise<void> {
+    const safePath = await this.resolveSafeStackPath(stackName, relPath);
+    await this.writeStackFileAtomic(safePath, buffer, opts);
   }
 
   async deleteStackPath(stackName: string, relPath: string, recursive: boolean = false): Promise<void> {


### PR DESCRIPTION
## Summary

writeStackFile and writeStackFileBuffer previously called `fs.writeFile` directly, which truncates the target then streams the new bytes. A crash, disk-full event, or process kill between the truncate and the write left the target with partial content and no easy way to detect the half-write at read time.

A private `writeStackFileAtomic` helper stages every write into a sibling `.sencho-tmp-<pid>-<ts>-<crypto-random>` file in the same directory, fsyncs, then promotes via `fs.rename`. A crash now leaves either the original target intact or a leftover .sencho-tmp file (cleaned up on the next failure path); a torn target file is no longer reachable through this path.

The helper accepts an optional `{ exclusive: true }` flag that swaps the promote step from rename to link+unlink. link is atomic against EEXIST so a caller that needs "create only if not present" gets a race-free FILE_EXISTS error instead of a clobber.

## Behaviour for current callers

Unchanged. `writeStackFile`, `writeStackFileBuffer`, and `BlueprintService.writeStackFile(blueprint, ...)` use the non-exclusive default which matches the prior `fs.writeFile` semantics from the caller's perspective. The atomic helper adds partial-write resistance underneath, no signature change.

## Follow-up wiring

The upload route's overwrite-confirm flow (PR #1204) can switch its `writeStackFileBuffer` call to `{ exclusive: !overwrite }` once both branches land, which closes the TOCTOU between the existence check and the write. Tracking as a small follow-up rather than including here to keep PR boundaries clean.

## Test plan

- [x] `cd backend && npx tsc --noEmit` clean
- [x] `cd backend && npx vitest run src/__tests__/filesystem-stack-paths.test.ts` — 41 passed (35 prior + 6 new atomic-semantics tests: success leaves no tmp leak; rename-throws preserves original + cleans tmp; exclusive create on fresh target succeeds; exclusive create on existing target throws FILE_EXISTS + preserves original; write-step failure cleans tmp; concurrent non-exclusive writers settle with at least one success and one consistent final value)
- [x] `cd backend && npx vitest run src/__tests__/stack-files-routes.test.ts` — 45 passed (route-level tests confirm no regression on the upload + write paths)
- [ ] Manual sanity: edit a file in the Files tab, kill the backend process mid-save, restart, confirm either the original or the new content survives intact

## Notes

PR 5 of 12 in the Stack File Explorer audit. Cross-platform notes documented inline: rename is silent overwrite on POSIX, throws EPERM on Windows when the destination is held open by another concurrent writer — both consistent with the "final file is always one of the inputs, never torn" contract.