### PR TITLE
feat(stack-files): drag-and-drop upload zone

### DIFF
--- a/e2e/stack-files.spec.ts
+++ b/e2e/stack-files.spec.ts
@@ -239,9 +239,11 @@ test.describe('File explorer - admin (full CRUD)', () => {
   });
 
   test('upload a text file and verify it appears in the tree', async ({ page }) => {
-    // Admins with stack:edit see the upload dropzone on every tier.
+    // Admins with stack:edit see the upload dropzone on every tier. The
+    // dropzone label includes "upload" (e.g. "Upload or drop file"); match
+    // on the word alone so future copy edits don't break this assertion.
     await expect(
-      page.locator('[role="button"]').filter({ hasText: /upload file/i }).first()
+      page.locator('[role="button"]').filter({ hasText: /upload/i }).first()
     ).toBeVisible({ timeout: 5_000 });
 
     // Set a file on the hidden input

--- a/frontend/src/components/files/FileUploadDropzone.tsx
+++ b/frontend/src/components/files/FileUploadDropzone.tsx
@@ -1,5 +1,6 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { UploadCloud } from 'lucide-react';
+import { cn } from '@/lib/utils';
 import { toast } from '@/components/ui/toast-store';
 import { uploadStackFile } from '@/lib/stackFilesApi';
 
@@ -19,6 +20,7 @@ export function FileUploadDropzone({
   onUploaded,
 }: FileUploadDropzoneProps) {
   const inputRef = useRef<HTMLInputElement>(null);
+  const [isOver, setIsOver] = useState(false);
 
   if (!canEdit) return null;
 
@@ -45,6 +47,34 @@ export function FileUploadDropzone({
     ev.target.value = '';
   };
 
+  const handleDragOver = (ev: React.DragEvent<HTMLDivElement>) => {
+    if (!ev.dataTransfer.types.includes('Files')) return;
+    ev.preventDefault();
+    ev.dataTransfer.dropEffect = 'copy';
+    if (!isOver) setIsOver(true);
+  };
+
+  const handleDragLeave = (ev: React.DragEvent<HTMLDivElement>) => {
+    // Ignore leave events that bubble from child elements still within the
+    // dropzone (relatedTarget is contained by currentTarget); only react when
+    // the cursor truly leaves the zone.
+    const next = ev.relatedTarget;
+    if (next instanceof Node && ev.currentTarget.contains(next)) return;
+    setIsOver(false);
+  };
+
+  const handleDrop = (ev: React.DragEvent<HTMLDivElement>) => {
+    ev.preventDefault();
+    setIsOver(false);
+    const files = ev.dataTransfer.files;
+    if (!files || files.length === 0) return;
+    if (files.length > 1) {
+      toast.error('Drop one file at a time.');
+      return;
+    }
+    void handleFile(files[0]);
+  };
+
   return (
     <>
       <input
@@ -57,7 +87,12 @@ export function FileUploadDropzone({
       <div
         role="button"
         tabIndex={0}
-        className="border border-dashed border-border rounded-md p-2 text-xs text-muted-foreground flex items-center gap-2 cursor-pointer hover:border-brand/50 transition-colors"
+        className={cn(
+          'border border-dashed rounded-md p-2 text-xs flex items-center gap-2 cursor-pointer transition-colors',
+          isOver
+            ? 'border-brand bg-brand/10 text-brand'
+            : 'border-border text-muted-foreground hover:border-brand/50',
+        )}
         onClick={() => inputRef.current?.click()}
         onKeyDown={(e) => {
           if (e.key === 'Enter' || e.key === ' ') {
@@ -65,9 +100,12 @@ export function FileUploadDropzone({
             inputRef.current?.click();
           }
         }}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
       >
         <UploadCloud className="w-3.5 h-3.5 shrink-0" strokeWidth={1.5} />
-        Upload file
+        {isOver ? 'Drop to upload' : 'Upload or drop file'}
       </div>
     </>
   );

--- a/frontend/src/components/files/__tests__/FileUploadDropzone.test.tsx
+++ b/frontend/src/components/files/__tests__/FileUploadDropzone.test.tsx
@@ -1,6 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import { FileUploadDropzone } from '../FileUploadDropzone';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 
 vi.mock('@/lib/stackFilesApi', () => ({
   uploadStackFile: vi.fn(),
@@ -15,30 +14,80 @@ vi.mock('@/components/ui/toast-store', () => ({
   },
 }));
 
+import { FileUploadDropzone } from '../FileUploadDropzone';
+import { uploadStackFile } from '@/lib/stackFilesApi';
+import { toast } from '@/components/ui/toast-store';
+
+const mockUpload = uploadStackFile as unknown as ReturnType<typeof vi.fn>;
+const mockToastError = toast.error as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mockUpload.mockReset();
+  mockToastError.mockReset();
+});
+
 describe('FileUploadDropzone', () => {
   it('renders upload control for users with stack edit permission', () => {
-    render(
-      <FileUploadDropzone
-        stackName="app"
-        currentDir=""
-        canEdit
-        onUploaded={vi.fn()}
-      />,
-    );
-
-    expect(screen.getByRole('button', { name: /upload file/i })).toBeInTheDocument();
+    render(<FileUploadDropzone stackName="app" currentDir="" canEdit onUploaded={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /upload or drop file/i })).toBeInTheDocument();
   });
 
   it('hides upload control when the user cannot edit the stack', () => {
-    render(
-      <FileUploadDropzone
-        stackName="app"
-        currentDir=""
-        canEdit={false}
-        onUploaded={vi.fn()}
-      />,
-    );
+    render(<FileUploadDropzone stackName="app" currentDir="" canEdit={false} onUploaded={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: /upload or drop file/i })).not.toBeInTheDocument();
+  });
 
-    expect(screen.queryByRole('button', { name: /upload file/i })).not.toBeInTheDocument();
+  it('uploads via the same pipeline when a file is dropped onto the zone', async () => {
+    mockUpload.mockResolvedValueOnce(undefined);
+    const onUploaded = vi.fn();
+    render(<FileUploadDropzone stackName="app" currentDir="config" canEdit onUploaded={onUploaded} />);
+    const zone = screen.getByRole('button', { name: /upload or drop file/i });
+
+    const file = new File(['hello'], 'drop.txt', { type: 'text/plain' });
+    const dataTransfer = {
+      files: [file],
+      types: ['Files'],
+      dropEffect: 'copy',
+    } as unknown as DataTransfer;
+
+    fireEvent.dragOver(zone, { dataTransfer });
+    expect(screen.getByText(/drop to upload/i)).toBeInTheDocument();
+
+    fireEvent.drop(zone, { dataTransfer });
+    await waitFor(() => expect(mockUpload).toHaveBeenCalledTimes(1));
+    expect(mockUpload).toHaveBeenCalledWith('app', 'config', file);
+    await waitFor(() => expect(onUploaded).toHaveBeenCalledTimes(1));
+  });
+
+  it('rejects a multi-file drop with a clear toast and does not upload', async () => {
+    render(<FileUploadDropzone stackName="app" currentDir="" canEdit onUploaded={vi.fn()} />);
+    const zone = screen.getByRole('button', { name: /upload or drop file/i });
+
+    const a = new File(['a'], 'a.txt');
+    const b = new File(['b'], 'b.txt');
+    const dataTransfer = {
+      files: [a, b],
+      types: ['Files'],
+      dropEffect: 'copy',
+    } as unknown as DataTransfer;
+
+    fireEvent.drop(zone, { dataTransfer });
+    expect(mockToastError).toHaveBeenCalledWith(expect.stringMatching(/one file at a time/i));
+    expect(mockUpload).not.toHaveBeenCalled();
+  });
+
+  it('ignores drag events that do not carry files (e.g. text selection)', () => {
+    render(<FileUploadDropzone stackName="app" currentDir="" canEdit onUploaded={vi.fn()} />);
+    const zone = screen.getByRole('button', { name: /upload or drop file/i });
+
+    const dataTransfer = {
+      files: [],
+      types: ['text/plain'],
+      dropEffect: 'none',
+    } as unknown as DataTransfer;
+
+    fireEvent.dragOver(zone, { dataTransfer });
+    // Zone never enters the active "Drop to upload" state.
+    expect(screen.queryByText(/drop to upload/i)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

The Files-tab upload dropzone was click-only. Drag-and-drop is the standard file-manager affordance and the audit named its absence as a gap. The same component now accepts file drops, reusing the existing single-file upload pipeline so all current rules apply (canEdit gate, 25 MB cap, server-side path validation).

- Drag-over from a Files payload lights the zone in the brand color and swaps the label to "Drop to upload".
- DragLeave honours bubbling: leaving onto a child node inside the zone is ignored so the highlight does not flicker as the cursor crosses inner icons.
- Multi-file drops are rejected with a clear toast (the upload route handles one file per request).
- Drag events without a Files payload (text selections, image drags) are silently ignored.

## Test plan

- [x] `cd frontend && npx tsc -b --noEmit` clean
- [x] `cd frontend && npx vitest run src/components/files` — 19 passed (16 prior + 3 new: drop fires the upload pipeline with the expected args, multi-file drop rejects with toast, non-Files drag is ignored)
- [ ] Manual UI: drag a single file onto the Files-tab dropzone, observe the highlight + drop label, confirm the upload + toast

## Notes

PR 7 of 12. Pure UI addition; no backend / API surface change.