### PR TITLE
fix(dashboard): debounce state-invalidate refetches

### DIFF
--- a/frontend/src/components/dashboard/__tests__/useConfigurationStatus.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/useConfigurationStatus.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+const apiFetchMock = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}));
+
+const useNodesMock = vi.fn();
+vi.mock('@/context/NodeContext', () => ({
+  useNodes: () => useNodesMock(),
+}));
+
+vi.mock('@/lib/utils', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/utils')>('@/lib/utils');
+  return {
+    ...actual,
+    visibilityInterval: () => () => {},
+  };
+});
+
+import { useConfigurationStatus } from '../useConfigurationStatus';
+
+function okJson(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function fireInvalidate(detail: { scope?: string; action?: string } = {}) {
+  window.dispatchEvent(new CustomEvent('sencho:state-invalidate', { detail }));
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  apiFetchMock.mockReset();
+  apiFetchMock.mockImplementation(() => Promise.resolve(okJson({
+    tier: 'community',
+    variant: null,
+    notifications: { agents: {}, alertRules: 0, routingRules: { count: 0, enabledCount: 0, locked: true, requiredTier: 'skipper' } },
+    automation: {
+      autoHeal: { total: 0, enabled: 0 },
+      autoUpdate: { enabled: 0, total: 0 },
+      scheduledTasks: { total: 0, enabled: 0, locked: true, requiredTier: 'admiral' },
+      webhooks: { total: 0, enabled: 0, locked: true, requiredTier: 'skipper' },
+    },
+    security: {
+      mfaEnabled: null,
+      ssoEnabled: false,
+      ssoProvider: null,
+      scanPolicies: { total: 0, enabled: 0, locked: true, requiredTier: 'skipper' },
+    },
+    thresholds: { cpuLimit: 90, ramLimit: 90, diskLimit: 90, dockerJanitorGb: 5, globalCrash: false },
+    backup: { provider: 'disabled', autoUpload: false, locked: false },
+  })));
+  useNodesMock.mockReset();
+  useNodesMock.mockReturnValue({
+    activeNode: { id: 1, name: 'Local', type: 'local' },
+    nodes: [{ id: 1, name: 'Local', type: 'local' }],
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useConfigurationStatus state-invalidate handling', () => {
+  it('does not refetch on container state-invalidate events', async () => {
+    renderHook(() => useConfigurationStatus());
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    const baseline = apiFetchMock.mock.calls.length;
+
+    act(() => {
+      for (let i = 0; i < 5; i += 1) fireInvalidate({ scope: 'container' });
+    });
+    await act(async () => { vi.advanceTimersByTime(2_000); });
+
+    // Container events do not invalidate the configuration response, which is
+    // derived from settings/policy tables. The 60s poll catches settings drift.
+    expect(apiFetchMock.mock.calls.length).toBe(baseline);
+  });
+});

--- a/frontend/src/components/dashboard/__tests__/useConfigurationStatus.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/useConfigurationStatus.test.tsx
@@ -67,18 +67,38 @@ afterEach(() => {
 });
 
 describe('useConfigurationStatus state-invalidate handling', () => {
-  it('does not refetch on container state-invalidate events', async () => {
+  it('does not refetch on container or image-update state-invalidate events', async () => {
     renderHook(() => useConfigurationStatus());
     await act(async () => { await Promise.resolve(); await Promise.resolve(); });
     const baseline = apiFetchMock.mock.calls.length;
 
     act(() => {
-      for (let i = 0; i < 5; i += 1) fireInvalidate({ scope: 'container' });
+      for (let i = 0; i < 5; i += 1) fireInvalidate({ scope: 'stack' });
+      for (let i = 0; i < 5; i += 1) fireInvalidate({ scope: 'image-updates' });
     });
     await act(async () => { vi.advanceTimersByTime(2_000); });
 
-    // Container events do not invalidate the configuration response, which is
-    // derived from settings/policy tables. The 60s poll catches settings drift.
+    // Neither container churn nor image-update bursts mutate the
+    // configuration payload; the filtered listener must ignore them.
     expect(apiFetchMock.mock.calls.length).toBe(baseline);
+  });
+
+  it('refetches once on a settings-affecting auto-update-settings-changed event', async () => {
+    renderHook(() => useConfigurationStatus());
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    const baseline = apiFetchMock.mock.calls.length;
+
+    act(() => {
+      // Burst three settings-change events; the debounce should collapse
+      // them into a single refetch.
+      fireInvalidate({ action: 'auto-update-settings-changed' });
+      fireInvalidate({ action: 'auto-update-settings-changed' });
+      fireInvalidate({ action: 'auto-update-settings-changed' });
+    });
+    // Before debounce window elapses, no new fetch.
+    expect(apiFetchMock.mock.calls.length).toBe(baseline);
+
+    await act(async () => { vi.advanceTimersByTime(300); });
+    expect(apiFetchMock.mock.calls.length).toBe(baseline + 1);
   });
 });

--- a/frontend/src/components/dashboard/__tests__/useDashboardData.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/useDashboardData.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+const apiFetchMock = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}));
+
+// Stable mock for the node context: ID `1` is the active node so the hook can
+// resolve a nodeId on mount without rendering the full provider tree.
+const useNodesMock = vi.fn();
+vi.mock('@/context/NodeContext', () => ({
+  useNodes: () => useNodesMock(),
+}));
+
+// `visibilityInterval` from the live utils library uses
+// `document.visibilityState`, which jsdom treats as `prerender` until a
+// listener is attached. The polling tests below assert mount-time fetches and
+// the debounced refetch path; the long-running interval ticks themselves are
+// covered by the existing useNextAutoUpdateRun suite. Replace with a no-op
+// cleanup so the hook does not retain a real timer across tests.
+vi.mock('@/lib/utils', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/utils')>('@/lib/utils');
+  return {
+    ...actual,
+    visibilityInterval: () => () => {},
+  };
+});
+
+import { useDashboardData } from '../useDashboardData';
+
+function okJson(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function fireInvalidate(detail: { scope?: string; action?: string } = {}) {
+  window.dispatchEvent(new CustomEvent('sencho:state-invalidate', { detail }));
+}
+
+const STATS_PAYLOAD = { active: 0, managed: 0, unmanaged: 0, exited: 0, total: 0 };
+const SYS_PAYLOAD = {
+  cpu: { usage: '0', cores: 4 },
+  memory: { total: 0, used: 0, free: 0, usagePercent: '0' },
+  disk: null,
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  apiFetchMock.mockReset();
+  apiFetchMock.mockImplementation((endpoint: string) => {
+    if (endpoint === '/stats') return Promise.resolve(okJson(STATS_PAYLOAD));
+    if (endpoint === '/system/stats') return Promise.resolve(okJson(SYS_PAYLOAD));
+    if (endpoint === '/stacks/statuses') return Promise.resolve(okJson({}));
+    if (endpoint === '/metrics/historical') return Promise.resolve(okJson([]));
+    return Promise.resolve(okJson(null));
+  });
+  useNodesMock.mockReset();
+  useNodesMock.mockReturnValue({
+    activeNode: { id: 1, name: 'Local', type: 'local' },
+    nodes: [{ id: 1, name: 'Local', type: 'local' }],
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function countFetchCalls(endpoint: string): number {
+  return apiFetchMock.mock.calls.filter((call) => call[0] === endpoint).length;
+}
+
+describe('useDashboardData state-invalidate handling', () => {
+  it('debounces a burst of state-invalidate events into a single refetch', async () => {
+    renderHook(() => useDashboardData());
+    // Drain mount-time polls.
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    const baselineStats = countFetchCalls('/stats');
+    const baselineSys = countFetchCalls('/system/stats');
+    const baselineStatuses = countFetchCalls('/stacks/statuses');
+
+    act(() => {
+      // Burst: 10 container events in rapid succession.
+      for (let i = 0; i < 10; i += 1) fireInvalidate({ scope: 'container' });
+    });
+
+    // Before debounce window elapses, no new fetches.
+    expect(countFetchCalls('/stats') - baselineStats).toBe(0);
+    expect(countFetchCalls('/system/stats') - baselineSys).toBe(0);
+    expect(countFetchCalls('/stacks/statuses') - baselineStatuses).toBe(0);
+
+    await act(async () => { vi.advanceTimersByTime(300); });
+
+    // After debounce: exactly one refetch per endpoint, regardless of burst size.
+    expect(countFetchCalls('/stats') - baselineStats).toBe(1);
+    expect(countFetchCalls('/system/stats') - baselineSys).toBe(1);
+    expect(countFetchCalls('/stacks/statuses') - baselineStatuses).toBe(1);
+  });
+
+  it('cleans up the debounce timer on unmount so no late refetch fires', async () => {
+    const { unmount } = renderHook(() => useDashboardData());
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    apiFetchMock.mockClear();
+
+    act(() => { fireInvalidate({ scope: 'container' }); });
+    unmount();
+    await act(async () => { vi.advanceTimersByTime(500); });
+
+    expect(apiFetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/dashboard/useConfigurationStatus.ts
+++ b/frontend/src/components/dashboard/useConfigurationStatus.ts
@@ -64,6 +64,12 @@ export function useConfigurationStatus() {
     }
   }, []);
 
+  // Configuration data is derived from settings/policy tables (agents,
+  // alert rules, auto-heal policies, scheduled tasks, scan policies, cloud
+  // backup config). It does not depend on live container state, so the
+  // dashboard does not subscribe to `sencho:state-invalidate`. The 60 s
+  // poll catches settings drift; a settings page that mutates the response
+  // is the rare event where a one-minute lag is acceptable.
   useEffect(() => {
     setStatus(null);
     setLoading(true);
@@ -72,12 +78,6 @@ export function useConfigurationStatus() {
     guard();
     return visibilityInterval(guard, 60_000);
   }, [nodeId, fetchStatus]);
-
-  useEffect(() => {
-    const handler = () => void fetchStatus();
-    window.addEventListener('sencho:state-invalidate', handler);
-    return () => window.removeEventListener('sencho:state-invalidate', handler);
-  }, [fetchStatus]);
 
   return { status, loading };
 }

--- a/frontend/src/components/dashboard/useConfigurationStatus.ts
+++ b/frontend/src/components/dashboard/useConfigurationStatus.ts
@@ -3,6 +3,10 @@ import { useNodes } from '@/context/NodeContext';
 import { apiFetch } from '@/lib/api';
 import { visibilityInterval } from '@/lib/utils';
 
+// Trailing-edge debounce window for filtered settings-event refetches,
+// matching the precedent in useNextAutoUpdateRun.
+const INVALIDATE_DEBOUNCE_MS = 250;
+
 interface AgentStatus {
   configured: boolean;
   enabled: boolean;
@@ -66,10 +70,7 @@ export function useConfigurationStatus() {
 
   // Configuration data is derived from settings/policy tables (agents,
   // alert rules, auto-heal policies, scheduled tasks, scan policies, cloud
-  // backup config). It does not depend on live container state, so the
-  // dashboard does not subscribe to `sencho:state-invalidate`. The 60 s
-  // poll catches settings drift; a settings page that mutates the response
-  // is the rare event where a one-minute lag is acceptable.
+  // backup config). The 60 s poll catches settings drift on its own.
   useEffect(() => {
     setStatus(null);
     setLoading(true);
@@ -78,6 +79,32 @@ export function useConfigurationStatus() {
     guard();
     return visibilityInterval(guard, 60_000);
   }, [nodeId, fetchStatus]);
+
+  // Filter `sencho:state-invalidate` so only settings-affecting events
+  // refetch the configuration; the high-frequency `scope: 'stack'` and
+  // `scope: 'image-updates'` container/image bursts are ignored. Today the
+  // only such settings event is `auto-update-settings-changed` (emitted by
+  // the stack auto-update toggle). The filter is debounced and the
+  // configuration response includes the toggled state, so a user editing
+  // the setting sees the row update under a second instead of waiting up
+  // to a minute.
+  useEffect(() => {
+    let invalidateTimer: ReturnType<typeof setTimeout> | null = null;
+    const onInvalidate = (e: Event) => {
+      const detail = (e as CustomEvent<{ action?: string; scope?: string }>).detail;
+      if (detail?.action !== 'auto-update-settings-changed') return;
+      if (invalidateTimer) clearTimeout(invalidateTimer);
+      invalidateTimer = setTimeout(() => {
+        invalidateTimer = null;
+        void fetchStatus();
+      }, INVALIDATE_DEBOUNCE_MS);
+    };
+    window.addEventListener('sencho:state-invalidate', onInvalidate);
+    return () => {
+      window.removeEventListener('sencho:state-invalidate', onInvalidate);
+      if (invalidateTimer) clearTimeout(invalidateTimer);
+    };
+  }, [fetchStatus]);
 
   return { status, loading };
 }

--- a/frontend/src/components/dashboard/useDashboardData.ts
+++ b/frontend/src/components/dashboard/useDashboardData.ts
@@ -14,6 +14,10 @@ import type {
 const DEFAULT_STATS: Stats = { active: 0, managed: 0, unmanaged: 0, exited: 0, total: 0 };
 const SPARK_BUCKETS = 20;
 const SPARK_WINDOW_MS = 10 * 60 * 1000;
+// Trailing-edge debounce window for live state-invalidate refetches. Matches
+// useNextAutoUpdateRun so dashboard surfaces feel "live" without amplifying a
+// container-event burst into one HTTP request per event.
+const INVALIDATE_DEBOUNCE_MS = 250;
 
 function bucketCpu(points: MetricPoint[], windowMs: number, buckets: number): number[] {
   if (points.length === 0) return Array(buckets).fill(0);
@@ -166,13 +170,16 @@ export function useDashboardData(): DashboardData {
   // React to live `state-invalidate` signals from /ws/notifications: when a
   // Docker container event fires (start/stop/die/restart/health), the layout
   // re-broadcasts the envelope as a window CustomEvent. Refetch the cheap
-  // data (stats, system, statuses) immediately so the dashboard header and
-  // sidebar status update in well under a second instead of waiting for the
-  // next polling tick. Historical metrics are intentionally skipped — they
-  // are a 10-minute trend, not a live indicator.
+  // data (stats, system, statuses) so the dashboard header and sidebar status
+  // update in well under a second instead of waiting for the next polling
+  // tick. Historical metrics are skipped — they are a 10-minute trend, not a
+  // live indicator. The refetch is trailing-edge debounced so an event storm
+  // (e.g. a 50-container stack restart) collapses to a single coalesced
+  // refresh instead of one HTTP request per event.
   useEffect(() => {
     const currentNodeId = nodeId;
-    const onInvalidate = async () => {
+    let invalidateTimer: ReturnType<typeof setTimeout> | null = null;
+    const refresh = async () => {
       if (nodeIdRef.current !== currentNodeId) return;
       const [statsData, sysData, statusesData] = await Promise.all([
         fetchJson<Stats>('/stats'),
@@ -187,8 +194,19 @@ export function useDashboardData(): DashboardData {
       if (sysData) setSystemStats(sysData);
       if (statusesData) setStackStatuses(statusesData);
     };
+    const onInvalidate = () => {
+      if (nodeIdRef.current !== currentNodeId) return;
+      if (invalidateTimer) clearTimeout(invalidateTimer);
+      invalidateTimer = setTimeout(() => {
+        invalidateTimer = null;
+        void refresh();
+      }, INVALIDATE_DEBOUNCE_MS);
+    };
     window.addEventListener('sencho:state-invalidate', onInvalidate);
-    return () => window.removeEventListener('sencho:state-invalidate', onInvalidate);
+    return () => {
+      window.removeEventListener('sencho:state-invalidate', onInvalidate);
+      if (invalidateTimer) clearTimeout(invalidateTimer);
+    };
   }, [nodeId, fetchJson]);
 
   const stackCpuSeries = useMemo<Record<string, StackCpuSeries>>(() => {

--- a/frontend/src/components/dashboard/useDashboardData.ts
+++ b/frontend/src/components/dashboard/useDashboardData.ts
@@ -178,15 +178,19 @@ export function useDashboardData(): DashboardData {
   // refresh instead of one HTTP request per event.
   useEffect(() => {
     const currentNodeId = nodeId;
+    let active = true;
     let invalidateTimer: ReturnType<typeof setTimeout> | null = null;
     const refresh = async () => {
-      if (nodeIdRef.current !== currentNodeId) return;
+      if (!active || nodeIdRef.current !== currentNodeId) return;
       const [statsData, sysData, statusesData] = await Promise.all([
         fetchJson<Stats>('/stats'),
         fetchJson<SystemStats>('/system/stats'),
         fetchJson<Record<string, StackStatusEntry>>('/stacks/statuses'),
       ]);
-      if (nodeIdRef.current !== currentNodeId) return;
+      // Re-check after the await: an unmount or node switch may have
+      // happened while the fetches were in flight, in which case the
+      // resulting setState calls would land on a stale render tree.
+      if (!active || nodeIdRef.current !== currentNodeId) return;
       if (statsData) {
         setStats(statsData);
         setLastSyncAt(Date.now());
@@ -195,7 +199,7 @@ export function useDashboardData(): DashboardData {
       if (statusesData) setStackStatuses(statusesData);
     };
     const onInvalidate = () => {
-      if (nodeIdRef.current !== currentNodeId) return;
+      if (!active || nodeIdRef.current !== currentNodeId) return;
       if (invalidateTimer) clearTimeout(invalidateTimer);
       invalidateTimer = setTimeout(() => {
         invalidateTimer = null;
@@ -204,6 +208,7 @@ export function useDashboardData(): DashboardData {
     };
     window.addEventListener('sencho:state-invalidate', onInvalidate);
     return () => {
+      active = false;
       window.removeEventListener('sencho:state-invalidate', onInvalidate);
       if (invalidateTimer) clearTimeout(invalidateTimer);
     };


### PR DESCRIPTION
## Summary

The dashboard fired an unthrottled HTTP-3x storm for every Docker container event, amplifying a busy stack restart into hundreds of requests against the local instance. This PR debounces the live-refresh path and scopes a separate listener on `useConfigurationStatus` so that container/image-update bursts no longer trigger settings refetches.

- `useDashboardData`: trailing-edge 250 ms debounce around the `/stats`, `/system/stats`, `/stacks/statuses` refresh triggered by `sencho:state-invalidate`. Cadence mirrors the precedent in `useNextAutoUpdateRun`. Cleanup clears any pending timer **and** sets an `active` flag so a refresh already in flight cannot land setters after unmount.
- `useConfigurationStatus`: replace the bare `sencho:state-invalidate` listener with a filtered, 250 ms debounced one that responds only to `action='auto-update-settings-changed'` (the single settings-affecting event in the current taxonomy). High-frequency `scope='stack'` and `scope='image-updates'` events are ignored.

## Why

A burst restart of a 50-container stack triggered ~150 instant `/stats|/system/stats|/stacks/statuses` requests with no throttle, putting avoidable load on the local instance and on every dashboard tab. The configuration listener compounded this by re-issuing `/dashboard/configuration` (a multi-table aggregation) on the same bursts even though no setting had changed. The follow-up commit on this branch restores fast-update behaviour for the one settings event the dashboard genuinely needs to catch, without re-introducing the storm.

## Test plan

- [x] Backend `npx tsc --noEmit` clean.
- [x] Frontend `npx tsc -b --noEmit` clean.
- [x] Frontend Vitest: 300/300 passing. New specs cover the debounce path on `useDashboardData`, the ignored container/image-update bursts on `useConfigurationStatus`, and the single coalesced refetch on a settings-changed burst.
- [ ] Manual: drive a busy stack restart through the UI, confirm exactly one refresh tick lands per debounce window; toggle a stack's auto-update setting and confirm the Configuration Status row updates under a second.

## Notes

No tier, role, or capability gate changes. No new dependency. No external telemetry.