### PR TITLE
fix(dashboard): decouple FleetHeartbeat refresh from the active local node

### DIFF
--- a/frontend/src/components/dashboard/__tests__/useFleetHeartbeat.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/useFleetHeartbeat.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+const apiFetchMock = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}));
+
+const useNodesMock = vi.fn();
+vi.mock('@/context/NodeContext', () => ({
+  useNodes: () => useNodesMock(),
+}));
+
+vi.mock('@/lib/utils', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/utils')>('@/lib/utils');
+  return {
+    ...actual,
+    visibilityInterval: () => () => {},
+  };
+});
+
+import { useFleetHeartbeat } from '../useFleetHeartbeat';
+
+function okJson(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const FLEET_PAYLOAD = [
+  { id: 1, name: 'Local', type: 'local', status: 'online', stats: { active: 3, managed: 3, unmanaged: 0, exited: 0, total: 3 } },
+  { id: 2, name: 'Edge', type: 'remote', status: 'online', stats: { active: 1, managed: 1, unmanaged: 0, exited: 0, total: 1 } },
+];
+
+beforeEach(() => {
+  apiFetchMock.mockReset();
+  apiFetchMock.mockImplementation(() => Promise.resolve(okJson(FLEET_PAYLOAD)));
+  useNodesMock.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useFleetHeartbeat node-switch behavior', () => {
+  it('does not reset state when the active local node changes', async () => {
+    useNodesMock.mockReturnValue({
+      activeNode: { id: 1, name: 'Local', type: 'local' },
+      nodes: [{ id: 1, name: 'Local', type: 'local' }, { id: 2, name: 'Edge', type: 'remote' }],
+    });
+    const { result, rerender } = renderHook(() => useFleetHeartbeat());
+
+    // Wait for the mount-time fetch to land.
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    expect(result.current.loading).toBe(false);
+    expect(result.current.nodes).toHaveLength(2);
+    const fetchCountAfterMount = apiFetchMock.mock.calls.length;
+
+    // Switch the active node. Fleet data is fleet-wide so the card should
+    // keep its current rows and not flicker back to a skeleton state.
+    useNodesMock.mockReturnValue({
+      activeNode: { id: 2, name: 'Edge', type: 'remote' },
+      nodes: [{ id: 1, name: 'Local', type: 'local' }, { id: 2, name: 'Edge', type: 'remote' }],
+    });
+    rerender();
+    await act(async () => { await Promise.resolve(); });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.nodes).toHaveLength(2);
+    // No new fetch should fire on the node switch; the data is fleet-wide.
+    expect(apiFetchMock.mock.calls.length).toBe(fetchCountAfterMount);
+  });
+});

--- a/frontend/src/components/dashboard/useFleetHeartbeat.ts
+++ b/frontend/src/components/dashboard/useFleetHeartbeat.ts
@@ -1,5 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
-import { useNodes } from '@/context/NodeContext';
+import { useState, useEffect, useCallback } from 'react';
 import { apiFetch } from '@/lib/api';
 import { visibilityInterval } from '@/lib/utils';
 
@@ -28,11 +27,6 @@ export interface FleetHeartbeatResult {
 }
 
 export function useFleetHeartbeat(): FleetHeartbeatResult {
-  const { activeNode } = useNodes();
-  const nodeId = activeNode?.id;
-  const nodeIdRef = useRef(nodeId);
-  useEffect(() => { nodeIdRef.current = nodeId; }, [nodeId]);
-
   const [nodes, setNodes] = useState<FleetNodeOverview[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -55,19 +49,14 @@ export function useFleetHeartbeat(): FleetHeartbeatResult {
     }
   }, []);
 
+  // /fleet/overview is fleet-wide: the response is the same regardless of
+  // which local node is active. Re-keying on activeNode would clear the
+  // card to its skeleton state on every node switch and issue an extra
+  // unnecessary fetch.
   useEffect(() => {
-    setNodes([]); // eslint-disable-line react-hooks/set-state-in-effect
-    setLoading(true);
-    setError(null);
-    const currentNodeId = nodeId;
-    const guard = () => {
-      if (nodeIdRef.current === currentNodeId) {
-        void fetchOverview();
-      }
-    };
-    guard();
-    return visibilityInterval(guard, 30_000);
-  }, [nodeId, fetchOverview]);
+    void fetchOverview();
+    return visibilityInterval(() => { void fetchOverview(); }, 30_000);
+  }, [fetchOverview]);
 
   return { nodes, loading, error };
 }


### PR DESCRIPTION
## Summary

`useFleetHeartbeat` was keyed on `activeNode.id` and reset its state to the skeleton on every node switch, even though `/fleet/overview` returns the same fleet-wide payload regardless of which local node is active. Switching the active node caused an unnecessary flicker and an extra HTTP request.

- Drop `nodeId` from the effect's dependency array.
- Remove the `nodeIdRef` stale-write guard; without keying on `nodeId` there is no stale-node race to guard against.
- Keep the 30 s visibility-interval poll so transient remote-node offline transitions still surface within one cycle.

## Why

The card displays per-node rows for every node registered to this Sencho instance. None of those rows depend on which node the operator has selected as active locally. Re-keying the hook on `activeNode.id` was a leftover from a stricter per-node hook pattern that does not fit this surface.

## Test plan

- [x] New Vitest spec asserts that switching the active node does not reset state and does not issue an extra fetch.
- [x] Frontend `npx tsc -b --noEmit` clean.
- [x] Frontend Vitest 297/297 passing.
- [ ] Manual: open the dashboard on a multi-node setup, switch active node, confirm the FleetHeartbeat card does not flicker.

## Notes

No tier, role, or capability gate changes. No backend changes.