### PR TITLE
fix(dashboard): slow HealthStatusBar sync-label tick to 5s

### DIFF
--- a/frontend/src/components/dashboard/HealthStatusBar.tsx
+++ b/frontend/src/components/dashboard/HealthStatusBar.tsx
@@ -88,6 +88,11 @@ function useTicker(intervalMs: number): number {
   return now;
 }
 
+// The "last sync Xs" label only shifts visibly every few seconds, so a 5 s
+// re-render cadence keeps the freshness signal accurate without forcing the
+// dashboard tree through the reconciler once per second.
+const SYNC_LABEL_TICK_MS = 5000;
+
 export function HealthStatusBar({
   stats,
   systemStats,
@@ -101,7 +106,7 @@ export function HealthStatusBar({
     [stats, systemStats, notifications],
   );
   const config = healthConfig[level];
-  const now = useTicker(1000);
+  const now = useTicker(SYNC_LABEL_TICK_MS);
   const unreadAlerts = notifications.filter(n => !n.is_read).length;
   const running = `${stats.active}/${stats.total}`;
   const cpuLabel = systemStats ? `${parseFloat(systemStats.cpu.usage).toFixed(0)}%` : '--';


### PR DESCRIPTION
## Summary

`HealthStatusBar` re-rendered the dashboard masthead once per second to keep its "last sync Xs" label accurate. The label only changes visibly every few seconds, so the per-second cadence cost 60 reconciler passes per minute for no perceptible gain. Slow the tick to 5 s and name the constant.

## Why

Reducing reconciler wake-ups by 5x on a long-lived foreground surface is cheap and removes background work from a tab that is, by design, always open. The label still feels live for sub-minute deltas.

## Test plan

- [x] Frontend `npx tsc -b --noEmit` clean.
- [x] Frontend Vitest 296/296 passing.
- [ ] Manual: open the dashboard, watch the meta line, confirm "last sync Xs" advances at 5 s steps and never reads more than 5 s stale.

## Notes

No tier, role, or capability gate changes. No backend changes.