### PR TITLE
chore(dashboard): drop misleading backup.requiredTier from configuration payload

### DIFF
--- a/backend/src/routes/dashboard.ts
+++ b/backend/src/routes/dashboard.ts
@@ -42,7 +42,6 @@ export interface ConfigurationStatus {
     provider: 'disabled' | 'sencho' | 'custom';
     autoUpload: boolean;
     locked: boolean;
-    requiredTier: 'admiral';
   };
 }
 
@@ -146,10 +145,13 @@ export function buildLocalConfigurationStatus(
       globalCrash,
     },
     backup: {
+      // Cloud Backup has a per-provider tier: Custom S3 is open to every
+      // tier; Sencho Cloud Backup requires Admiral. The row is rendered for
+      // every tier because Custom S3 is universally configurable, so no
+      // dashboard-level lock is meaningful.
       provider: cloudProvider,
       autoUpload: cloudAutoUpload,
       locked: false,
-      requiredTier: 'admiral',
     },
   };
 }

--- a/frontend/src/components/dashboard/useConfigurationStatus.ts
+++ b/frontend/src/components/dashboard/useConfigurationStatus.ts
@@ -39,7 +39,6 @@ export interface ConfigurationStatus {
     provider: 'disabled' | 'sencho' | 'custom';
     autoUpload: boolean;
     locked: boolean;
-    requiredTier: 'admiral';
   };
 }
 


### PR DESCRIPTION
## Summary

`/api/dashboard/configuration` returned `backup.requiredTier: 'admiral'` even after Custom S3 was opened to every tier (#1143). The field was never read by the frontend and it misrepresented the per-provider split (Custom S3 is universal, Sencho Cloud Backup is Admiral). Remove the field from both the backend response interface and the frontend mirror type; annotate the response site so the per-provider intent stays documented.

## Why

Stale type metadata in an aggregated response is worse than no metadata: it suggests a constraint that does not exist. The actual gate lives in `routes/cloudBackup.ts` and is enforced per provider.

## Gate parity

No tier, role, or capability gate changed. The Cloud Backup row in `ConfigurationStatus.tsx` already renders for every tier (the row reads `!backup.locked`, and `locked` stays `false`); per-provider enforcement remains in the Cloud Backup endpoints. Pre-commit grep on this PR:

```
git diff --cached --name-only | rg "(tierGates|requirePaid|requireAdmiral|isPaid|isAdmiral|PaidGate|AdmiralGate|CapabilityGate)"
```

Returns no matches — no gate edits to audit.

## Test plan

- [x] Backend `npx tsc --noEmit` clean.
- [x] Frontend `npx tsc -b --noEmit` clean.
- [x] Frontend Vitest 296/296 passing.
- [ ] Manual: hit `/api/dashboard/configuration` and confirm the response no longer includes `backup.requiredTier`.

## Notes

No new dependency. No external telemetry. Field removal is a backwards-compatible narrowing of an already-unused field; consumers that ignored it continue to ignore it.