### PR TITLE
chore(dashboard): add developer-mode timing diagnostics on dashboard routes

### DIFF
--- a/backend/src/routes/dashboard.ts
+++ b/backend/src/routes/dashboard.ts
@@ -2,6 +2,7 @@ import { Router, type Request, type Response } from 'express';
 import { DatabaseService, type StackRestartSummary } from '../services/DatabaseService';
 import { CloudBackupService } from '../services/CloudBackupService';
 import { effectiveTier, effectiveVariant } from '../middleware/tierGates';
+import { isDebugEnabled } from '../utils/debug';
 import type { LicenseTier, LicenseVariant } from '../services/license-types';
 
 export const dashboardRouter = Router();
@@ -157,12 +158,20 @@ export function buildLocalConfigurationStatus(
 // All routes below are protected by the global authGate mounted at app.use('/api', authGate)
 dashboardRouter.get('/configuration', (req: Request, res: Response): void => {
   try {
+    const debug = isDebugEnabled();
+    const startedAt = debug ? Date.now() : 0;
     const nodeId = req.nodeId ?? 0;
     const userId = req.user?.userId ?? 0;
     const tier = effectiveTier(req);
     const variant = effectiveVariant(req);
 
-    res.json(buildLocalConfigurationStatus(nodeId, userId, tier, variant));
+    const payload = buildLocalConfigurationStatus(nodeId, userId, tier, variant);
+    if (debug) {
+      console.debug(
+        `[Dashboard:debug] /configuration built in ${Date.now() - startedAt} ms (nodeId=${nodeId})`,
+      );
+    }
+    res.json(payload);
   } catch (error) {
     console.error('[Dashboard] Failed to build configuration status:', error);
     res.status(500).json({ error: 'Failed to fetch configuration status' });
@@ -171,12 +180,19 @@ dashboardRouter.get('/configuration', (req: Request, res: Response): void => {
 
 dashboardRouter.get('/stack-restarts', (req: Request, res: Response): void => {
   try {
+    const debug = isDebugEnabled();
+    const startedAt = debug ? Date.now() : 0;
     const db = DatabaseService.getInstance();
     const nodeId = req.nodeId ?? 0;
     const rawDays = parseInt(String(req.query['days'] ?? '7'), 10);
     const days = isNaN(rawDays) || rawDays < 1 ? 7 : Math.min(rawDays, 30);
 
     const result: StackRestartSummary[] = db.getStackRestartSummary(nodeId, days);
+    if (debug) {
+      console.debug(
+        `[Dashboard:debug] /stack-restarts returned ${result.length} rows for nodeId=${nodeId} over ${days}d in ${Date.now() - startedAt} ms`,
+      );
+    }
     res.json(result);
   } catch (error) {
     console.error('[Dashboard] Failed to fetch stack restarts:', error);


### PR DESCRIPTION
## Summary

`/api/dashboard/configuration` reads from a dozen database tables on every mount; `/api/dashboard/stack-restarts` walks up to 30 days of restart history. When an operator reports a slow dashboard on a large deployment there is no instrumentation today that points at which endpoint is at fault. Add a single dev-mode timing line per endpoint, gated behind the existing `isDebugEnabled()` helper that reads `developer_mode` from `DatabaseService.global_settings`.

- `/configuration` logs ` [Dashboard:debug] /configuration built in <ms> ms (nodeId=N)`.
- `/stack-restarts` logs ` [Dashboard:debug] /stack-restarts returned <n> rows for nodeId=N over Dd in <ms> ms`.

Both lines are skipped entirely when developer mode is off; the timing measurement and the `console.debug` call are short-circuited at the `isDebugEnabled()` check, so production hot path is unchanged.

The 500-error paths keep their existing `console.error` lines (per the comment in `backend/src/utils/debug.ts`, error paths are exempt from the dev-mode gate).

## Why

This is the smallest observability addition that pays for itself the next time someone files a slow-dashboard ticket. No new dependency. No external telemetry. No metrics facility introduced (Sencho has no in-process metrics surface yet; filing that gap to Linear as part of the audit follow-ups).

## Test plan

- [x] Backend `npx tsc --noEmit` clean.
- [x] No existing dashboard-route Vitest suite to regress; that gap is filled by Phase 4 of the audit.
- [ ] Manual: toggle `developer_mode` on in Settings, hit `/api/dashboard/configuration` and `/api/dashboard/stack-restarts`, confirm both `[Dashboard:debug]` lines appear in the backend log. Toggle off, confirm they disappear.

## Notes

No tier, role, or capability gate changes. No frontend changes.