### PR TITLE
chore(dashboard): drop unused AgentStatus exports on both sides

### DIFF
--- a/backend/src/routes/dashboard.ts
+++ b/backend/src/routes/dashboard.ts
@@ -6,7 +6,7 @@ import type { LicenseTier, LicenseVariant } from '../services/license-types';
 
 export const dashboardRouter = Router();
 
-export interface AgentStatus {
+interface AgentStatus {
   configured: boolean;
   enabled: boolean;
 }

--- a/frontend/src/components/dashboard/useConfigurationStatus.ts
+++ b/frontend/src/components/dashboard/useConfigurationStatus.ts
@@ -3,7 +3,7 @@ import { useNodes } from '@/context/NodeContext';
 import { apiFetch } from '@/lib/api';
 import { visibilityInterval } from '@/lib/utils';
 
-export interface AgentStatus {
+interface AgentStatus {
   configured: boolean;
   enabled: boolean;
 }


### PR DESCRIPTION
## Summary

The Phase 5 dead-code sweep across the dashboard call graph (HomeDashboard ±1 hop, `dashboard/*`, `routes/dashboard.ts`) found two identically shaped surface leaks. The `AgentStatus` interface is declared and exported in both `backend/src/routes/dashboard.ts` and `frontend/src/components/dashboard/useConfigurationStatus.ts`, but no other file imports it. The frontend `StackAlertSheet` component carries a separate, differently shaped private `AgentStatus` that does not refer to either of these.

Drop the `export` keyword on both. The interfaces stay alive as file-internal types; the public surface shrinks by two names; behaviour is unchanged.

## What else the sweep looked at

- **Internal dashboard exports** (`FleetHeartbeat`, `StackRestartMap`, `useFleetHeartbeat`, `useMeshDataPlane`, `useStackRestartMap`, `useConfigurationStatus`, `FleetNodeOverview`, `StackRestartSummary`): re-exported through `dashboard/index.ts` but only consumed within the dashboard directory. Left in place — matches the barrel-everything convention in the rest of Sencho's component library.
- **`dashboard/types.ts`** (`Stats`, `SystemStats`, `MetricPoint`, `NotificationItem`, `NotificationCategory`, `StackStatusEntry`, `HealthLevel`, `StackCpuSeries`, `DashboardData`): heavily consumed across 30+ files. Nothing dead.
- **Per-file unused vars or imports**: ESLint clean on the entire dashboard surface.
- **Pre-PR #932 Recent Activity leftovers**: none. The replacement card and hooks are the only callers of the activity-related code.
- **Unused payload fields** (`requiredTier` on individual row objects, top-level `tier` / `variant`): real dead surface, but removal is wider than this PR's scope. Filed as Linear roadmap items.

## Test plan

- [x] Backend `npx tsc --noEmit` clean.
- [x] Frontend `npx tsc -b --noEmit` clean.
- [x] No behaviour change; existing dashboard Vitest coverage from `test/dashboard-vitest-coverage` continues to apply.

## Notes

No tier, role, or capability gate changes. No runtime change.