### PR TITLE
docs: soften Admiral tier wording in the introduction

### DIFF
--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -105,7 +105,7 @@ Some nodes can't accept an inbound connection (CG-NAT, locked-down VLAN, no publ
 
 ## Tiers at a glance
 
-Sencho ships in three tiers: **Community**, **Skipper**, and **Admiral**. Community covers single- and multi-node deploy, monitor, and security basics. Skipper adds automation, fleet secrets, and advanced fleet management. Admiral covers enterprise-grade controls (audit log, host console, cross-node Mesh traffic management, federation overrides, fleet-wide policy push). The full matrix lives on the [licensing page](/features/licensing).
+Sencho ships in three tiers: **Community**, **Skipper**, and **Admiral**. Community covers single- and multi-node deploy, monitor, and security basics. Skipper adds automation, fleet secrets, and advanced fleet management. Admiral covers fleet-wide governance and operational controls (audit log, host console, cross-node Mesh traffic management, federation overrides, fleet-wide policy push). The full matrix lives on the [licensing page](/features/licensing).
 
 ## Where to next
 


### PR DESCRIPTION
## Summary

Replace "enterprise-grade controls" with "fleet-wide governance and operational controls" in `docs/getting-started/introduction.mdx` (the only public-facing file using the phrase, per a sweep of \`docs/\`, README.md, SUPPORT.md, KNOWN_LIMITATIONS.md, SECURITY.md, and CONTRIBUTING.md).

## Why

"Enterprise-grade" is an absolute readiness claim that overstates the maturity of a pre-1.0 product, and it does not describe what the Admiral tier actually contains. The parenthetical already lists the real items (audit log, host console, cross-node Mesh traffic management, federation overrides, fleet-wide policy push). The new wording names that category directly: these are fleet-scale governance and operational features, not "enterprise" features.

This is the same overclaim-softening pattern as the BSL paraphrase change shipped in #1225.

## Test plan

- [ ] `docs/getting-started/introduction.mdx` renders correctly on the live docs site after merge.
- [ ] No other occurrences of "enterprise-grade" or similar absolute-readiness claims remain in public-facing files (verified via grep before this PR).

## Notes

The literal phrase the related audit suggested was "team-oriented controls." I deliberately chose "fleet-wide governance and operational controls" instead because the listed features are not about team management; they are about governance and operations at fleet scale. Happy to switch to "team-oriented" or another phrasing on request.