### PR TITLE
fix(stack-files): guard download stream destroy against the supertest in-process close race

### DIFF
--- a/backend/src/routes/stacks.ts
+++ b/backend/src/routes/stacks.ts
@@ -1521,37 +1521,18 @@ stacksRouter.get('/:stackName/files/download', async (req: Request, res: Respons
       downloadRecorded = true;
       recordFileOp(req.nodeId, 'download', startedAt, ok);
     };
-    // TEMP DIAG: capture the actual event order and response state at each
-    // step so we can identify the supertest in-process race on Linux CI.
-    // Remove after the metric race is resolved.
-    const diagId = `${stackName}/${relPath}/${startedAt}`;
-    const diag = (event: string): void => {
-      console.log(
-        `[download-diag] id=${diagId} event=${event}` +
-          ` writable=${res.writable} writableEnded=${res.writableEnded}` +
-          ` writableFinished=${res.writableFinished} headersSent=${res.headersSent}` +
-          ` reqDestroyed=${req.destroyed} recorded=${downloadRecorded}`,
-      );
-    };
-    diag('handler-setup');
     result.stream.on('error', (streamErr) => {
-      diag('stream-error');
       console.error('[files] stream error:', sanitizeForLog(getErrorMessage(streamErr, 'unknown')));
       if (!res.headersSent) res.status(500).end();
       else res.destroy();
       recordDownloadOnce(false);
     });
-    result.stream.on('end', () => {
-      diag('stream-end');
-      recordDownloadOnce(true);
-    });
+    result.stream.on('end', () => recordDownloadOnce(true));
     result.stream.on('close', () => {
-      diag('stream-close');
       if (res.writableEnded) recordDownloadOnce(true);
       else recordDownloadOnce(false);
     });
     req.on('close', () => {
-      diag('req-close');
       if (!res.writableEnded) result.stream.destroy();
     });
     logFileDiag('download stream opened', { stackName, relPath, nodeId: req.nodeId, size: result.size, elapsedMs: Date.now() - startedAt });

--- a/backend/src/routes/stacks.ts
+++ b/backend/src/routes/stacks.ts
@@ -1531,12 +1531,27 @@ stacksRouter.get('/:stackName/files/download', async (req: Request, res: Respons
     // at that point the response has the payload it needs to ship and the
     // download has succeeded from the server's perspective.
     result.stream.on('end', () => recordDownloadOnce(true));
-    // `close` is the fallback for a destroyed-mid-stream path (the req-close
-    // handler below tears the stream down on client disconnect). The flag
-    // bails when close fires post-end so a clean completion still records
-    // as success.
-    result.stream.on('close', () => recordDownloadOnce(false));
-    req.on('close', () => result.stream.destroy());
+    // `close` is the fallback for a destroyed-mid-stream path. On a real
+    // client disconnect the response was not finished, so `res.writableEnded`
+    // stays false and we book a failure. If `close` chases a prior `end` on
+    // a clean read, the flag bails. The `writableEnded` check defends against
+    // a transport that hands us `close` without `end` after the pipe already
+    // called `res.end()`.
+    result.stream.on('close', () => {
+      if (res.writableEnded) recordDownloadOnce(true);
+      else recordDownloadOnce(false);
+    });
+    // Destroy the file stream on a real client disconnect, but NOT after the
+    // pipe has already finished writing the response. Under the in-process
+    // supertest transport, `req.close` can fire as soon as the test consumes
+    // the response, which races ahead of the readable's own `end`/`close`
+    // pair. Calling `destroy()` there short-circuits the readable into a
+    // `close`-without-`end` state and the recorder booked the request as a
+    // failure even though the pipe had delivered every byte. The guard makes
+    // the cleanup conditional on the response still being in flight.
+    req.on('close', () => {
+      if (!res.writableEnded) result.stream.destroy();
+    });
     logFileDiag('download stream opened', { stackName, relPath, nodeId: req.nodeId, size: result.size, elapsedMs: Date.now() - startedAt });
     result.stream.pipe(res);
     return;

--- a/backend/src/routes/stacks.ts
+++ b/backend/src/routes/stacks.ts
@@ -1521,35 +1521,37 @@ stacksRouter.get('/:stackName/files/download', async (req: Request, res: Respons
       downloadRecorded = true;
       recordFileOp(req.nodeId, 'download', startedAt, ok);
     };
+    // TEMP DIAG: capture the actual event order and response state at each
+    // step so we can identify the supertest in-process race on Linux CI.
+    // Remove after the metric race is resolved.
+    const diagId = `${stackName}/${relPath}/${startedAt}`;
+    const diag = (event: string): void => {
+      console.log(
+        `[download-diag] id=${diagId} event=${event}` +
+          ` writable=${res.writable} writableEnded=${res.writableEnded}` +
+          ` writableFinished=${res.writableFinished} headersSent=${res.headersSent}` +
+          ` reqDestroyed=${req.destroyed} recorded=${downloadRecorded}`,
+      );
+    };
+    diag('handler-setup');
     result.stream.on('error', (streamErr) => {
+      diag('stream-error');
       console.error('[files] stream error:', sanitizeForLog(getErrorMessage(streamErr, 'unknown')));
       if (!res.headersSent) res.status(500).end();
       else res.destroy();
       recordDownloadOnce(false);
     });
-    // `end` fires after all bytes are read off disk and pushed into the pipe;
-    // at that point the response has the payload it needs to ship and the
-    // download has succeeded from the server's perspective.
-    result.stream.on('end', () => recordDownloadOnce(true));
-    // `close` is the fallback for a destroyed-mid-stream path. On a real
-    // client disconnect the response was not finished, so `res.writableEnded`
-    // stays false and we book a failure. If `close` chases a prior `end` on
-    // a clean read, the flag bails. The `writableEnded` check defends against
-    // a transport that hands us `close` without `end` after the pipe already
-    // called `res.end()`.
+    result.stream.on('end', () => {
+      diag('stream-end');
+      recordDownloadOnce(true);
+    });
     result.stream.on('close', () => {
+      diag('stream-close');
       if (res.writableEnded) recordDownloadOnce(true);
       else recordDownloadOnce(false);
     });
-    // Destroy the file stream on a real client disconnect, but NOT after the
-    // pipe has already finished writing the response. Under the in-process
-    // supertest transport, `req.close` can fire as soon as the test consumes
-    // the response, which races ahead of the readable's own `end`/`close`
-    // pair. Calling `destroy()` there short-circuits the readable into a
-    // `close`-without-`end` state and the recorder booked the request as a
-    // failure even though the pipe had delivered every byte. The guard makes
-    // the cleanup conditional on the response still being in flight.
     req.on('close', () => {
+      diag('req-close');
       if (!res.writableEnded) result.stream.destroy();
     });
     logFileDiag('download stream opened', { stackName, relPath, nodeId: req.nodeId, size: result.size, elapsedMs: Date.now() - startedAt });


### PR DESCRIPTION
## Summary

Closes the remaining race in the download metric recorder. PR #1220 moved tracking off `res.{finish,close}` and onto `stream.{end,close}`, which removed the response-event race. A second race lives one level up: under the in-process supertest transport, `req.on("close")` can fire as soon as the test consumes the response, before the readable's own `end` event is dispatched.

The unconditional `req.on("close", () => result.stream.destroy())` line forced the readable into a close-without-end state every time that happened. The close handler then booked a failure even though the pipe had delivered every byte. The test that exposes this is `records the download metric exactly once per successful response` in `stack-files-routes.test.ts:418`, which has been failing deterministically on Linux CI (verified across two runs: initial CI on PR #1226 and the re-run, both with exit code 1 on the same assertion: `successCount: expected 1, got 0`).

## Fix

Two layers of defense in `backend/src/routes/stacks.ts`:

1. **`req.on("close")` now skips destroy when the response is already finished.** If `res.writableEnded` is true the pipe has delivered every byte and the readable will end on its own; there is nothing to clean up and no synthetic close to provoke. Real client disconnects still hit the destroy path because `res.writableEnded` stays false in that case.

2. **`stream.on("close")` falls back to recording success when `res.writableEnded` is true.** Belt-and-suspenders for any transport that hands us close without end after the pipe already called `res.end()`. Real disconnects keep recording a failure because `res.writableEnded` stays false.

The semantic stays unchanged: success means the server finished reading the file off disk and pushed it into the pipe. The fix removes the spurious failure path without weakening disconnect detection.

## Test plan

- [ ] CI on this branch turns green on the `records the download metric exactly once per successful response` test (the test that was failing deterministically on Linux CI before this fix; same assertion, same line, two runs in a row, same result).
- [ ] Existing `stack-files-routes.test.ts` suite passes locally (verified: 78 passed, 4 platform-skipped on Windows).
- [ ] `backend && npx tsc --noEmit` is clean (verified).
- [ ] Manual sanity: a download flow through the UI still records a single metric per request; a real client disconnect mid-download still records a failure (the writable-not-ended path).

## Why no new test

A deterministic regression test would have to force `req.on("close")` to fire before `stream.on("end")` is dispatched while the pipe has finished writing. Supertest does not expose enough of its in-process transport to force that ordering from a test, and forcing it from outside would require mocking the route handler's `req` and `res` directly. The existing test is the regression check: it was failing deterministically before this fix; it should pass deterministically after.

## Risk

Low. The fix is two `if` checks on `res.writableEnded`, a property whose semantics are documented in Node's HTTP module. The behaviour change is strictly conservative:

- Clean download: identical (our `end` handler runs first, sets the flag, the close handler bails either way).
- Real client disconnect mid-download: identical (`res.writableEnded` is false, we destroy and record failure as before).
- Supertest race (the bug): destroy is now skipped, the readable ends on its own, the metric records success.

No other route in the file uses this pattern; the change is isolated to the download endpoint.