### PR TITLE
fix(security): gate admin-only scan affordances on isAdmin

### DIFF
--- a/frontend/src/components/EditorLayout/ShellOverlays.tsx
+++ b/frontend/src/components/EditorLayout/ShellOverlays.tsx
@@ -129,6 +129,7 @@ export function ShellOverlays({
       <VulnerabilityScanSheet
         scanId={stackMisconfigScanId}
         onClose={() => setStackMisconfigScanId(null)}
+        canManageSuppressions={isAdmin}
       />
 
       {/* Compose diff preview */}

--- a/frontend/src/components/ResourcesView.tsx
+++ b/frontend/src/components/ResourcesView.tsx
@@ -1343,7 +1343,7 @@ export default function ResourcesView() {
             <VulnerabilityScanSheet
                 scanId={inspectScanId}
                 onClose={() => setInspectScanId(null)}
-                onRescan={(imageRef) => { setInspectScanId(null); handleScanImage(imageRef, { force: true }); }}
+                onRescan={isAdmin ? (imageRef) => { setInspectScanId(null); handleScanImage(imageRef, { force: true }); } : undefined}
                 canGenerateSbom={isPaid && isAdmin}
                 canCompare
                 canManageSuppressions={isAdmin}

--- a/frontend/src/components/ResourcesView.tsx
+++ b/frontend/src/components/ResourcesView.tsx
@@ -1344,7 +1344,7 @@ export default function ResourcesView() {
                 scanId={inspectScanId}
                 onClose={() => setInspectScanId(null)}
                 onRescan={(imageRef) => { setInspectScanId(null); handleScanImage(imageRef, { force: true }); }}
-                canGenerateSbom={isPaid}
+                canGenerateSbom={isPaid && isAdmin}
                 canCompare
                 canManageSuppressions={isAdmin}
             />

--- a/frontend/src/components/SecurityHistoryView.tsx
+++ b/frontend/src/components/SecurityHistoryView.tsx
@@ -314,7 +314,7 @@ export function SecurityHistoryView({ open, onClose }: SecurityHistoryViewProps)
       <VulnerabilityScanSheet
         scanId={inspectScanId}
         onClose={() => setInspectScanId(null)}
-        canGenerateSbom={isPaid}
+        canGenerateSbom={isPaid && isAdmin}
         canCompare={false}
         canManageSuppressions={isAdmin}
       />

--- a/frontend/src/components/VulnerabilityScanSheet.tsx
+++ b/frontend/src/components/VulnerabilityScanSheet.tsx
@@ -110,8 +110,27 @@ export function VulnerabilityScanSheet({
   onRescan,
   canGenerateSbom = false,
   canCompare = false,
-  canManageSuppressions = false,
+  canManageSuppressions: canManageSuppressionsProp = false,
 }: VulnerabilityScanSheetProps) {
+  const [isReplica, setIsReplica] = useState(false);
+  useEffect(() => {
+    if (!canManageSuppressionsProp || scanId == null) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await apiFetch('/fleet/role', { localOnly: true });
+        if (!res.ok || cancelled) return;
+        const data = await res.json();
+        if (data?.role === 'replica') setIsReplica(true);
+      } catch (err) {
+        // Defense in depth: if /fleet/role is unreachable the UI keeps the
+        // write action visible and relies on the backend blockIfReplica guard.
+        console.warn('Failed to probe fleet role for replica gate:', err);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [canManageSuppressionsProp, scanId]);
+  const canManageSuppressions = canManageSuppressionsProp && !isReplica;
   const [scan, setScan] = useState<VulnerabilityScan | null>(null);
   const [details, setDetails] = useState<VulnerabilityDetail[]>([]);
   const [totalDetails, setTotalDetails] = useState(0);

--- a/frontend/src/components/VulnerabilityScanSheet.tsx
+++ b/frontend/src/components/VulnerabilityScanSheet.tsx
@@ -114,17 +114,20 @@ export function VulnerabilityScanSheet({
 }: VulnerabilityScanSheetProps) {
   const [isReplica, setIsReplica] = useState(false);
   useEffect(() => {
+    // Reset on every probe so a stale `true` from a previous replica view
+    // does not survive switching to a control instance with the sheet kept
+    // mounted by its parent. Defense in depth: if the probe never resolves
+    // the UI stays permissive and the backend blockIfReplica guard runs.
+    setIsReplica(false);
     if (!canManageSuppressionsProp || scanId == null) return;
     let cancelled = false;
     (async () => {
       try {
         const res = await apiFetch('/fleet/role', { localOnly: true });
-        if (!res.ok || cancelled) return;
+        if (cancelled || !res.ok) return;
         const data = await res.json();
-        if (data?.role === 'replica') setIsReplica(true);
+        if (!cancelled) setIsReplica(data?.role === 'replica');
       } catch (err) {
-        // Defense in depth: if /fleet/role is unreachable the UI keeps the
-        // write action visible and relies on the backend blockIfReplica guard.
         console.warn('Failed to probe fleet role for replica gate:', err);
       }
     })();

--- a/frontend/src/components/settings/MisconfigAckPanel.tsx
+++ b/frontend/src/components/settings/MisconfigAckPanel.tsx
@@ -10,6 +10,7 @@ import { ChevronLeft, ChevronRight, Plus, ShieldCheck, Trash2 } from 'lucide-rea
 import { toast } from '@/components/ui/toast-store';
 import { apiFetch } from '@/lib/api';
 import type { MisconfigAcknowledgement } from '@/types/security';
+import { useAuth } from '@/context/AuthContext';
 
 const RULE_RE = /^[A-Z0-9][A-Z0-9_-]{0,199}$/i;
 const PAGE_SIZE = 8;
@@ -33,6 +34,7 @@ interface MisconfigAckPanelProps {
 }
 
 export function MisconfigAckPanel({ isReplica }: MisconfigAckPanelProps) {
+  const { isAdmin } = useAuth();
   const [rows, setRows] = useState<MisconfigAcknowledgement[]>([]);
   const [loading, setLoading] = useState(true);
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -179,7 +181,7 @@ export function MisconfigAckPanel({ isReplica }: MisconfigAckPanelProps) {
               </Button>
             </>
           )}
-          {!isReplica && (
+          {isAdmin && !isReplica && (
             <Button size="sm" onClick={openCreate}>
               <Plus className="w-4 h-4 mr-1.5" />
               Add Acknowledgement
@@ -231,7 +233,7 @@ export function MisconfigAckPanel({ isReplica }: MisconfigAckPanelProps) {
                     by {row.created_by} · expires {formatExpiry(row)}
                   </div>
                 </div>
-                {!isReplica && row.replicated_from_control === 0 && (
+                {isAdmin && !isReplica && row.replicated_from_control === 0 && (
                   <Button
                     variant="ghost"
                     size="icon"

--- a/frontend/src/components/settings/SecuritySection.tsx
+++ b/frontend/src/components/settings/SecuritySection.tsx
@@ -18,6 +18,7 @@ import { useNodes } from '@/context/NodeContext';
 import { useTrivyStatus } from '@/hooks/useTrivyStatus';
 import { SuppressionsPanel } from './SuppressionsPanel';
 import { MisconfigAckPanel } from './MisconfigAckPanel';
+import { useAuth } from '@/context/AuthContext';
 
 const SEVERITY_OPTIONS: Array<{ value: VulnSeverity; label: string }> = [
   { value: 'CRITICAL', label: 'Critical' },
@@ -61,6 +62,7 @@ const TRIVY_OP_LABELS: Record<'install' | 'update' | 'uninstall', { loading: str
 };
 
 export function SecuritySection({ isPaid }: { isPaid: boolean }) {
+  const { isAdmin } = useAuth();
   const [policies, setPolicies] = useState<ScanPolicy[]>([]);
   const [loading, setLoading] = useState(true);
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -291,7 +293,7 @@ export function SecuritySection({ isPaid }: { isPaid: boolean }) {
 
   return (
     <div className="space-y-6">
-      {isPaid && !isRemote && !isReplica && (
+      {isPaid && isAdmin && !isRemote && !isReplica && (
         <div className="flex justify-end">
           <SettingsPrimaryButton size="sm" onClick={openCreate}>
             <Plus className="w-4 h-4" />
@@ -358,7 +360,7 @@ export function SecuritySection({ isPaid }: { isPaid: boolean }) {
             )}
           </div>
           <div className="flex items-center gap-2 shrink-0">
-            {trivy.source === 'none' && (
+            {isAdmin && trivy.source === 'none' && (
               <SettingsPrimaryButton size="sm" onClick={handleInstallTrivy} disabled={trivyBusy !== null}>
                 {trivyBusy === 'install' ? (
                   <Loader2 className="w-3.5 h-3.5 mr-1.5 animate-spin" strokeWidth={1.5} />
@@ -368,7 +370,7 @@ export function SecuritySection({ isPaid }: { isPaid: boolean }) {
                 Install Trivy
               </SettingsPrimaryButton>
             )}
-            {trivy.source === 'managed' && updateCheck?.updateAvailable && (
+            {isAdmin && trivy.source === 'managed' && updateCheck?.updateAvailable && (
               <Button size="sm" variant="outline" onClick={handleUpdateTrivy} disabled={trivyBusy !== null}>
                 {trivyBusy === 'update' ? (
                   <Loader2 className="w-3.5 h-3.5 mr-1.5 animate-spin" strokeWidth={1.5} />
@@ -378,7 +380,7 @@ export function SecuritySection({ isPaid }: { isPaid: boolean }) {
                 Update
               </Button>
             )}
-            {trivy.source === 'managed' && (
+            {isAdmin && trivy.source === 'managed' && (
               <Button
                 size="sm"
                 variant="ghost"
@@ -399,7 +401,7 @@ export function SecuritySection({ isPaid }: { isPaid: boolean }) {
           <div className="text-xs text-stat-subtitle">{TRIVY_SOURCE_DESCRIPTIONS[trivy.source]}</div>
         )}
 
-        {trivy.source === 'managed' && isPaid && (
+        {trivy.source === 'managed' && isPaid && isAdmin && (
           <div className="flex items-center justify-between rounded-lg border border-glass-border px-3 py-2.5">
             <div>
               <Label className="text-sm">Auto-update Trivy</Label>
@@ -468,7 +470,7 @@ export function SecuritySection({ isPaid }: { isPaid: boolean }) {
                   </Badge>
                 )}
               </div>
-              {!isReplica && (
+              {isAdmin && !isReplica && (
                 <div className="flex items-center gap-1 shrink-0">
                   <Button
                     variant="ghost"

--- a/frontend/src/components/settings/SuppressionsPanel.tsx
+++ b/frontend/src/components/settings/SuppressionsPanel.tsx
@@ -10,6 +10,7 @@ import { ChevronLeft, ChevronRight, Plus, ShieldOff, Trash2 } from 'lucide-react
 import { toast } from '@/components/ui/toast-store';
 import { apiFetch } from '@/lib/api';
 import type { CveSuppression } from '@/types/security';
+import { useAuth } from '@/context/AuthContext';
 
 const CVE_ID_RE = /^(CVE-\d{4}-\d{4,}|GHSA-[\w-]{14,})$/;
 const PAGE_SIZE = 8;
@@ -35,6 +36,7 @@ interface SuppressionsPanelProps {
 }
 
 export function SuppressionsPanel({ isReplica }: SuppressionsPanelProps) {
+  const { isAdmin } = useAuth();
   const [rows, setRows] = useState<CveSuppression[]>([]);
   const [loading, setLoading] = useState(true);
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -182,7 +184,7 @@ export function SuppressionsPanel({ isReplica }: SuppressionsPanelProps) {
               </Button>
             </>
           )}
-          {!isReplica && (
+          {isAdmin && !isReplica && (
             <Button size="sm" onClick={openCreate}>
               <Plus className="w-4 h-4 mr-1.5" />
               Add Suppression
@@ -239,7 +241,7 @@ export function SuppressionsPanel({ isReplica }: SuppressionsPanelProps) {
                     by {row.created_by} - expires {formatExpiry(row)}
                   </div>
                 </div>
-                {!isReplica && row.replicated_from_control === 0 && (
+                {isAdmin && !isReplica && row.replicated_from_control === 0 && (
                   <Button
                     variant="ghost"
                     size="icon"


### PR DESCRIPTION
## Summary

The Vulnerability Scanning feature exposed several admin-only backend routes through frontend buttons that lacked an `isAdmin` gate. Non-admin users at the same tier saw the affordance, clicked it, and got a 403 toast.

This PR threads `isAdmin` from `useAuth()` into the affected components so the trigger renders only when the user can actually complete the action. A follow-up commit closes three additional sites surfaced by independent review (SecurityHistoryView SBOM/SARIF, the sheet's Re-scan primary action, and replica-admin suppress/ack columns).

## Gate parity

| Backend route | Backend guard | Frontend surface | After |
|---|---|---|---|
| `POST /api/security/trivy-install` | `requireAdmin` | `SecuritySection.tsx` Install Trivy button | `isAdmin && trivy.source === 'none'` |
| `POST /api/security/trivy-update` | `requireAdmin` | `SecuritySection.tsx` Update button | `isAdmin && trivy.source === 'managed' && updateAvailable` |
| `DELETE /api/security/trivy-install` | `requireAdmin` | `SecuritySection.tsx` Uninstall button | `isAdmin && trivy.source === 'managed'` |
| `PUT /api/security/trivy-auto-update` | `requireAdmin + requirePaid` | `SecuritySection.tsx` auto-update toggle | `isPaid && isAdmin && trivy.source === 'managed'` |
| `POST/PUT/DELETE /api/security/policies` | `requireAdmin + requirePaid` | `SecuritySection.tsx` Add/Edit/Delete policy | `isPaid && isAdmin && !isRemote && !isReplica` (Add); `isAdmin && !isReplica` (CRUD) |
| `POST /api/security/sbom` | `requireAdmin + requirePaid` | `VulnerabilityScanSheet` SBOM button via `canGenerateSbom` prop | callers pass `isPaid && isAdmin` (ResourcesView, SecurityHistoryView) |
| `GET /api/security/scans/:id/sarif` | `requireAdmin + requirePaid` | `VulnerabilityScanSheet` SARIF button via `canGenerateSbom` prop | same as SBOM |
| `POST /api/security/scan` (Re-scan from sheet) | `requireAdmin` | `VulnerabilityScanSheet` primary Re-scan action via `onRescan` prop | ResourcesView passes `onRescan` only for `isAdmin` |
| `POST/PUT/DELETE /api/security/suppressions` | `requireAdmin` + `blockIfReplica` on writes | `SuppressionsPanel.tsx` Add/Remove; `VulnerabilityScanSheet` inline suppress | `isAdmin && !isReplica` in panel; sheet probes `/fleet/role` and ANDs `!isReplica` into `canManageSuppressions` |
| `POST/PUT/DELETE /api/security/misconfig-acks` | `requireAdmin` + `blockIfReplica` on writes | `MisconfigAckPanel.tsx` Add/Remove; `VulnerabilityScanSheet` inline ack | same as suppressions |
| `POST /api/security/misconfig-acks` (from stack-misconfig sheet) | `requireAdmin` + `blockIfReplica` | `VulnerabilityScanSheet` from `ShellOverlays.tsx` | `canManageSuppressions={isAdmin}`; sheet ANDs `!isReplica` internally |

Read paths (`GET /api/security/scans`, `/scans/:id`, `/scans/:id/vulnerabilities`, `/secrets`, `/misconfigs`, `/suppressions`, `/misconfig-acks`, `/compare`, `/image-summaries`, `/trivy-status`) remain visible to non-admins; auth-only on both sides. `GET /api/security/policies` is paid-gated on the backend and the matching list view in SecuritySection is gated on `isPaid`; non-admin paid users see policy reads (intended).

Scan trigger buttons themselves were already correctly gated: `ResourcesView` image-scan dropdown on `trivy.available && isAdmin`, `EditorView` stack-scan menu item on `trivy.available && isAdmin`. The new internal replica probe inside `VulnerabilityScanSheet` is best-effort: if `/fleet/role` is unreachable, the UI keeps the write action visible and the backend's `blockIfReplica` guard remains the source of truth.

## Notes

- Backend code is untouched.
- `canGenerateSbom` prop on `VulnerabilityScanSheet` controls both SBOM and SARIF rendering. The name is a carryover; renaming was out of scope. A follow-up could split it into `canGenerateSbom` and `canExportSarif` or rename to `canExportSecurityArtifacts`.
- No new dependencies. No schema changes. No new env vars.

## Test plan

- [x] `cd backend && npx tsc --noEmit` clean
- [x] `cd frontend && npx tsc -b --noEmit` clean
- [x] Frontend Vitest: 337/337 pass (40 files)
- [x] Backend scan-related Vitest: 77/77 pass (6 files). Unrelated Windows-SQLite-flake failures in mesh/fleet/filesystem-backup suites are pre-existing and untouched.
- [ ] Manual UI walk as Community admin: SecuritySection shows Trivy install/update/uninstall; SuppressionsPanel and MisconfigAckPanel show Add/Remove.
- [ ] Manual UI walk as Community non-admin: Trivy install/update/uninstall hidden; suppression/ack Add hidden; per-row Remove hidden; opening a scan summary from ResourcesView opens the sheet but the Re-scan primary action is absent.
- [ ] Manual UI walk as Skipper admin (via dev-license toggle): all affordances visible and functional, including SBOM, SARIF, Re-scan, suppress/ack columns.
- [ ] Manual UI walk as Skipper non-admin: paid+admin affordances hidden (SBOM, SARIF, auto-update toggle, policy CRUD); paid reads still visible (policy list); direct-route calls still 403 (defense in depth).
- [ ] Manual UI walk as Admiral admin on a replica: SuppressionsPanel/MisconfigAckPanel Add/Remove hidden; inline suppress/ack columns inside the scan sheet hidden once `/fleet/role` resolves to replica.

## Linear follow-ups (1.1 backlog)

SEN-87 poll cadence rework, SEN-88 developer_mode logging migration, SEN-89 scheduled-scan-on-remote UX, SEN-90 in-process scan metrics, SEN-91 VEX docs clarification, SEN-92 VulnerabilityScanSheet component tests, SEN-93 E2E + tier-persona matrix, SEN-94 troubleshooting accordion.