### PR TITLE
feat(security): per-image scroll + retention cap in scan history

### DIFF
--- a/backend/src/__tests__/database-scan-list.test.ts
+++ b/backend/src/__tests__/database-scan-list.test.ts
@@ -16,13 +16,14 @@ beforeAll(async () => {
 afterAll(() => cleanupTestDb(tmpDir));
 
 function seedScan(overrides: Partial<{
+  node_id: number;
   image_ref: string;
   scanned_at: number;
   status: 'completed' | 'in_progress' | 'failed';
 }> = {}): number {
   const db = DatabaseService.getInstance();
   return db.createVulnerabilityScan({
-    node_id: 1,
+    node_id: overrides.node_id ?? 1,
     image_ref: overrides.image_ref ?? 'alpine:3.19',
     image_digest: `sha256:${Math.random().toString(16).slice(2)}`,
     scanned_at: overrides.scanned_at ?? Date.now(),
@@ -91,5 +92,115 @@ describe('getVulnerabilityScans filters and pagination', () => {
     expect(page1.items).toHaveLength(2);
     expect(page2.items).toHaveLength(2);
     expect(page1.items[0].id).not.toBe(page2.items[0].id);
+  });
+});
+
+describe('getVulnerabilityScans per-image cap', () => {
+  it('caps rows per image_ref when no imageRef filter is set', () => {
+    const db = DatabaseService.getInstance();
+    db.updateGlobalSetting('scan_history_per_image_limit', '10');
+
+    for (let i = 0; i < 80; i++) seedScan({ image_ref: 'hot:latest', scanned_at: 1000 + i });
+    for (let i = 0; i < 5; i++) seedScan({ image_ref: 'cool:latest', scanned_at: 1000 + i });
+
+    const result = db.getVulnerabilityScans(1, { limit: 500 });
+    const hotRows = result.items.filter((s) => s.image_ref === 'hot:latest');
+    const coolRows = result.items.filter((s) => s.image_ref === 'cool:latest');
+
+    expect(hotRows).toHaveLength(10);
+    expect(coolRows).toHaveLength(5);
+    expect(result.total).toBe(15);
+    expect(result.cappedImageRefs).toEqual(['hot:latest']);
+    expect(result.perImageLimit).toBe(10);
+  });
+
+  it('bypasses the cap when imageRef targets a single image', () => {
+    const db = DatabaseService.getInstance();
+    db.updateGlobalSetting('scan_history_per_image_limit', '10');
+
+    for (let i = 0; i < 30; i++) seedScan({ image_ref: 'hot:latest', scanned_at: 1000 + i });
+
+    const result = db.getVulnerabilityScans(1, { imageRef: 'hot:latest', limit: 500 });
+    expect(result.items).toHaveLength(30);
+    expect(result.total).toBe(30);
+    expect(result.cappedImageRefs).toEqual([]);
+  });
+});
+
+describe('pruneScanHistoryPerImage', () => {
+  it('keeps the newest N rows per (node_id, image_ref) and deletes the rest', () => {
+    const db = DatabaseService.getInstance();
+    for (let i = 0; i < 60; i++) seedScan({ image_ref: 'hot:latest', scanned_at: 1000 + i });
+    for (let i = 0; i < 5; i++) seedScan({ image_ref: 'cool:latest', scanned_at: 1000 + i });
+
+    const deleted = db.pruneScanHistoryPerImage(50);
+    expect(deleted).toBe(10);
+
+    const after = db.getVulnerabilityScans(1, { imageRef: 'hot:latest', limit: 500 });
+    expect(after.items).toHaveLength(50);
+    const oldest = Math.min(...after.items.map((s) => s.scanned_at));
+    expect(oldest).toBe(1010);
+
+    const cool = db.getVulnerabilityScans(1, { imageRef: 'cool:latest', limit: 500 });
+    expect(cool.items).toHaveLength(5);
+  });
+
+  it('is a no-op when no image exceeds the cap', () => {
+    const db = DatabaseService.getInstance();
+    for (let i = 0; i < 3; i++) seedScan({ image_ref: 'small:latest', scanned_at: 1000 + i });
+
+    const deleted = db.pruneScanHistoryPerImage(50);
+    expect(deleted).toBe(0);
+  });
+
+  it('partitions by node_id so two nodes scanning the same image keep independent histories', () => {
+    const db = DatabaseService.getInstance();
+    db.getDb()
+      .prepare(`INSERT INTO nodes (id, name, type, compose_dir, is_default, status, created_at)
+                VALUES (2, 'Peer', 'remote', '/tmp', 0, 'online', ?)`)
+      .run(Date.now());
+
+    for (let i = 0; i < 60; i++) seedScan({ node_id: 1, image_ref: 'alpine:3.19', scanned_at: 1000 + i });
+    for (let i = 0; i < 60; i++) seedScan({ node_id: 2, image_ref: 'alpine:3.19', scanned_at: 2000 + i });
+
+    const deleted = db.pruneScanHistoryPerImage(50);
+    expect(deleted).toBe(20);
+
+    const node1 = db.getVulnerabilityScans(1, { imageRef: 'alpine:3.19', limit: 500 });
+    const node2 = db.getVulnerabilityScans(2, { imageRef: 'alpine:3.19', limit: 500 });
+    expect(node1.items).toHaveLength(50);
+    expect(node2.items).toHaveLength(50);
+  });
+
+  it('deletes child vulnerability_details rows for pruned scans', () => {
+    const db = DatabaseService.getInstance();
+    const ids: number[] = [];
+    for (let i = 0; i < 60; i++) {
+      ids.push(seedScan({ image_ref: 'hot:latest', scanned_at: 1000 + i }));
+    }
+    const oldestScanId = ids[0];
+    db.insertVulnerabilityDetails(oldestScanId, [{
+      vulnerability_id: 'CVE-2020-0001',
+      pkg_name: 'libfoo',
+      installed_version: '1.0',
+      fixed_version: '1.1',
+      severity: 'HIGH',
+      title: 'Test',
+      description: null,
+      primary_url: null,
+    }]);
+
+    const beforeChildren = db.getDb()
+      .prepare('SELECT COUNT(*) as cnt FROM vulnerability_details WHERE scan_id = ?')
+      .get(oldestScanId) as { cnt: number };
+    expect(beforeChildren.cnt).toBe(1);
+
+    const deleted = db.pruneScanHistoryPerImage(50);
+    expect(deleted).toBe(10);
+
+    const afterChildren = db.getDb()
+      .prepare('SELECT COUNT(*) as cnt FROM vulnerability_details WHERE scan_id = ?')
+      .get(oldestScanId) as { cnt: number };
+    expect(afterChildren.cnt).toBe(0);
   });
 });

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -23,6 +23,7 @@ const ALLOWED_SETTING_KEYS = new Set([
   'log_retention_days',
   'audit_retention_days',
   'mesh_auto_recreate',
+  'scan_history_per_image_limit',
 ]);
 
 // Bulk PATCH schema. All keys optional; present keys are fully validated.
@@ -39,6 +40,7 @@ const SettingsPatchSchema = z.object({
   log_retention_days: z.coerce.number().int().min(1).max(365).transform(String),
   audit_retention_days: z.coerce.number().int().min(1).max(365).transform(String),
   mesh_auto_recreate: z.enum(['0', '1']),
+  scan_history_per_image_limit: z.coerce.number().int().min(5).max(1000).transform(String),
 }).partial();
 
 export const settingsRouter = Router();

--- a/backend/src/services/DatabaseService.ts
+++ b/backend/src/services/DatabaseService.ts
@@ -1244,6 +1244,7 @@ export class DatabaseService {
         stmt.run('developer_mode', '0');
         stmt.run('metrics_retention_hours', '24');
         stmt.run('log_retention_days', '30');
+        stmt.run('scan_history_per_image_limit', '50');
         stmt.run('trivy_auto_update', '0');
         stmt.run('trivy_last_notified_version', '');
         stmt.run('mesh_auto_recreate', '0');
@@ -3402,7 +3403,7 @@ export class DatabaseService {
     public getVulnerabilityScans(
         nodeId: number,
         opts: { imageRef?: string; imageRefLike?: string; status?: VulnScanStatus; limit?: number; offset?: number } = {},
-    ): { items: VulnerabilityScan[]; total: number } {
+    ): { items: VulnerabilityScan[]; total: number; cappedImageRefs: string[]; perImageLimit: number } {
         const limit = Math.max(1, Math.min(opts.limit ?? 50, 500));
         const offset = Math.max(0, opts.offset ?? 0);
         const where = ['node_id = ?'];
@@ -3420,17 +3421,100 @@ export class DatabaseService {
             params.push(opts.status);
         }
         const whereSql = where.join(' AND ');
+
+        // Grouped (history) view caps rows per image_ref so a hot image
+        // cannot drown out the others. Single-image deep-dive (imageRef set)
+        // bypasses the cap so users can drill past it.
+        const applyPerImageCap = !opts.imageRef;
+        const parsedLimit = parseInt(this.getGlobalSettings()['scan_history_per_image_limit'] ?? '50', 10);
+        const perImageLimit = parsedLimit > 0 ? parsedLimit : 50;
+
+        if (!applyPerImageCap) {
+            const total = (
+                this.db
+                    .prepare(`SELECT COUNT(*) as cnt FROM vulnerability_scans WHERE ${whereSql}`)
+                    .get(...(params as never[])) as { cnt: number }
+            ).cnt;
+            const items = this.db
+                .prepare(
+                    `SELECT * FROM vulnerability_scans WHERE ${whereSql} ORDER BY scanned_at DESC LIMIT ? OFFSET ?`,
+                )
+                .all(...(params as never[]), limit, offset) as VulnerabilityScan[];
+            return { items, total, cappedImageRefs: [], perImageLimit };
+        }
+
+        const rankedCte = `WITH ranked AS (
+            SELECT *, ROW_NUMBER() OVER (PARTITION BY image_ref ORDER BY scanned_at DESC) AS rn
+            FROM vulnerability_scans
+            WHERE ${whereSql}
+        )`;
         const total = (
             this.db
-                .prepare(`SELECT COUNT(*) as cnt FROM vulnerability_scans WHERE ${whereSql}`)
-                .get(...(params as never[])) as { cnt: number }
+                .prepare(`${rankedCte} SELECT COUNT(*) as cnt FROM ranked WHERE rn <= ?`)
+                .get(...(params as never[]), perImageLimit) as { cnt: number }
         ).cnt;
         const items = this.db
             .prepare(
-                `SELECT * FROM vulnerability_scans WHERE ${whereSql} ORDER BY scanned_at DESC LIMIT ? OFFSET ?`,
+                `${rankedCte} SELECT id, node_id, image_ref, image_digest, scanned_at,
+                    total_vulnerabilities, critical_count, high_count, medium_count, low_count,
+                    unknown_count, fixable_count, secret_count, misconfig_count, scanners_used,
+                    highest_severity, os_info, trivy_version, scan_duration_ms, triggered_by,
+                    status, error, stack_context, policy_evaluation
+                 FROM ranked WHERE rn <= ?
+                 ORDER BY scanned_at DESC LIMIT ? OFFSET ?`,
             )
-            .all(...(params as never[]), limit, offset) as VulnerabilityScan[];
-        return { items, total };
+            .all(...(params as never[]), perImageLimit, limit, offset) as VulnerabilityScan[];
+
+        // Identify which image_refs sit at or above the cap so the UI can
+        // flag them. `>=` (not `>`) is intentional: the daily prune keeps
+        // each image at exactly perImageLimit rows, so by the time a user
+        // opens the history sheet the underlying count rarely exceeds the
+        // cap. Flagging at-cap groups still tells the truth (older scans
+        // have been or will be pruned at this image's next scan).
+        const cappedRows = this.db
+            .prepare(
+                `SELECT image_ref FROM vulnerability_scans
+                 WHERE ${whereSql}
+                 GROUP BY image_ref HAVING COUNT(*) >= ?`,
+            )
+            .all(...(params as never[]), perImageLimit) as Array<{ image_ref: string }>;
+        const cappedImageRefs = cappedRows.map((r) => r.image_ref);
+
+        return { items, total, cappedImageRefs, perImageLimit };
+    }
+
+    /**
+     * Per-image scan history pruner. For each (node_id, image_ref), keep the
+     * newest N scans (ordered by scanned_at DESC) and delete older rows along
+     * with their child findings. SQLite foreign-key cascade is not enabled
+     * at the connection level here, so children are deleted explicitly. The
+     * subquery is self-contained so we don't bind one parameter per ID. A
+     * first-run backlog of thousands of stale scans would otherwise blow
+     * past SQLITE_MAX_VARIABLE_NUMBER.
+     */
+    public pruneScanHistoryPerImage(perImageLimit: number): number {
+        const limit = Math.max(1, Math.floor(perImageLimit));
+        const overflowSubquery = `SELECT id FROM (
+            SELECT id, ROW_NUMBER() OVER (
+              PARTITION BY node_id, image_ref ORDER BY scanned_at DESC
+            ) AS rn
+            FROM vulnerability_scans
+          ) WHERE rn > ?`;
+        const deleteChild = (table: string) =>
+            this.db
+                .prepare(`DELETE FROM ${table} WHERE scan_id IN (${overflowSubquery})`)
+                .run(limit);
+        const deleteParent = this.db.prepare(
+            `DELETE FROM vulnerability_scans WHERE id IN (${overflowSubquery})`,
+        );
+
+        const txn = this.db.transaction(() => {
+            deleteChild('vulnerability_details');
+            deleteChild('secret_findings');
+            deleteChild('misconfig_findings');
+            return deleteParent.run(limit).changes;
+        });
+        return txn();
     }
 
     public getLatestScanForImage(

--- a/backend/src/services/MonitorService.ts
+++ b/backend/src/services/MonitorService.ts
@@ -551,7 +551,9 @@ export class MonitorService {
             const notifSummary = db.cleanupOldNotifications(isNaN(retentionDays) ? 30 : retentionDays);
             const auditRetentionDays = parseInt(settings['audit_retention_days'] || '90', 10);
             db.cleanupOldAuditLogs(isNaN(auditRetentionDays) ? 90 : auditRetentionDays);
-            if (isDebugEnabled()) console.log(`[Monitor:diag] Cleanup: metrics ${isNaN(retentionHours) ? 24 : retentionHours}h, notifications ${isNaN(retentionDays) ? 30 : retentionDays}d (ttl=${notifSummary.ttl} perStack=${notifSummary.perStack} perNode=${notifSummary.perNode}), audit ${isNaN(auditRetentionDays) ? 90 : auditRetentionDays}d`);
+            const scanPerImage = parseInt(settings['scan_history_per_image_limit'] || '50', 10);
+            const scanPruned = db.pruneScanHistoryPerImage(isNaN(scanPerImage) ? 50 : scanPerImage);
+            if (isDebugEnabled()) console.log(`[Monitor:diag] Cleanup: metrics ${isNaN(retentionHours) ? 24 : retentionHours}h, notifications ${isNaN(retentionDays) ? 30 : retentionDays}d (ttl=${notifSummary.ttl} perStack=${notifSummary.perStack} perNode=${notifSummary.perNode}), audit ${isNaN(auditRetentionDays) ? 90 : auditRetentionDays}d, scans pruned ${scanPruned}`);
         } catch (e) {
             console.error('MonitorService: failed to cleanup old data', e);
         }

--- a/frontend/src/components/SecurityHistoryView.tsx
+++ b/frontend/src/components/SecurityHistoryView.tsx
@@ -118,7 +118,13 @@ export function SecurityHistoryView({ open, onClose }: SecurityHistoryViewProps)
     // happen to match the previous values, so the fetch re-runs exactly once.
   }, [open, load, page, search, reloadToken]);
 
+  // Skip the initial mount: the effect fires once with the original
+  // searchDraft, and unconditionally resetting page to 0 after 300ms races
+  // with any pagination the user may have done in that window.
+  const prevSearchDraftRef = useRef(searchDraft);
   useEffect(() => {
+    if (prevSearchDraftRef.current === searchDraft) return;
+    prevSearchDraftRef.current = searchDraft;
     const t = setTimeout(() => {
       setSearch(searchDraft);
       setPage(0);

--- a/frontend/src/components/SecurityHistoryView.tsx
+++ b/frontend/src/components/SecurityHistoryView.tsx
@@ -65,6 +65,7 @@ export function SecurityHistoryView({ open, onClose }: SecurityHistoryViewProps)
   const { activeNode } = useNodes();
   const [scans, setScans] = useState<VulnerabilityScan[]>([]);
   const [total, setTotal] = useState(0);
+  const [capInfo, setCapInfo] = useState<{ perImageLimit: number; refs: Set<string> } | null>(null);
   const [loading, setLoading] = useState(false);
   const [searchDraft, setSearchDraft] = useState('');
   const [search, setSearch] = useState('');
@@ -88,6 +89,9 @@ export function SecurityHistoryView({ open, onClose }: SecurityHistoryViewProps)
       const items: VulnerabilityScan[] = Array.isArray(body?.items) ? body.items : [];
       setScans(items);
       setTotal(typeof body?.total === 'number' ? body.total : items.length);
+      const limit = typeof body?.perImageLimit === 'number' ? body.perImageLimit : 0;
+      const refs: string[] = Array.isArray(body?.cappedImageRefs) ? body.cappedImageRefs : [];
+      setCapInfo(limit > 0 ? { perImageLimit: limit, refs: new Set(refs) } : null);
     } catch (err) {
       toast.error((err as Error)?.message || 'Could not load scan history');
     } finally {
@@ -227,79 +231,89 @@ export function SecurityHistoryView({ open, onClose }: SecurityHistoryViewProps)
         ) : (
           <ScrollArea block className="max-h-[60vh]">
             <div className="space-y-5">
-              {groups.map((group) => (
-                <div key={group.image_ref}>
-                  <div className="flex items-center gap-2 mb-1.5">
-                    <span className="font-mono text-sm truncate" title={group.image_ref}>
-                      {group.image_ref}
-                    </span>
-                    <span className="text-xs text-stat-subtitle">
-                      {group.scans.length} scan{group.scans.length === 1 ? '' : 's'}
-                    </span>
-                  </div>
-                  <Table>
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead className="w-[40px]" />
-                        <TableHead className="w-[180px]">Scanned</TableHead>
-                        <TableHead className="w-[120px]">Trigger</TableHead>
-                        <TableHead className="w-[120px]">Highest</TableHead>
-                        <TableHead className="w-[90px] text-right">Total</TableHead>
-                        <TableHead className="w-[90px] text-right">Fixable</TableHead>
-                        <TableHead />
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {group.scans.map((scan) => {
-                        const isSelected = selected.includes(scan.id);
-                        return (
-                          <TableRow
-                            key={scan.id}
-                            className={cn(isSelected && 'bg-accent/30')}
-                          >
-                            <TableCell>
-                              <Checkbox
-                                checked={isSelected}
-                                onCheckedChange={() => toggleSelect(scan.id)}
-                                aria-label={`Select scan ${scan.id}`}
-                              />
-                            </TableCell>
-                            <TableCell className="font-mono text-xs">
-                              {new Date(scan.scanned_at).toLocaleString()}
-                            </TableCell>
-                            <TableCell className="font-mono text-xs capitalize">
-                              {scan.triggered_by}
-                            </TableCell>
-                            <TableCell>
-                              {scan.highest_severity ? (
-                                <SeverityChip severity={scan.highest_severity} />
-                              ) : (
-                                <span className="text-xs text-success font-mono">none</span>
-                              )}
-                            </TableCell>
-                            <TableCell className="text-right font-mono text-xs tabular-nums">
-                              {scan.total_vulnerabilities}
-                            </TableCell>
-                            <TableCell className="text-right font-mono text-xs tabular-nums text-success">
-                              {scan.fixable_count}
-                            </TableCell>
-                            <TableCell className="text-right">
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                className="h-7 text-xs"
-                                onClick={() => setInspectScanId(scan.id)}
-                              >
-                                Open
-                              </Button>
-                            </TableCell>
+              {groups.map((group) => {
+                const isCapped = capInfo?.refs.has(group.image_ref) ?? false;
+                return (
+                  <div key={group.image_ref}>
+                    <div className="flex items-center gap-2 mb-1.5">
+                      <span className="font-mono text-sm truncate" title={group.image_ref}>
+                        {group.image_ref}
+                      </span>
+                      <span className="text-xs text-stat-subtitle">
+                        {group.scans.length} scan{group.scans.length === 1 ? '' : 's'}
+                      </span>
+                      {isCapped && capInfo && (
+                        <span className="text-xs text-stat-subtitle italic">
+                          Capped at {capInfo.perImageLimit} · older scans pruned
+                        </span>
+                      )}
+                    </div>
+                    <ScrollArea block className="max-h-64 border border-border/40 rounded-sm">
+                      <Table>
+                        <TableHeader>
+                          <TableRow>
+                            <TableHead className="w-[40px]" />
+                            <TableHead className="w-[180px]">Scanned</TableHead>
+                            <TableHead className="w-[120px]">Trigger</TableHead>
+                            <TableHead className="w-[120px]">Highest</TableHead>
+                            <TableHead className="w-[90px] text-right">Total</TableHead>
+                            <TableHead className="w-[90px] text-right">Fixable</TableHead>
+                            <TableHead />
                           </TableRow>
-                        );
-                      })}
-                    </TableBody>
-                  </Table>
-                </div>
-              ))}
+                        </TableHeader>
+                        <TableBody>
+                          {group.scans.map((scan) => {
+                            const isSelected = selected.includes(scan.id);
+                            return (
+                              <TableRow
+                                key={scan.id}
+                                className={cn(isSelected && 'bg-accent/30')}
+                              >
+                                <TableCell>
+                                  <Checkbox
+                                    checked={isSelected}
+                                    onCheckedChange={() => toggleSelect(scan.id)}
+                                    aria-label={`Select scan ${scan.id}`}
+                                  />
+                                </TableCell>
+                                <TableCell className="font-mono text-xs">
+                                  {new Date(scan.scanned_at).toLocaleString()}
+                                </TableCell>
+                                <TableCell className="font-mono text-xs capitalize">
+                                  {scan.triggered_by}
+                                </TableCell>
+                                <TableCell>
+                                  {scan.highest_severity ? (
+                                    <SeverityChip severity={scan.highest_severity} />
+                                  ) : (
+                                    <span className="text-xs text-success font-mono">none</span>
+                                  )}
+                                </TableCell>
+                                <TableCell className="text-right font-mono text-xs tabular-nums">
+                                  {scan.total_vulnerabilities}
+                                </TableCell>
+                                <TableCell className="text-right font-mono text-xs tabular-nums text-success">
+                                  {scan.fixable_count}
+                                </TableCell>
+                                <TableCell className="text-right">
+                                  <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    className="h-7 text-xs"
+                                    onClick={() => setInspectScanId(scan.id)}
+                                  >
+                                    Open
+                                  </Button>
+                                </TableCell>
+                              </TableRow>
+                            );
+                          })}
+                        </TableBody>
+                      </Table>
+                    </ScrollArea>
+                  </div>
+                );
+              })}
             </div>
           </ScrollArea>
         )}

--- a/frontend/src/components/__tests__/SecurityHistoryView.test.tsx
+++ b/frontend/src/components/__tests__/SecurityHistoryView.test.tsx
@@ -86,11 +86,19 @@ function scan(overrides: Partial<VulnerabilityScan> = {}): VulnerabilityScan {
   };
 }
 
-function listResponse(items: VulnerabilityScan[], total?: number): Response {
+function listResponse(
+  items: VulnerabilityScan[],
+  opts: { total?: number; cappedImageRefs?: string[]; perImageLimit?: number } = {},
+): Response {
   return {
     ok: true,
     status: 200,
-    json: async () => ({ items, total: total ?? items.length }),
+    json: async () => ({
+      items,
+      total: opts.total ?? items.length,
+      cappedImageRefs: opts.cappedImageRefs ?? [],
+      perImageLimit: opts.perImageLimit ?? 50,
+    }),
   } as unknown as Response;
 }
 
@@ -116,7 +124,7 @@ describe('SecurityHistoryView', () => {
   });
 
   it('advances offset when the user pages forward', async () => {
-    mockedFetch.mockResolvedValue(listResponse([scan()], 250));
+    mockedFetch.mockResolvedValue(listResponse([scan()], { total: 250 }));
     const user = userEvent.setup();
     render(<SecurityHistoryView open onClose={vi.fn()} />);
 
@@ -227,5 +235,22 @@ describe('SecurityHistoryView', () => {
     await user.click(checkboxes[1]);
 
     expect(screen.getByRole('button', { name: /Compare \(2\/2\)/ })).toBeEnabled();
+  });
+
+  it('renders the cap hint only for images flagged in cappedImageRefs', async () => {
+    mockedFetch.mockResolvedValue(
+      listResponse(
+        [
+          scan({ id: 1, image_ref: 'hot:latest', scanned_at: 1000 }),
+          scan({ id: 2, image_ref: 'cool:latest', scanned_at: 2000 }),
+        ],
+        { cappedImageRefs: ['hot:latest'], perImageLimit: 50 },
+      ),
+    );
+    render(<SecurityHistoryView open onClose={vi.fn()} />);
+
+    const cappedHint = await screen.findByText(/Capped at 50 . older scans pruned/);
+    expect(cappedHint).toBeInTheDocument();
+    expect(screen.queryAllByText(/Capped at 50/)).toHaveLength(1);
   });
 });

--- a/frontend/src/components/settings/DeveloperSection.tsx
+++ b/frontend/src/components/settings/DeveloperSection.tsx
@@ -30,13 +30,14 @@ function SectionSkeleton() {
     );
 }
 
-type DeveloperFields = Pick<PatchableSettings, 'developer_mode' | 'metrics_retention_hours' | 'log_retention_days' | 'audit_retention_days'>;
+type DeveloperFields = Pick<PatchableSettings, 'developer_mode' | 'metrics_retention_hours' | 'log_retention_days' | 'audit_retention_days' | 'scan_history_per_image_limit'>;
 
 const DEFAULT_DEVELOPER: DeveloperFields = {
     developer_mode: DEFAULT_SETTINGS.developer_mode,
     metrics_retention_hours: DEFAULT_SETTINGS.metrics_retention_hours,
     log_retention_days: DEFAULT_SETTINGS.log_retention_days,
     audit_retention_days: DEFAULT_SETTINGS.audit_retention_days,
+    scan_history_per_image_limit: DEFAULT_SETTINGS.scan_history_per_image_limit,
 };
 
 export function DeveloperSection({ onDirtyChange }: DeveloperSectionProps) {
@@ -51,7 +52,8 @@ export function DeveloperSection({ onDirtyChange }: DeveloperSectionProps) {
         settings.developer_mode !== serverSettingsRef.current.developer_mode ||
         settings.metrics_retention_hours !== serverSettingsRef.current.metrics_retention_hours ||
         settings.log_retention_days !== serverSettingsRef.current.log_retention_days ||
-        settings.audit_retention_days !== serverSettingsRef.current.audit_retention_days;
+        settings.audit_retention_days !== serverSettingsRef.current.audit_retention_days ||
+        settings.scan_history_per_image_limit !== serverSettingsRef.current.scan_history_per_image_limit;
 
     useEffect(() => {
         onDirtyChange?.(hasChanges);
@@ -85,6 +87,7 @@ export function DeveloperSection({ onDirtyChange }: DeveloperSectionProps) {
                     metrics_retention_hours: localData.metrics_retention_hours ?? DEFAULT_SETTINGS.metrics_retention_hours,
                     log_retention_days: localData.log_retention_days ?? DEFAULT_SETTINGS.log_retention_days,
                     audit_retention_days: localData.audit_retention_days ?? DEFAULT_SETTINGS.audit_retention_days,
+                    scan_history_per_image_limit: localData.scan_history_per_image_limit ?? DEFAULT_SETTINGS.scan_history_per_image_limit,
                 };
                 setSettings(safe);
                 serverSettingsRef.current = { ...safe };
@@ -108,6 +111,7 @@ export function DeveloperSection({ onDirtyChange }: DeveloperSectionProps) {
             metrics_retention_hours: settings.metrics_retention_hours,
             log_retention_days: settings.log_retention_days,
             audit_retention_days: settings.audit_retention_days,
+            scan_history_per_image_limit: settings.scan_history_per_image_limit,
         };
         setIsSaving(true);
         try {
@@ -182,6 +186,23 @@ export function DeveloperSection({ onDirtyChange }: DeveloperSectionProps) {
                             className="w-24"
                         />
                         <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-stat-subtitle">days</span>
+                    </div>
+                </SettingsField>
+
+                <SettingsField
+                    label="Scan history per image"
+                    helper="How many vulnerability scans to keep per image. Older scans beyond the cap are pruned."
+                >
+                    <div className="flex items-center gap-2">
+                        <Input
+                            type="number"
+                            min={5}
+                            max={1000}
+                            value={settings.scan_history_per_image_limit}
+                            onChange={(e) => onSettingChange('scan_history_per_image_limit', e.target.value)}
+                            className="w-24"
+                        />
+                        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-stat-subtitle">scans</span>
                     </div>
                 </SettingsField>
 

--- a/frontend/src/components/settings/types.ts
+++ b/frontend/src/components/settings/types.ts
@@ -11,6 +11,7 @@ export interface PatchableSettings {
     log_retention_days?: string;
     audit_retention_days?: string;
     mesh_auto_recreate?: '0' | '1';
+    scan_history_per_image_limit?: string;
 }
 
 export const DEFAULT_SETTINGS: PatchableSettings = {
@@ -26,6 +27,7 @@ export const DEFAULT_SETTINGS: PatchableSettings = {
     log_retention_days: '30',
     audit_retention_days: '90',
     mesh_auto_recreate: '0',
+    scan_history_per_image_limit: '50',
 };
 
 export type SectionId =


### PR DESCRIPTION
## Summary

- Each image group in the Scan history sheet now scrolls inside its own panel (`max-h-64`) instead of pushing other images off screen when a single image has many scans.
- New global setting `scan_history_per_image_limit` (default 50, min 5, max 1000) caps the response per `image_ref` via a window-function CTE and is enforced by a prune step on the `MonitorService` cleanup tick.
- The `/security/scans` response carries `cappedImageRefs` + `perImageLimit` so the UI renders a quiet "Capped at N · older scans pruned" hint on groups at the ceiling without a second `/settings` round-trip.
- Settings → Developer → Data retention adds a "Scan history per image" field.
- Drive-by: skip the `searchDraft` debounce on initial mount so it can no longer race the user's first pagination click (surfaced by CI on the slower Linux jsdom run after the cap work added state-update overhead).

Single-image deep-dive (`imageRef` query param) bypasses the cap so a user clicking into one image can still see its full history.

## Implementation notes

- The prune uses self-contained subqueries (no JS-side ID list) so a first-run install with a large backlog does not blow past `SQLITE_MAX_VARIABLE_NUMBER`. It explicitly deletes child rows from `vulnerability_details`, `secret_findings`, and `misconfig_findings` inside a transaction since the connection does not enable FK cascade.
- The cap hint fires when `COUNT(*) >= perImageLimit`. The daily prune keeps each image at exactly the cap, so flagging at-cap groups is the only way the hint reliably renders in steady state.
- Single source of truth on the client: a `capInfo: { perImageLimit, refs } | null` state reads both pieces from the scans response, dropping the separate `/settings` fetch and the silent-fallback-to-50 path.
- `searchDraft` debounce now tracks its previous value with a ref and exits early when nothing changed, so the mount cycle never resets `page` to 0.

## Test plan

- [x] `cd backend && npx vitest run src/__tests__/database-scan-list.test.ts` — 9/9 pass: per-image cap, bypass on `imageRef`, multi-node partitioning, child-row cleanup, no-op, prune.
- [x] `cd frontend && npx vitest run src/components/__tests__/SecurityHistoryView.test.tsx` — 9/9 pass including a new test asserting the cap hint renders only for `cappedImageRefs` entries.
- [x] `cd backend && npx tsc --noEmit` clean.
- [x] `cd frontend && npx tsc -b --noEmit` clean.
- [x] Manual run: seeded 80 + 12 + 3 + 2 scans across four images; opened Scan history; confirmed each per-image table clips at ~256 px with vertical scroll (`scrollHeight - clientHeight = 2036` on the 50-row group, `326` on the 12-row group, `0` on the 3- and 2-row groups); confirmed "Capped at 50 · older scans pruned" rendered only on the 50-row group.

## Gate parity

No tier, role, capability, or experimental-flag gates were added, removed, or moved. Scan history and retention live at Community as security basics. `git diff --cached --name-only | rg "(tierGates|requirePaid|requireAdmiral|isPaid|isAdmiral|PaidGate|AdmiralGate|CapabilityGate)"` returns nothing.