### PR TITLE
feat(labels): harden Stack Labels (gate parity, abort, dry-run, cap)

### DIFF
--- a/backend/src/__tests__/labels-bulk-actions.test.ts
+++ b/backend/src/__tests__/labels-bulk-actions.test.ts
@@ -65,6 +65,10 @@ afterAll(() => cleanupTestDb(tmpDir));
 
 beforeEach(() => {
   vi.restoreAllMocks();
+  // restoreAllMocks only resets spies; bare vi.fn() mocks keep their call
+  // history across tests. Clear them all so each test sees a fresh slate
+  // before its `.not.toHaveBeenCalled()` assertions run.
+  vi.clearAllMocks();
   vi.spyOn(LicenseService.getInstance(), 'getTier').mockReturnValue('paid');
   mockFsStacks = ['alpha', 'beta'];
   deployStack.mockResolvedValue(undefined);
@@ -72,7 +76,6 @@ beforeEach(() => {
   stopContainer.mockResolvedValue(undefined);
   restartContainer.mockResolvedValue(undefined);
   enforcePolicyPreDeploy.mockResolvedValue({ ok: true });
-  invalidateNodeCaches.mockClear();
   activeBulkActions.clear();
   db.getDb().prepare('DELETE FROM stack_label_assignments').run();
   db.getDb().prepare('DELETE FROM stack_labels').run();
@@ -145,5 +148,63 @@ describe('Stack Labels bulk actions', () => {
     expect(res.status).toBe(429);
     expect(res.body.error).toContain('already running');
     expect(restartContainer).not.toHaveBeenCalled();
+  });
+
+  it('dry-run deploy runs the policy gate and reports blocked stacks honestly', async () => {
+    const label = await createAssignedLabel(['alpha']);
+    enforcePolicyPreDeploy.mockResolvedValue({
+      ok: false,
+      policy: { name: 'block-criticals', max_severity: 'high' },
+      violations: [{ image: 'nginx:latest', severity: 'critical' }],
+    });
+
+    const res = await request(app)
+      .post(`/api/labels/${label.id}/action`)
+      .set('Authorization', authHeader)
+      .send({ action: 'deploy', dryRun: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body.results).toEqual([
+      expect.objectContaining({ stackName: 'alpha', success: false, dryRun: true }),
+    ]);
+    expect(res.body.results[0].error).toContain('Policy "block-criticals" blocked deploy');
+    expect(deployStack).not.toHaveBeenCalled();
+    expect(invalidateNodeCaches).not.toHaveBeenCalled();
+  });
+
+  it('dry-run deploy reports success when the policy gate passes, without touching Docker', async () => {
+    const label = await createAssignedLabel(['alpha']);
+    enforcePolicyPreDeploy.mockResolvedValue({ ok: true });
+
+    const res = await request(app)
+      .post(`/api/labels/${label.id}/action`)
+      .set('Authorization', authHeader)
+      .send({ action: 'deploy', dryRun: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body.results).toEqual([
+      { stackName: 'alpha', success: true, dryRun: true },
+    ]);
+    expect(enforcePolicyPreDeploy).toHaveBeenCalledWith('alpha', label.node_id, expect.any(Object));
+    expect(deployStack).not.toHaveBeenCalled();
+    expect(invalidateNodeCaches).not.toHaveBeenCalled();
+  });
+
+  it('dry-run stop reports per-stack success without dispatching real stops', async () => {
+    const label = await createAssignedLabel(['alpha', 'beta']);
+
+    const res = await request(app)
+      .post(`/api/labels/${label.id}/action`)
+      .set('Authorization', authHeader)
+      .send({ action: 'stop', dryRun: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body.results).toEqual([
+      { stackName: 'alpha', success: true, dryRun: true },
+      { stackName: 'beta', success: true, dryRun: true },
+    ]);
+    expect(getContainersByStack).not.toHaveBeenCalled();
+    expect(stopContainer).not.toHaveBeenCalled();
+    expect(invalidateNodeCaches).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/__tests__/labels-community-tier.test.ts
+++ b/backend/src/__tests__/labels-community-tier.test.ts
@@ -34,6 +34,14 @@ beforeAll(async () => {
 
 afterAll(() => cleanupTestDb(tmpDir));
 
+// Tests in this file accumulate labels in the shared DB; clear them between
+// runs so later tests do not bump into MAX_LABELS_PER_NODE.
+afterEach(() => {
+  const db = DatabaseService.getInstance().getDb();
+  db.prepare('DELETE FROM stack_label_assignments').run();
+  db.prepare('DELETE FROM stack_labels').run();
+});
+
 function mockTier(tier: 'paid' | 'community') {
   vi.spyOn(LicenseService.getInstance(), 'getTier').mockReturnValue(tier);
 }
@@ -125,6 +133,40 @@ describe('Stack Labels on Community tier', () => {
       .send({ labelIds: [] });
     expect(res.status).toBe(400);
     expect(res.body.error).toBe('Invalid stack name');
+  });
+
+  it('rejects labelIds arrays over the per-node cap', async () => {
+    mockTier('community');
+    const oversized = Array.from({ length: 51 }, (_, i) => i + 1);
+    const res = await request(app)
+      .put('/api/stacks/cap-stack/labels')
+      .set('Authorization', authHeader)
+      .send({ labelIds: oversized });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('may not exceed');
+  });
+
+  it('accepts labelIds at exactly the per-node cap', async () => {
+    mockTier('community');
+    // Seed 50 labels directly so the FK check on assignment passes without
+    // running 50 HTTP round trips per test. The route resolves nodeId via
+    // nodeContextMiddleware (default node when no x-node-id header), so the
+    // seeded rows must use the same nodeId the request will look up.
+    const { NodeRegistry } = await import('../services/NodeRegistry');
+    const nodeId = NodeRegistry.getInstance().getDefaultNodeId();
+    const db = DatabaseService.getInstance().getDb();
+    const insert = db.prepare('INSERT INTO stack_labels (node_id, name, color) VALUES (?, ?, ?)');
+    const ids: number[] = [];
+    for (let i = 0; i < 50; i++) {
+      const r = insert.run(nodeId, `cap-edge-${i}`, 'teal');
+      ids.push(r.lastInsertRowid as number);
+    }
+    const res = await request(app)
+      .put('/api/stacks/cap-edge-stack/labels')
+      .set('Authorization', authHeader)
+      .send({ labelIds: ids });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
   });
 });
 

--- a/backend/src/routes/labels.ts
+++ b/backend/src/routes/labels.ts
@@ -206,14 +206,21 @@ labelsRouter.post('/:id/action', authMiddleware, async (req: Request, res: Respo
       const results: { stackName: string; success: boolean; error?: string; dryRun?: boolean }[] = [];
 
       for (const stackName of validStacks) {
-        if (isDryRun) {
-          // Rehearse the action under the same lock + label resolution + fs
-          // intersection. Skip the destructive leaf call.
-          results.push({ stackName, success: true, dryRun: true });
-          continue;
+        // Client disconnected mid-bulk: stop dispatching new per-stack ops.
+        // The currently in-flight call still runs to completion; the outer
+        // finally releases the lock when it returns. Stays on `req.aborted`
+        // rather than `req.destroyed` because supertest's in-process server
+        // mode flips `destroyed` between handler and response write, which
+        // would cause every bulk-action test to look like a client abort.
+        if (req.aborted) {
+          if (isDebugEnabled()) console.debug('[Labels:debug] Bulk action aborted by client at stack:', stackName);
+          break;
         }
         try {
           if (action === 'deploy') {
+            // Policy gate runs for both real and dry-run deploys: a dry-run
+            // that omits the policy check would falsely report success for
+            // stacks the real deploy would block.
             const gate = await enforcePolicyPreDeploy(
               stackName,
               req.nodeId,
@@ -221,11 +228,21 @@ labelsRouter.post('/:id/action', authMiddleware, async (req: Request, res: Respo
             );
             if (!gate.ok) {
               const blockedMsg = `Policy "${gate.policy?.name}" blocked deploy: ${gate.violations.length} image(s) exceed ${gate.policy?.max_severity}`;
-              results.push({ stackName, success: false, error: blockedMsg });
+              results.push({ stackName, success: false, error: blockedMsg, ...(isDryRun ? { dryRun: true } : {}) });
+              continue;
+            }
+            if (isDryRun) {
+              results.push({ stackName, success: true, dryRun: true });
               continue;
             }
             await ComposeService.getInstance(req.nodeId).deployStack(stackName, undefined, false);
           } else {
+            // stop / restart have no pre-action policy gate; dry-run just
+            // confirms the stack would be reached.
+            if (isDryRun) {
+              results.push({ stackName, success: true, dryRun: true });
+              continue;
+            }
             const dockerController = DockerController.getInstance(req.nodeId);
             const containers = await dockerController.getContainersByStack(stackName);
             if (action === 'stop') {
@@ -242,12 +259,18 @@ labelsRouter.post('/:id/action', authMiddleware, async (req: Request, res: Respo
 
       const succeeded = results.filter(r => r.success).length;
       const failed = results.length - succeeded;
-      console.log(`[Labels] Bulk ${sanitizeForLog(action)}${isDryRun ? ' (dry run)' : ''} on label ${id}: ${validStacks.length} stacks (${succeeded} succeeded, ${failed} failed)`);
-      if (isDebugEnabled()) console.debug('[Labels:debug] Bulk action complete:', { id, action, total: results.length, succeeded, failed, dryRun: isDryRun });
+      // Two-axis truncation reporting: `results.length` is what we actually
+      // processed; `validStacks.length` is what we set out to process. They
+      // differ when the client aborted mid-loop.
+      console.log(`[Labels] Bulk ${sanitizeForLog(action)}${isDryRun ? ' (dry run)' : ''} on label ${id}: ${results.length}/${validStacks.length} stacks (${succeeded} succeeded, ${failed} failed)`);
+      if (isDebugEnabled()) console.debug('[Labels:debug] Bulk action complete:', { id, action, processed: results.length, total: validStacks.length, succeeded, failed, dryRun: isDryRun });
 
       if (succeeded > 0 && !isDryRun) {
         invalidateNodeCaches(req.nodeId);
       }
+      // Writing the response is harmless even if the client already
+      // disconnected; Node swallows the EPIPE / write-after-end. The
+      // lock release in the outer finally still happens.
       res.json({ results });
     } finally {
       activeBulkActions.delete(lockKey);
@@ -279,6 +302,13 @@ stackLabelsRouter.put('/:stackName/labels', authMiddleware, async (req: Request,
 
     if (!Array.isArray(labelIds) || !labelIds.every((id: unknown) => typeof id === 'number')) {
       res.status(400).json({ error: 'labelIds must be an array of numbers' });
+      return;
+    }
+    // A node can hold at most MAX_LABELS_PER_NODE labels, so any stack
+    // assignment over that count is either an authenticated client mistake
+    // or a deliberate transaction-bloat attempt. Reject before the DB sees it.
+    if (labelIds.length > MAX_LABELS_PER_NODE) {
+      res.status(400).json({ error: `labelIds may not exceed ${MAX_LABELS_PER_NODE} entries` });
       return;
     }
 

--- a/frontend/src/components/EditorLayout/hooks/useSidebarContextMenu.ts
+++ b/frontend/src/components/EditorLayout/hooks/useSidebarContextMenu.ts
@@ -44,6 +44,10 @@ export function useSidebarContextMenu({
       isAdmiral,
       canDelete: can('stack:delete', 'stack', sName),
       canEditLabels: can('stack:edit', 'stack', sName),
+      // POST /api/labels (the inline "New label" entry) is guarded by the
+      // unscoped requirePermission('stack:edit'); a user with only per-stack
+      // scoped edit can toggle existing labels but cannot create new ones.
+      canCreateLabels: can('stack:edit'),
       isPinned: stackListState.isPinned(file),
       labels: stackListState.labels,
       assignedLabelIds: (stackListState.stackLabelMap[file] ?? []).map(l => l.id),

--- a/frontend/src/components/EditorLayout/hooks/useSidebarContextMenu.ts
+++ b/frontend/src/components/EditorLayout/hooks/useSidebarContextMenu.ts
@@ -43,6 +43,7 @@ export function useSidebarContextMenu({
       isPaid,
       isAdmiral,
       canDelete: can('stack:delete', 'stack', sName),
+      canEditLabels: can('stack:edit', 'stack', sName),
       isPinned: stackListState.isPinned(file),
       labels: stackListState.labels,
       assignedLabelIds: (stackListState.stackLabelMap[file] ?? []).map(l => l.id),

--- a/frontend/src/components/settings/LabelsSection.tsx
+++ b/frontend/src/components/settings/LabelsSection.tsx
@@ -6,6 +6,7 @@ import { Modal, ModalHeader, ModalBody, ModalFooter, ConfirmModal } from '@/comp
 import { apiFetch } from '@/lib/api';
 import { toast } from '@/components/ui/toast-store';
 import { SENCHO_LABELS_CHANGED } from '@/lib/events';
+import { useAuth } from '@/context/AuthContext';
 import { CapabilityGate } from '../CapabilityGate';
 import { LabelDot } from '../LabelPill';
 import { LABEL_COLORS, MAX_LABELS_PER_NODE, type Label, type LabelColor } from '../label-types';
@@ -18,6 +19,11 @@ interface LabelsSectionProps {
 }
 
 export function LabelsSection({ onLabelsChanged }: LabelsSectionProps = {}) {
+    const { can } = useAuth();
+    // Mirrors the backend `requirePermission('stack:edit')` guard on
+    // POST/PUT/DELETE /api/labels, keeping a viewer/deployer/auditor from
+    // clicking through to a guaranteed 403.
+    const canMutate = can('stack:edit');
     const [labels, setLabels] = useState<Label[]>([]);
     const [loading, setLoading] = useState(true);
     const [assignmentCounts, setAssignmentCounts] = useState<Record<number, number>>({});
@@ -128,12 +134,14 @@ export function LabelsSection({ onLabelsChanged }: LabelsSectionProps = {}) {
     return (
         <CapabilityGate capability="labels" featureName="Stack Labels">
             <div className="space-y-4">
-                <div className="flex justify-end">
-                    <SettingsPrimaryButton size="sm" onClick={openCreate} disabled={labels.length >= MAX_LABELS_PER_NODE}>
-                        <Plus className="w-4 h-4" strokeWidth={1.5} />
-                        {labels.length >= MAX_LABELS_PER_NODE ? 'Limit reached' : 'New label'}
-                    </SettingsPrimaryButton>
-                </div>
+                {canMutate && (
+                    <div className="flex justify-end">
+                        <SettingsPrimaryButton size="sm" onClick={openCreate} disabled={labels.length >= MAX_LABELS_PER_NODE}>
+                            <Plus className="w-4 h-4" strokeWidth={1.5} />
+                            {labels.length >= MAX_LABELS_PER_NODE ? 'Limit reached' : 'New label'}
+                        </SettingsPrimaryButton>
+                    </div>
+                )}
 
                 <div className="rounded-lg border border-card-border border-t-card-border-top bg-card shadow-card-bevel">
                     {loading ? (
@@ -153,22 +161,26 @@ export function LabelsSection({ onLabelsChanged }: LabelsSectionProps = {}) {
                                     <span className="text-xs text-muted-foreground tabular-nums">
                                         {assignmentCounts[label.id] || 0} stack{(assignmentCounts[label.id] || 0) !== 1 ? 's' : ''}
                                     </span>
-                                    <Button
-                                        variant="ghost"
-                                        size="icon"
-                                        className="h-7 w-7 opacity-0 group-hover:opacity-100 transition-opacity"
-                                        onClick={() => openEdit(label)}
-                                    >
-                                        <Pencil className="w-3.5 h-3.5" strokeWidth={1.5} />
-                                    </Button>
-                                    <Button
-                                        variant="ghost"
-                                        size="icon"
-                                        className="h-7 w-7 text-destructive/60 hover:bg-destructive hover:text-destructive-foreground opacity-0 group-hover:opacity-100 transition-opacity"
-                                        onClick={() => setDeleteTarget(label)}
-                                    >
-                                        <Trash2 className="w-3.5 h-3.5" strokeWidth={1.5} />
-                                    </Button>
+                                    {canMutate && (
+                                        <>
+                                            <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                className="h-7 w-7 opacity-0 group-hover:opacity-100 transition-opacity"
+                                                onClick={() => openEdit(label)}
+                                            >
+                                                <Pencil className="w-3.5 h-3.5" strokeWidth={1.5} />
+                                            </Button>
+                                            <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                className="h-7 w-7 text-destructive/60 hover:bg-destructive hover:text-destructive-foreground opacity-0 group-hover:opacity-100 transition-opacity"
+                                                onClick={() => setDeleteTarget(label)}
+                                            >
+                                                <Trash2 className="w-3.5 h-3.5" strokeWidth={1.5} />
+                                            </Button>
+                                        </>
+                                    )}
                                 </div>
                             ))}
                         </div>

--- a/frontend/src/components/sidebar/LabelInlineCreateForm.tsx
+++ b/frontend/src/components/sidebar/LabelInlineCreateForm.tsx
@@ -19,7 +19,9 @@ export function LabelInlineCreateForm({ onSubmit, onCancel }: LabelInlineCreateF
     setSaving(true);
     try {
       await onSubmit(trimmed, color);
-    } catch {
+    } finally {
+      // Reset even on success so the form stays interactive if the parent
+      // keeps it mounted (e.g. when reused outside the kebab/context menu).
       setSaving(false);
     }
   };

--- a/frontend/src/components/sidebar/LabelInlineCreateForm.tsx
+++ b/frontend/src/components/sidebar/LabelInlineCreateForm.tsx
@@ -19,6 +19,10 @@ export function LabelInlineCreateForm({ onSubmit, onCancel }: LabelInlineCreateF
     setSaving(true);
     try {
       await onSubmit(trimmed, color);
+    } catch {
+      // Parents (createAndAssignLabel) toast and rethrow to signal failure;
+      // swallow here so the rejection does not surface as an unhandled
+      // event-handler rejection in the browser console.
     } finally {
       // Reset even on success so the form stays interactive if the parent
       // keeps it mounted (e.g. when reused outside the kebab/context menu).

--- a/frontend/src/components/sidebar/StackContextMenu.tsx
+++ b/frontend/src/components/sidebar/StackContextMenu.tsx
@@ -63,7 +63,7 @@ function LabelsSub({ item, ctx }: { item: MenuItem; ctx: StackMenuCtx }) {
               );
             })}
             <ContextMenuSeparator />
-            {ctx.labels.length < MAX_LABELS_PER_NODE && (
+            {ctx.canCreateLabels && ctx.labels.length < MAX_LABELS_PER_NODE && (
               <ContextMenuItem onSelect={e => { e.preventDefault(); setCreating(true); }}>
                 <Plus className="w-3.5 h-3.5 mr-2 text-muted-foreground" strokeWidth={1.5} />
                 <span className="text-xs">New label</span>

--- a/frontend/src/components/sidebar/StackKebabMenu.tsx
+++ b/frontend/src/components/sidebar/StackKebabMenu.tsx
@@ -63,7 +63,7 @@ function LabelsSub({ item, ctx }: { item: MenuItem; ctx: StackMenuCtx }) {
               );
             })}
             <DropdownMenuSeparator />
-            {ctx.labels.length < MAX_LABELS_PER_NODE && (
+            {ctx.canCreateLabels && ctx.labels.length < MAX_LABELS_PER_NODE && (
               <DropdownMenuItem onSelect={e => { e.preventDefault(); setCreating(true); }}>
                 <Plus className="w-3.5 h-3.5 mr-2 text-muted-foreground" strokeWidth={1.5} />
                 <span className="text-xs">New label</span>

--- a/frontend/src/components/sidebar/sidebar-types.ts
+++ b/frontend/src/components/sidebar/sidebar-types.ts
@@ -28,6 +28,7 @@ export interface StackMenuCtx {
   isPaid: boolean;
   isAdmiral: boolean;
   canDelete: boolean;
+  canEditLabels: boolean;
   isPinned: boolean;
   labels: Label[];
   assignedLabelIds: number[];

--- a/frontend/src/components/sidebar/sidebar-types.ts
+++ b/frontend/src/components/sidebar/sidebar-types.ts
@@ -29,6 +29,7 @@ export interface StackMenuCtx {
   isAdmiral: boolean;
   canDelete: boolean;
   canEditLabels: boolean;
+  canCreateLabels: boolean;
   isPinned: boolean;
   labels: Label[];
   assignedLabelIds: number[];

--- a/frontend/src/hooks/__tests__/useStackMenuItems.test.tsx
+++ b/frontend/src/hooks/__tests__/useStackMenuItems.test.tsx
@@ -13,6 +13,7 @@ function makeCtx(overrides: Partial<StackMenuCtx> = {}): StackMenuCtx {
     isAdmiral: false,
     canDelete: true,
     canEditLabels: true,
+    canCreateLabels: true,
     isPinned: false,
     labels: [],
     assignedLabelIds: [],

--- a/frontend/src/hooks/__tests__/useStackMenuItems.test.tsx
+++ b/frontend/src/hooks/__tests__/useStackMenuItems.test.tsx
@@ -12,6 +12,7 @@ function makeCtx(overrides: Partial<StackMenuCtx> = {}): StackMenuCtx {
     isPaid: true,
     isAdmiral: false,
     canDelete: true,
+    canEditLabels: true,
     isPinned: false,
     labels: [],
     assignedLabelIds: [],
@@ -104,6 +105,16 @@ describe('useStackMenuItems', () => {
     const labelsItem = organize.items.find(i => i.id === 'labels');
     expect(labelsItem).toBeDefined();
     expect(labelsItem?.subItems?.[0]).toMatchObject({ id: 'label:1', label: 'prod' });
+  });
+
+  it('hides the Labels submenu when !canEditLabels (viewer role)', () => {
+    const { result } = renderHook(() => useStackMenuItems('web.yml', makeCtx({
+      canEditLabels: false,
+      labels: [{ id: 1, node_id: 0, name: 'prod', color: 'teal' }],
+    })));
+    const organize = result.current.find(g => g.id === 'organize')!;
+    expect(organize.items.find(i => i.id === 'labels')).toBeUndefined();
+    expect(organize.items.find(i => i.id === 'pin')).toBeDefined();
   });
 
   it('auto-update toggle calls setAutoUpdateEnabled with toggled value', () => {

--- a/frontend/src/hooks/useStackMenuItems.tsx
+++ b/frontend/src/hooks/useStackMenuItems.tsx
@@ -19,7 +19,7 @@ import type { MenuGroup, MenuItem, StackMenuCtx } from '@/components/sidebar/sid
 
 export function useStackMenuItems(_file: string, ctx: StackMenuCtx): MenuGroup[] {
   const {
-    stackStatus, hasPort, isBusy, isPaid, canDelete, isPinned, labels,
+    stackStatus, hasPort, isBusy, isPaid, canDelete, canEditLabels, isPinned, labels,
     openAlertSheet, openAutoHeal, checkUpdates, openStackApp,
     deploy, stop, restart, update, remove, pin, unpin, toggleLabel,
     menuVisibility, autoUpdateEnabled, setAutoUpdateEnabled, openScheduleTask,
@@ -48,19 +48,21 @@ export function useStackMenuItems(_file: string, ctx: StackMenuCtx): MenuGroup[]
     groups.push({ id: 'inspect', items: inspect });
 
     const organize: MenuItem[] = [];
-    organize.push({
-      id: 'labels',
-      label: 'Labels',
-      icon: Tag,
-      shortcut: 'L ›',
-      onSelect: () => {},
-      subItems: labels.map(l => ({
-        id: `label:${l.id}`,
-        label: l.name,
+    if (canEditLabels) {
+      organize.push({
+        id: 'labels',
+        label: 'Labels',
         icon: Tag,
-        onSelect: () => toggleLabel(l.id),
-      })),
-    });
+        shortcut: 'L ›',
+        onSelect: () => {},
+        subItems: labels.map(l => ({
+          id: `label:${l.id}`,
+          label: l.name,
+          icon: Tag,
+          onSelect: () => toggleLabel(l.id),
+        })),
+      });
+    }
     organize.push(
       isPinned
         ? { id: 'pin', label: 'Unpin', icon: PinOff, shortcut: 'P', onSelect: unpin }
@@ -85,7 +87,7 @@ export function useStackMenuItems(_file: string, ctx: StackMenuCtx): MenuGroup[]
 
     return groups;
   }, [
-    stackStatus, hasPort, isBusy, isPaid, canDelete, isPinned, labels,
+    stackStatus, hasPort, isBusy, isPaid, canDelete, canEditLabels, isPinned, labels,
     showDeploy, showStop, showRestart, showUpdate,
     autoUpdateEnabled, setAutoUpdateEnabled,
     openAlertSheet, openAutoHeal, checkUpdates, openStackApp,


### PR DESCRIPTION
## Summary

Five fixes from the Stack Labels feature audit, severities High through Medium, plus a follow-up commit addressing two findings from a Codex review pass.

Initial commit (c651e445):
- **H-1**: DoS via unbounded `labelIds` array on `PUT /api/stacks/:name/labels`. Cap at `MAX_LABELS_PER_NODE` (50); reject 400 above. Previously an authenticated `stack:edit` user could send a 10k-element array and block the DB on a single transaction.
- **M-1**: Backend/frontend gate parity for label-edit affordances. Backend already required `stack:edit`; frontend rendered the buttons unconditionally so viewer/deployer/auditor roles saw mutation controls that always 403'd. Now the sidebar Labels submenu hides on `can('stack:edit', 'stack', sName)` and the Settings page hides New label / Pencil / Trash on `can('stack:edit')`.
- **M-3**: Per-label bulk action loop now checks `req.aborted` at the top of each iteration and breaks. Cancelled requests release the per-node lock once the in-flight op completes, capping the worst case from N stacks to one.
- **M-4**: `LabelInlineCreateForm.submit` previously left `saving=true` after a successful POST (only worked because parents always unmounted). Switched `catch` to `finally` so the form stays interactive if reused.
- **M-6**: Dry-run deploy via `POST /api/labels/:id/action` previously short-circuited before the policy gate and would falsely report success for stacks the real deploy would block. The dry-run now invokes `enforcePolicyPreDeploy` and reports blocked stacks honestly. (Endpoint has no UI caller today; fixed so any future caller gets an honest prediction.)

Follow-up commit (a41edaf9), from Codex review:
- **Codex-M**: `POST /api/labels` is guarded by unscoped `requirePermission('stack:edit')`, but the original sidebar inline "New label" entry was gated by `canEditLabels` (per-stack scoped). An Admiral user with only scoped grants could toggle existing labels but the inline create would 403. Split the gate: `canEditLabels` (scoped) keeps gating the submenu trigger + toggle items; `canCreateLabels` (unscoped) now gates the inline "New label" entry.
- **Codex-L**: The M-4 catch-to-finally change in c651e445 let the rethrow from `createAndAssignLabel` surface as an unhandled event-handler rejection in the browser console. Restored the swallow-catch in `LabelInlineCreateForm.submit`; parents already toast on failure, and the rethrow exists only so callers that DO care can observe it.

## Gate parity

Every label-touching guard and its matching UI gate, after this branch:

| Surface | Backend guard (path:line) | Frontend gate (path:line) |
|---|---|---|
| `GET /api/labels` | `authMiddleware` only (`backend/src/routes/labels.ts:27`) | open read, no UI gate needed |
| `GET /api/labels/assignments` | `authMiddleware` only (`backend/src/routes/labels.ts:79`) | open read |
| `POST /api/labels` | `authMiddleware` + `requirePermission('stack:edit')`, unscoped (`backend/src/routes/labels.ts:39-40`) | `canMutate = can('stack:edit')` gates New label button in `frontend/src/components/settings/LabelsSection.tsx:131-138`; sidebar inline `New label` entry now gated by `canCreateLabels = can('stack:edit')` (unscoped) in `useSidebarContextMenu.ts:48` consumed by `StackKebabMenu.tsx:66` and `StackContextMenu.tsx:66` |
| `PUT /api/labels/:id` | `authMiddleware` + `requirePermission('stack:edit')` (`backend/src/routes/labels.ts:109-110`) | `canMutate` gates Pencil edit icon (`LabelsSection.tsx:165-173`) |
| `DELETE /api/labels/:id` | `authMiddleware` + `requirePermission('stack:edit')` (`backend/src/routes/labels.ts:153-154`) | `canMutate` gates Trash icon (`LabelsSection.tsx:174-182`) |
| `PUT /api/stacks/:stackName/labels` | `authMiddleware` + `requirePermission('stack:edit', 'stack', stackName)` + new 50-cap (`backend/src/routes/labels.ts:269-289`) | `canEditLabels = can('stack:edit', 'stack', sName)` gates the Labels submenu in `useSidebarContextMenu.ts:46` consumed by `useStackMenuItems.tsx:51` |
| `POST /api/labels/:id/action` | `authMiddleware` + `requirePaid` + `requireAdmin` (`backend/src/routes/labels.ts:168-170`) | no frontend caller (API-only endpoint); no UI gate needed |
| Settings > Labels page (capability gate) | n/a, backend has no `requireCapability('labels')` | `<CapabilityGate capability="labels">` (`LabelsSection.tsx:129`) is a node-version check, not a tier check; backend `CapabilityRegistry.ts:22` advertises `labels` so the local node always passes |

Both per-stack scoped (`canEditLabels`) and unscoped (`canCreateLabels`, `canMutate`) frontend checks now mirror their matching backend guards.

## Test plan

Automated (CI):
- [x] Backend: 80 label tests pass (`labels.test.ts`, `labels-bulk-actions.test.ts`, `labels-community-tier.test.ts`).
- [x] Frontend: 14 `useStackMenuItems` tests pass including the `hides the Labels submenu when !canEditLabels (viewer role)` case.
- [x] Backend tsc clean; frontend tsc clean; no new lint warnings.
- [x] New tests added: labelIds cap at 51 rejects with 400; labelIds at exactly 50 succeeds; dry-run deploy with blocking policy reports `success: false`; dry-run deploy with passing policy reports `success: true`; dry-run stop reports per-stack success without dispatching real stops.

Manual (to run during review):
- [ ] Sign in as admin; Settings > Labels page shows New label + edit/delete affordances; create, rename, delete a label.
- [ ] Sign in as a viewer-role user; Settings > Labels page shows the list but no mutation buttons; sidebar kebab on a stack shows no Labels submenu.
- [ ] Sign in as a deployer-role user (stack:deploy but no stack:edit); sidebar Labels submenu hides; Settings > Labels page hides mutation controls.
- [ ] As admin on Skipper tier, `POST /api/labels/:id/action` with `{"action":"deploy","dryRun":true}` against a label with a policy-blocked stack reports `success: false` with the policy reason; without `dryRun`, the same request actually blocks the deploy.

## Test gaps (documented, not fixed in this PR)

- `req.aborted` mid-loop break behavior is not unit-tested. supertest does not expose `req.aborted` without surgery on the request object. The behavior is mechanically simple (Node sets `req.aborted = true` on socket close).
- `canCreateLabels` gate on the inline "New label" entry inside `LabelsSub` is not unit-tested. There is no existing React Testing Library harness for `StackKebabMenu`/`StackContextMenu`, and the gate itself is a single conditional. Verifiable by manual click-through with a deployer-role user.
- `LabelsSection` viewer-persona render is verified manually rather than via React Testing Library (same reason; no existing RTL harness for this component).
- `LabelInlineCreateForm.submit` reset-on-success is mechanically simple and the existing call sites unmount on success; not separately unit-tested.

## Rollback

`git revert <sha>` is safe on either commit. Backend guards remain in place for every role/tier the frontend was hiding affordances from, so the worst rollback exposes a small DoS surface again (H-1) plus the pre-existing UX gap (M-1 and Codex-M). No schema changes, no on-disk state.

## What is NOT in this PR

- L-1 (overflow `+N` tooltip), L-2 (`refreshLabels` dev-mode warn), L-3 (`LabelsSection.fetchLabels` error surface), L-4 (client-side label-name regex), M-5 (`LabelsSub` component dedup) are filed separately on the Sencho project at 1.1-milestone (SEN-95 through SEN-99).
- Frontend `capabilities.ts` missing `'vulnerability-scanning'` is filed as SEN-100; adjacent type-list drift, not a labels concern.
- Observability work (Phase 3 of the audit): standard + dev-mode logging, in-process metrics service. Lands on top of this branch after merge.