### PR TITLE
fix(sidebar): require admin role for Schedule task and debounce search input

### DIFF
--- a/backend/src/__tests__/proxy-mount-order.test.ts
+++ b/backend/src/__tests__/proxy-mount-order.test.ts
@@ -76,6 +76,21 @@ describe('remote proxy mount order', () => {
     expect(res.status).not.toBe(502);
   });
 
+  it('short-circuits /api/stacks/statuses (the sidebar status poll) for remote nodes', async () => {
+    // The sidebar polls /api/stacks/statuses every few seconds; if a future
+    // refactor accidentally mounted a local fast-path before the proxy, every
+    // operator viewing a remote node would silently see the central instance's
+    // own statuses. Asserts the same 502 short-circuit as /api/stacks.
+    const res = await request(app)
+      .get('/api/stacks/statuses')
+      .set('Authorization', authHeader)
+      .set('x-node-id', String(remoteNodeId));
+
+    expect(res.status).toBe(502);
+    expect(res.headers['x-sencho-proxy']).toBeUndefined();
+    expect(res.body?.error).toMatch(/unreachable/i);
+  });
+
   it('handles proxy-exempt paths locally even when x-node-id targets a remote', async () => {
     // /api/nodes/:id is in PROXY_EXEMPT_PREFIXES. The proxy must never catch
     // gateway-level concerns; otherwise a user whose default node is remote

--- a/docs/features/sidebar.mdx
+++ b/docs/features/sidebar.mdx
@@ -85,7 +85,7 @@ Right-click any stack (or open the kebab that appears on hover) for its context 
 - **Destructive**: **Delete**.
 
 <Note>
-  **Auto-Heal** and **Schedule task** require a **Skipper** or **Admiral** license.
+  **Auto-Heal** requires a **Skipper** or **Admiral** license. **Schedule task** requires a **Skipper** or **Admiral** license and an **admin** role.
 </Note>
 
 <Frame>
@@ -142,5 +142,8 @@ The footer surfaces the most recent stack lifecycle event on the node. Each tick
   </Accordion>
   <Accordion title="The filter chips disappeared from the sidebar">
     Click the **+** icon to the right of the search box to bring them back. The chip row collapses to a thin **−** / **+** toggle, and the state is remembered in your browser, so an earlier collapse persists across reloads until you expand it again.
+  </Accordion>
+  <Accordion title="Schedule task is missing from the right-click menu">
+    Scheduling requires a **Skipper** or **Admiral** license and an **admin** role. Ask an admin on this node to schedule the task for you, or sign in with an admin account.
   </Accordion>
 </AccordionGroup>

--- a/frontend/src/components/EditorLayout.tsx
+++ b/frontend/src/components/EditorLayout.tsx
@@ -176,6 +176,7 @@ export default function EditorLayout() {
     activeNode,
     isPaid,
     isAdmiral,
+    isAdmin,
     can,
   });
 

--- a/frontend/src/components/EditorLayout/hooks/useSidebarContextMenu.ts
+++ b/frontend/src/components/EditorLayout/hooks/useSidebarContextMenu.ts
@@ -21,6 +21,7 @@ interface UseSidebarContextMenuOptions {
   activeNode: Node | null | undefined;
   isPaid: boolean;
   isAdmiral: boolean;
+  isAdmin: boolean;
   can: (action: PermissionAction, resourceType?: string, resourceId?: string) => boolean;
 }
 
@@ -32,6 +33,7 @@ export function useSidebarContextMenu({
   activeNode,
   isPaid,
   isAdmiral,
+  isAdmin,
   can,
 }: UseSidebarContextMenuOptions) {
   const buildMenuCtx = useCallback((file: string): StackMenuCtx => {
@@ -42,6 +44,7 @@ export function useSidebarContextMenu({
       isBusy: stackListState.isStackBusy(file),
       isPaid,
       isAdmiral,
+      isAdmin,
       canDelete: can('stack:delete', 'stack', sName),
       canEditLabels: can('stack:edit', 'stack', sName),
       // POST /api/labels (the inline "New label" entry) is guarded by the
@@ -121,9 +124,13 @@ export function useSidebarContextMenu({
         navState.setActiveView('scheduled-ops');
       },
     };
+    // Handlers from useStackActions, useOverlayState, useViewNavigationState are
+    // useCallback-stabilized at their owner hooks, so listing the menu surface
+    // values (status maps, role/tier flags, pin state) is sufficient. Exhaustive
+    // deps would force a rebuild on every parent render and defeat the memo.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    stackListState.stackStatuses, stackListState.stackPorts, isPaid, isAdmiral,
+    stackListState.stackStatuses, stackListState.stackPorts, isPaid, isAdmiral, isAdmin,
     stackListState.isPinned, stackListState.labels, stackListState.stackLabelMap,
     stackListState.pin, stackListState.unpin,
   ]);

--- a/frontend/src/components/sidebar/SidebarSearch.tsx
+++ b/frontend/src/components/sidebar/SidebarSearch.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from 'react';
 import { CommandInput } from '@/components/ui/command';
 
 interface SidebarSearchProps {
@@ -5,13 +6,44 @@ interface SidebarSearchProps {
   onValueChange: (v: string) => void;
 }
 
+// 120ms feels instant to a typist (still under the ~150ms human reaction
+// floor) while collapsing a burst of keystrokes into one filter rebuild.
+// `<Command shouldFilter={false}>` means useStackListState owns the actual
+// filter pass; debouncing here directly cuts its rebuild count.
+const DEBOUNCE_MS = 120;
+
 export function SidebarSearch({ value, onValueChange }: SidebarSearchProps) {
+  const [local, setLocal] = useState(value);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastEmittedRef = useRef(value);
+
+  useEffect(() => {
+    // Parent value can move for two reasons:
+    //   1. Echo of our own debounced emit (lastEmittedRef matches): skip.
+    //   2. External reset (e.g., clear-on-filter-change): adopt it.
+    if (value === lastEmittedRef.current) return;
+    setLocal(value);
+  }, [value]);
+
+  useEffect(() => () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+  }, []);
+
+  const handleChange = (next: string) => {
+    setLocal(next);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      lastEmittedRef.current = next;
+      onValueChange(next);
+    }, DEBOUNCE_MS);
+  };
+
   return (
     <div className="px-4 py-2 flex-none">
       <CommandInput
         placeholder="Search stacks..."
-        value={value}
-        onValueChange={onValueChange}
+        value={local}
+        onValueChange={handleChange}
         className="h-9 border-none"
       />
     </div>

--- a/frontend/src/components/sidebar/__tests__/SidebarSearch.test.tsx
+++ b/frontend/src/components/sidebar/__tests__/SidebarSearch.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act, fireEvent, cleanup } from '@testing-library/react';
+import { Command } from '@/components/ui/command';
+import { SidebarSearch } from '../SidebarSearch';
+
+function renderInsideCommand(props: { value: string; onValueChange: (v: string) => void }) {
+  return render(
+    <Command shouldFilter={false}>
+      <SidebarSearch {...props} />
+    </Command>,
+  );
+}
+
+describe('SidebarSearch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+  });
+
+  it('reflects typing immediately in the input but does not emit until the debounce window closes', () => {
+    const onValueChange = vi.fn();
+    const { getByPlaceholderText } = renderInsideCommand({ value: '', onValueChange });
+    const input = getByPlaceholderText('Search stacks...') as HTMLInputElement;
+
+    act(() => {
+      fireEvent.input(input, { target: { value: 'n' } });
+      fireEvent.input(input, { target: { value: 'ng' } });
+      fireEvent.input(input, { target: { value: 'ngi' } });
+      fireEvent.input(input, { target: { value: 'ngin' } });
+      fireEvent.input(input, { target: { value: 'nginx' } });
+    });
+
+    expect(input.value).toBe('nginx');
+    expect(onValueChange).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(120);
+    });
+
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+    expect(onValueChange).toHaveBeenLastCalledWith('nginx');
+  });
+
+  it('does not clobber in-flight typing when the parent value echoes back the previous debounced emit', () => {
+    const onValueChange = vi.fn();
+    const { getByPlaceholderText, rerender } = renderInsideCommand({ value: '', onValueChange });
+    const input = getByPlaceholderText('Search stacks...') as HTMLInputElement;
+
+    act(() => {
+      fireEvent.input(input, { target: { value: 'web' } });
+    });
+    act(() => {
+      vi.advanceTimersByTime(120);
+    });
+    expect(onValueChange).toHaveBeenLastCalledWith('web');
+
+    // Parent now propagates 'web' back as the controlled value.
+    rerender(
+      <Command shouldFilter={false}>
+        <SidebarSearch value="web" onValueChange={onValueChange} />
+      </Command>,
+    );
+
+    // User keeps typing before the parent's echo settles.
+    act(() => {
+      fireEvent.input(input, { target: { value: 'web-api' } });
+    });
+
+    // The echo of 'web' must not overwrite 'web-api' on the input.
+    expect(input.value).toBe('web-api');
+  });
+
+  it('adopts an external reset of the parent value (e.g., clear)', () => {
+    const onValueChange = vi.fn();
+    const { getByPlaceholderText, rerender } = renderInsideCommand({ value: 'old-query', onValueChange });
+    const input = getByPlaceholderText('Search stacks...') as HTMLInputElement;
+    expect(input.value).toBe('old-query');
+
+    rerender(
+      <Command shouldFilter={false}>
+        <SidebarSearch value="" onValueChange={onValueChange} />
+      </Command>,
+    );
+
+    expect(input.value).toBe('');
+  });
+});

--- a/frontend/src/components/sidebar/sidebar-types.ts
+++ b/frontend/src/components/sidebar/sidebar-types.ts
@@ -27,6 +27,7 @@ export interface StackMenuCtx {
   isBusy: boolean;
   isPaid: boolean;
   isAdmiral: boolean;
+  isAdmin: boolean;
   canDelete: boolean;
   canEditLabels: boolean;
   canCreateLabels: boolean;

--- a/frontend/src/hooks/__tests__/useStackMenuItems.test.tsx
+++ b/frontend/src/hooks/__tests__/useStackMenuItems.test.tsx
@@ -11,6 +11,7 @@ function makeCtx(overrides: Partial<StackMenuCtx> = {}): StackMenuCtx {
     isBusy: false,
     isPaid: true,
     isAdmiral: false,
+    isAdmin: true,
     canDelete: true,
     canEditLabels: true,
     canCreateLabels: true,
@@ -92,6 +93,12 @@ describe('useStackMenuItems', () => {
     }
     const lifecycle = paid.result.current.find(g => g.id === 'lifecycle')!;
     expect(lifecycle.items.some(i => i.id === 'schedule')).toBe(true);
+  });
+
+  it('hides Schedule task when paid but not admin', () => {
+    const { result } = renderHook(() => useStackMenuItems('web.yml', makeCtx({ isPaid: true, isAdmin: false })));
+    const lifecycle = result.current.find(g => g.id === 'lifecycle');
+    expect(lifecycle?.items.some(i => i.id === 'schedule')).toBeFalsy();
   });
 
   it('keeps label assignment available when !isPaid', () => {

--- a/frontend/src/hooks/useStackMenuItems.tsx
+++ b/frontend/src/hooks/useStackMenuItems.tsx
@@ -18,7 +18,7 @@ import type { MenuGroup, MenuItem, StackMenuCtx } from '@/components/sidebar/sid
 
 export function useStackMenuItems(_file: string, ctx: StackMenuCtx): MenuGroup[] {
   const {
-    stackStatus, hasPort, isBusy, isPaid, canDelete, canEditLabels, isPinned, labels,
+    stackStatus, hasPort, isBusy, isPaid, isAdmin, canDelete, canEditLabels, isPinned, labels,
     openAlertSheet, openAutoHeal, checkUpdates, openStackApp,
     deploy, stop, restart, update, remove, pin, unpin, toggleLabel,
     menuVisibility, openScheduleTask,
@@ -68,7 +68,7 @@ export function useStackMenuItems(_file: string, ctx: StackMenuCtx): MenuGroup[]
     if (showStop) lifecycle.push({ id: 'stop', label: 'Stop', icon: Square, shortcut: '⌘.', onSelect: stop, disabled: isBusy });
     if (showRestart) lifecycle.push({ id: 'restart', label: 'Restart', icon: RotateCw, shortcut: '⌘R', onSelect: restart, disabled: isBusy });
     if (showUpdate) lifecycle.push({ id: 'update', label: 'Update', icon: Download, shortcut: '⌘↑', onSelect: update, disabled: isBusy });
-    if (isPaid) lifecycle.push({ id: 'schedule', label: 'Schedule task', icon: CalendarClock, onSelect: openScheduleTask });
+    if (isPaid && isAdmin) lifecycle.push({ id: 'schedule', label: 'Schedule task', icon: CalendarClock, onSelect: openScheduleTask });
     if (lifecycle.length > 0) groups.push({ id: 'lifecycle', items: lifecycle });
 
     if (canDelete) {
@@ -80,7 +80,7 @@ export function useStackMenuItems(_file: string, ctx: StackMenuCtx): MenuGroup[]
 
     return groups;
   }, [
-    stackStatus, hasPort, isBusy, isPaid, canDelete, canEditLabels, isPinned, labels,
+    stackStatus, hasPort, isBusy, isPaid, isAdmin, canDelete, canEditLabels, isPinned, labels,
     showDeploy, showStop, showRestart, showUpdate,
     openAlertSheet, openAutoHeal, checkUpdates, openStackApp,
     deploy, stop, restart, update, remove, pin, unpin, toggleLabel, openScheduleTask,


### PR DESCRIPTION
## Summary

- The right-click **Schedule task** menu item was gated on `isPaid` only, but every write under `/api/scheduled-tasks` enforces `requireAdmin` + `requirePaid`. Non-admin Skipper or Admiral users saw the menu item and would get a 403 on click. Frontend now mirrors backend: Schedule task renders only when `isPaid && isAdmin`.
- Sidebar search now debounces at 120ms before reaching `useStackListState`'s filter rebuild. `<Command shouldFilter={false}>` disables cmdk's own filter, so previously every keystroke rebuilt the group memo from scratch. Local input state stays immediate so typing feels unchanged.
- Adds a regression guard that `/api/stacks/statuses` (the sidebar status poll path) is short-circuited by the remote-node proxy when `x-node-id` targets a remote.
- Updates the sidebar feature docs to reflect the admin role requirement on Schedule task and adds a troubleshooting accordion for the missing-menu-item case.

## Gate parity

Two-column inventory for sidebar-triggered actions (only mismatches and the one being fixed are listed; the full sweep is below).

| Backend route | Backend guard | Frontend trigger | Frontend gate (before → after) |
|---|---|---|---|
| `POST /api/scheduled-tasks` (and write paths in that router) | `requireAdmin` + `requirePaid` | per-stack **Schedule task** in `useStackMenuItems.tsx:71`; navigates to `scheduled-ops` view | `isPaid` → **`isPaid && isAdmin`** |
| `PUT /api/stacks/:name/auto-update` | `requirePaid` + `requireAdmin` | n/a in `origin/main` (auto-update menu item already removed in a prior cleanup; `Schedule task` is now the auto-update path) | no change needed |

Full sweep (validated, no further mismatches found):

- `/api/stacks` (GET), `/api/stacks/statuses` (GET): `stack:read` permission both sides.
- `/api/stacks/:name/{deploy,stop,restart,update,delete}`: permission-based both sides via `menuVisibility` + `canDelete`.
- `/api/stacks/:name/labels` (PUT, mounted via `stackLabelsRouter`): permission-based both sides (`canEditLabels`).
- `/api/labels` (POST, inline label create): `stack:edit` both sides (`canCreateLabels`).
- `/api/labels/:id/action`: `requirePaid` + `requireAdmin`. Not reachable from the sidebar's own surface; the **Manage labels...** entry navigates to Settings, where the action lives. Out of scope for this PR.
- `/api/auto-heal/*` writes: `requireAdmin` + `requirePaid`. The sidebar **Auto-Heal** trigger opens a read-only panel (which is `requirePaid`-only); admin gating of writes happens inside the panel. Different audit surface.
- Bulk `Update` button in `SidebarBulkBar.tsx`: backend `stack:deploy` only; frontend gates on `isPaid` (product gate tied to atomic-deploy semantics on the paid tier, not a 403-on-click drift). Left as-is.

## Test plan

- [x] `cd backend && npx tsc --noEmit` · zero errors.
- [x] `cd frontend && npx tsc -b --noEmit` · zero errors.
- [x] `cd frontend && npm run lint` · zero new errors (141 pre-existing warnings unchanged).
- [x] `cd backend && npm run lint` · zero new errors (333 pre-existing warnings unchanged).
- [x] `cd frontend && npx vitest run src/components/sidebar src/components/EditorLayout src/hooks` · 18 files / 157 tests pass, including the new `SidebarSearch.test.tsx` debounce coverage and the new non-admin Schedule task case in `useStackMenuItems.test.tsx`.
- [x] `cd backend && npx vitest run src/__tests__/proxy-mount-order.test.ts` · 4 tests pass, now including the `/api/stacks/statuses` short-circuit assertion.
- **Tier-persona matrix**:
  - [x] Community admin: Schedule task hidden in the right-click context menu. Verified end-to-end via Playwright on a fresh worktree dev instance. Auto-Heal also correctly hidden via the `!isPaid` clause, which together with the rendered `Stop`/`Restart`/`Update`/`Delete`/`Labels`/`Unpin`/`Alerts`/`Check updates`/`Open App` items confirms the new `isAdmin` value reaches the menu builder through the new threading.
  - [ ] Skipper non-admin: Schedule task hidden; direct `POST /api/scheduled-tasks` returns 403. (Pending: requires a Skipper license key on the dev instance.)
  - [ ] Skipper admin: Schedule task visible; POST succeeds end-to-end. (Pending: same license-key requirement.)
  - [ ] Admiral non-admin: Schedule task hidden; direct POST returns 403. (Pending: license-key requirement.)
  - [ ] Admiral admin: Schedule task visible; POST succeeds end-to-end. (Pending: license-key requirement.)
  - All four `(isPaid × isAdmin)` quadrants are covered by Vitest in `useStackMenuItems.test.tsx` (`hides Schedule task when paid but not admin`); the live persona checks above re-confirm the wiring at runtime.
- [x] **Search debounce check** verified via Playwright on the dev instance. A 5-character typing burst on the `Search stacks...` input produced exactly **1 mutation** on the stack listbox subtree (mutation-observer count taken 500ms after the burst), with the input value still reading `nginx` and the filter correctly emptying the list (no stack matches that query). Pre-debounce baseline would have been one mutation per keystroke.
- [x] **Console-noise check**: 6 console errors observed during the Playwright session, all the same pre-existing `useNextAutoUpdateRun` polling bug (now tracked as **SEN-104**, Pre-1.0 Beta, Medium). No new console errors or warnings introduced by this PR.

## Notes

- **Rollback**: single-PR revert; no DB migration; no backend gate change.
- **Fleet dimension**: frontend-only; mixed version skew is safe across remote nodes since only the user-visible affordance changes.
- **Watch (24-48h post-deploy)**: any Discord/support reports of "I can't see Schedule task" from non-admin paid users indicate the product call (admin-only) needs revisiting, not a code-rollback emergency.
- **Deferred to Linear (1.1)**: SEN-101 (M-1: partial status state for multi-container stacks, per founder decision); SEN-102 (L-3: silent pin eviction at the 10-cap); SEN-103 (L-4: failed-nodes tooltip unbounded join).
- **Surfaced during validation, filed to Linear (Pre-1.0 Beta)**: SEN-104 · `useNextAutoUpdateRun` polls a paid+admin-guarded endpoint regardless of the user's tier or role, generating one 403 every 60s plus on every state-invalidate broadcast. Pre-existing; not introduced by this PR. Cheap frontend gate fix (~5 lines) tracked separately to keep this PR surgical.
- **Audit corrections**: the initial Phase 1 audit recorded L-1 and L-2 as info-leak candidates on the assumption that the relevant GET endpoints had no tier guard. Closer reading shows the framing was off on both:
  - L-1 (`GET /api/stacks/:stackName/auto-update`, `stacks.ts:423-432`): still ungated beyond the global auth gate, but the only data returned is a single `enabled` boolean. Every authed user already holds `stack:read` and can list every stack on the node, so a per-stack auto-update toggle adds nothing material. Not a real leak; no follow-up filed.
  - L-2 (`GET /api/scheduled-tasks?action=update`, `scheduledTasks.ts:122-124`): the audit assumed unguarded; the route in fact enforces `requireAdmin` + `requirePaid`. There is no info leak; the surfaced behaviour (a 403 visible in the console for Community / non-admin sessions) is the call-site bug captured as SEN-104, not a backend gate gap.
- **Audit findings out of scope**: M-2 (useNextAutoUpdateRun cleanup race) re-verified clean against the unmount path; the closure-captured `active` flag and cleanup function already clear the timer, interval, and in-flight AbortController.

