### PR TITLE
fix(sidebar): cancel pending debounce emit on external value reset

### DIFF
--- a/frontend/src/components/sidebar/SidebarSearch.tsx
+++ b/frontend/src/components/sidebar/SidebarSearch.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { CommandInput } from '@/components/ui/command';
 
 interface SidebarSearchProps {
@@ -13,17 +13,32 @@ interface SidebarSearchProps {
 const DEBOUNCE_MS = 120;
 
 export function SidebarSearch({ value, onValueChange }: SidebarSearchProps) {
-  const [local, setLocal] = useState(value);
+  const [local, setLocalState] = useState(value);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const lastEmittedRef = useRef(value);
+  // localRef mirrors `local` for the value-sync effect. Reading state via the
+  // ref keeps the effect deps on [value] without dropping a real read of
+  // `local`, which would either lie to React or trigger spurious re-runs.
+  const localRef = useRef(value);
+
+  const setLocal = useCallback((next: string) => {
+    localRef.current = next;
+    setLocalState(next);
+  }, []);
 
   useEffect(() => {
-    // Parent value can move for two reasons:
-    //   1. Echo of our own debounced emit (lastEmittedRef matches): skip.
-    //   2. External reset (e.g., clear-on-filter-change): adopt it.
-    if (value === lastEmittedRef.current) return;
+    // The parent value moved. Skip only when it already matches what's shown
+    // locally: that is the post-emit steady state (the debounce echo settled
+    // back through the parent). Any other movement is an external change
+    // (clear-on-filter-change, navigation restore, programmatic set, or a
+    // coincidence) and must win: cancel any in-flight emit so it cannot undo
+    // the reset, then adopt the value.
+    if (value === localRef.current) return;
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
     setLocal(value);
-  }, [value]);
+  }, [value, setLocal]);
 
   useEffect(() => () => {
     if (timerRef.current) clearTimeout(timerRef.current);
@@ -33,7 +48,7 @@ export function SidebarSearch({ value, onValueChange }: SidebarSearchProps) {
     setLocal(next);
     if (timerRef.current) clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => {
-      lastEmittedRef.current = next;
+      timerRef.current = null;
       onValueChange(next);
     }, DEBOUNCE_MS);
   };

--- a/frontend/src/components/sidebar/__tests__/SidebarSearch.test.tsx
+++ b/frontend/src/components/sidebar/__tests__/SidebarSearch.test.tsx
@@ -88,4 +88,35 @@ describe('SidebarSearch', () => {
 
     expect(input.value).toBe('');
   });
+
+  it('cancels the pending debounce emit when the parent resets the value mid-window', () => {
+    const onValueChange = vi.fn();
+    // Start at a non-empty initial so the later reset to '' is a real prop
+    // transition; rerendering with the same string would no-op in React.
+    const { getByPlaceholderText, rerender } = renderInsideCommand({ value: 'initial', onValueChange });
+    const input = getByPlaceholderText('Search stacks...') as HTMLInputElement;
+    expect(input.value).toBe('initial');
+
+    act(() => {
+      fireEvent.input(input, { target: { value: 'web' } });
+    });
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+    expect(onValueChange).not.toHaveBeenCalled();
+
+    rerender(
+      <Command shouldFilter={false}>
+        <SidebarSearch value="" onValueChange={onValueChange} />
+      </Command>,
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    // The stale timer must not fire and re-emit 'web', undoing the reset.
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(input.value).toBe('');
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to PR #1243. An independent review of that PR caught a race in `SidebarSearch`'s debounce: when the parent value reset mid-window (clear-on-filter-change, navigation restore, etc.), the value-sync effect adopted the new value but left the pending `setTimeout` in place. The stale timer then fired after the adopt and emitted the typed query back to the parent, silently undoing the reset.

The skip condition also leaned on `lastEmittedRef`, which had the secondary issue of treating a genuine reset whose value happened to equal the last emit as if it were an echo.

## Change

Compare the parent value against the locally shown value (mirrored through `localRef` so the effect deps stay on `[value]`). On any external transition, clear the pending timer before adopting. `lastEmittedRef` is dead under this model and removed.

## Test plan

- [x] `cd frontend && npx tsc -b --noEmit` clean.
- [x] `cd frontend && npm run lint` 0 errors (141 pre-existing warnings unchanged).
- [x] `cd frontend && npx vitest run src/components/sidebar` 7 files / 51 tests pass, including the new `cancels the pending debounce emit when the parent resets the value mid-window` case (typed 'web', advanced 50ms, rerendered with `value=""`, advanced 200ms past the original deadline, asserted `onValueChange` was never called and the input adopted the reset).
- [ ] Manual repro in the dev instance: type a query, click a filter chip that triggers a search reset, confirm the input clears and stays clear instead of bouncing back to the typed value 120ms later.

## Notes

- No backend change. No gate change.
- The `value === lastEmittedRef.current` skip predicate is replaced by `value === localRef.current`. The two are equivalent in steady state but the new form correctly distinguishes "parent echoed our last emit" from "parent reset to an arbitrary value".
- A test for the "reset value coincidentally equals the last emit" case was drafted and then dropped: rerendering a controlled component with the same prop value is a no-op in React (the reconciler bails on `Object.is`), so the scenario cannot actually surface to the child. The relevant transition is "value changed to a new value", which the new test covers.
- Rollback: single-PR revert; no database or backend impact.