### PR TITLE
fix(auto-heal): gate panel write controls on admin role

### DIFF
--- a/docs/features/sidebar.mdx
+++ b/docs/features/sidebar.mdx
@@ -85,7 +85,7 @@ Right-click any stack (or open the kebab that appears on hover) for its context 
 - **Destructive**: **Delete**.
 
 <Note>
-  **Auto-Heal** requires a **Skipper** or **Admiral** license. **Schedule task** requires a **Skipper** or **Admiral** license and an **admin** role.
+  **Auto-Heal** requires a **Skipper** or **Admiral** license; configuring policies (add, toggle, delete) also requires an **admin** role. **Schedule task** requires a **Skipper** or **Admiral** license and an **admin** role.
 </Note>
 
 <Frame>
@@ -145,5 +145,8 @@ The footer surfaces the most recent stack lifecycle event on the node. Each tick
   </Accordion>
   <Accordion title="Schedule task is missing from the right-click menu">
     Scheduling requires a **Skipper** or **Admiral** license and an **admin** role. Ask an admin on this node to schedule the task for you, or sign in with an admin account.
+  </Accordion>
+  <Accordion title="Auto-Heal panel opens but Add Policy and the toggles are missing">
+    Reading existing Auto-Heal policies only needs a **Skipper** or **Admiral** license, so the panel still opens for non-admin operators on paid tiers. Adding, enabling, disabling, or deleting policies also requires the **admin** role. Sign in with an admin account, or ask an admin on this node to make the change.
   </Accordion>
 </AccordionGroup>

--- a/frontend/src/components/StackAlertSheet.tsx
+++ b/frontend/src/components/StackAlertSheet.tsx
@@ -482,6 +482,7 @@ function AlertsTab({ stackName }: { stackName: string }) {
 }
 
 function AutoHealTab({ stackName, open }: { stackName: string; open: boolean }) {
+    const { isAdmin } = useAuth();
     const [policies, setPolicies] = useState<AutoHealPolicy[]>([]);
     const [loading, setLoading] = useState(false);
     const [saving, setSaving] = useState(false);
@@ -617,12 +618,14 @@ function AutoHealTab({ stackName, open }: { stackName: string; open: boolean }) 
                                 onToggle={handleToggle}
                                 deleting={deleting}
                                 saving={saving}
+                                isAdmin={isAdmin}
                             />
                         ))}
                     </div>
                 )}
             </SheetSection>
 
+            {isAdmin && (
             <SheetSection title="Add new policy">
                 <div className="space-y-3">
                     <div className="space-y-2">
@@ -700,6 +703,7 @@ function AutoHealTab({ stackName, open }: { stackName: string; open: boolean }) 
                     </Button>
                 </div>
             </SheetSection>
+            )}
         </>
     );
 }
@@ -710,9 +714,10 @@ interface PolicyRowProps {
     onToggle: (id: number, enabled: boolean) => void;
     deleting: boolean;
     saving: boolean;
+    isAdmin: boolean;
 }
 
-function PolicyRow({ policy, onDelete, onToggle, deleting, saving }: PolicyRowProps) {
+function PolicyRow({ policy, onDelete, onToggle, deleting, saving, isAdmin }: PolicyRowProps) {
     const [historyOpen, setHistoryOpen] = useState(false);
     const [history, setHistory] = useState<AutoHealHistoryEntry[]>([]);
     const [loadingHistory, setLoadingHistory] = useState(false);
@@ -760,12 +765,14 @@ function PolicyRow({ policy, onDelete, onToggle, deleting, saving }: PolicyRowPr
                     )}
                 </div>
                 <div className="flex items-center gap-2 shrink-0">
-                    <TogglePill
-                        checked={policy.enabled === 1}
-                        onChange={(checked) => policy.id != null && onToggle(policy.id, checked)}
-                        disabled={saving}
-                        aria-label={`Toggle policy for ${policy.service_name ?? 'all services'}`}
-                    />
+                    {isAdmin && (
+                        <TogglePill
+                            checked={policy.enabled === 1}
+                            onChange={(checked) => policy.id != null && onToggle(policy.id, checked)}
+                            disabled={saving}
+                            aria-label={`Toggle policy for ${policy.service_name ?? 'all services'}`}
+                        />
+                    )}
                     <Button
                         variant="ghost"
                         size="icon"
@@ -782,16 +789,18 @@ function PolicyRow({ policy, onDelete, onToggle, deleting, saving }: PolicyRowPr
                             <ChevronDown className="h-4 w-4" strokeWidth={1.5} />
                         )}
                     </Button>
-                    <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-7 w-7 text-destructive/60 hover:bg-destructive hover:text-destructive-foreground"
-                        onClick={() => policy.id != null && onDelete(policy.id)}
-                        disabled={deleting}
-                        aria-label="Delete policy"
-                    >
-                        <Trash2 className="h-4 w-4" strokeWidth={1.5} />
-                    </Button>
+                    {isAdmin && (
+                        <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7 text-destructive/60 hover:bg-destructive hover:text-destructive-foreground"
+                            onClick={() => policy.id != null && onDelete(policy.id)}
+                            disabled={deleting}
+                            aria-label="Delete policy"
+                        >
+                            <Trash2 className="h-4 w-4" strokeWidth={1.5} />
+                        </Button>
+                    )}
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary

Follow-up to PR #1243. Independent review caught a second drift in the same class as the Schedule task fix: the Auto-Heal panel rendered its add-policy form, the per-policy enable toggle, and the per-policy delete button without any admin guard, but the backend POST/PATCH/DELETE on `/api/auto-heal/policies` enforce `requireAdmin + requirePaid`. A paid non-admin user could see the controls and would hit a 403 on click.

The trigger to *open* the panel correctly stays on `isPaid` only, because the matching backend reads (`GET /policies` and `GET /policies/:id/history`) are `requirePaid` and intentionally available to all paid operators.

## Gate parity

| Backend route | Backend guard | Frontend surface | Frontend gate (before → after) |
|---|---|---|---|
| `GET /api/auto-heal/policies` | `requirePaid` | Auto-Heal context-menu item + panel open | `isPaid` (unchanged) |
| `GET /api/auto-heal/policies/:id/history` | `requirePaid` | History expand button | unguarded (unchanged) |
| `POST /api/auto-heal/policies` | `requireAdmin` + `requirePaid` | "Add new policy" section in `StackAlertSheet.tsx:626` | unguarded → **`isAdmin`** |
| `PATCH /api/auto-heal/policies/:id` | `requireAdmin` + `requirePaid` | Per-policy enable `TogglePill` in `StackAlertSheet.tsx:763` | unguarded → **`isAdmin`** |
| `DELETE /api/auto-heal/policies/:id` | `requireAdmin` + `requirePaid` | Per-policy delete `Trash2` button in `StackAlertSheet.tsx:785` | unguarded → **`isAdmin`** |

The plumbing mirrors what the Alerts tab in the same file already does (it reads `useAuth()` and wraps its delete button + Add-new-rule section in `{isAdmin && ...}`); `AutoHealTab` now does the same and threads `isAdmin` into `PolicyRow` as a prop.

## Test plan

- [x] `cd frontend && npx tsc -b --noEmit` clean.
- [x] `cd frontend && npm run lint` 0 errors (141 pre-existing warnings unchanged).
- [x] `cd frontend && npx vitest run src/components/sidebar src/hooks` 11 files / 84 tests pass.
- [ ] Manual repro in the dev instance, with a paid license:
  - **Paid admin**: right-click a running stack > Auto-Heal opens > "Add new policy" form visible > per-policy toggle visible > per-policy delete visible > Add Policy POST succeeds > Toggle PATCH succeeds > Delete succeeds.
  - **Paid non-admin**: same right-click > Auto-Heal opens > "Active policies" list visible > **no** "Add new policy" form > **no** per-policy toggle > **no** delete button > history expand still works > direct `POST /api/auto-heal/policies` returns 403.

## Notes

- No backend change. No new dependency. The `StackAlertSheet` component is large (~825 lines) and has no existing test harness; adding one is out of scope for a surgical parity fix. The manual repro above closes the loop.
- Rollback: single-PR revert; no DB or backend impact.
- Docs: `docs/features/sidebar.mdx` updated to call out the admin requirement on Auto-Heal write actions and to add a troubleshooting accordion. `docs/features/auto-heal-policies.mdx` already stated the admin requirement explicitly in its Prerequisites; left unchanged.