### PR TITLE
fix(fleet-secrets): restrict bundle management to admin hub sessions

### DIFF
--- a/backend/src/__tests__/hub-only-guard.test.ts
+++ b/backend/src/__tests__/hub-only-guard.test.ts
@@ -201,6 +201,31 @@ describe('hubOnlyGuard', () => {
     expect(res.body?.code).not.toBe('HUB_ONLY_ENDPOINT');
   });
 
+  // Regression for Fleet Secrets: bundles are stored and decrypted per instance,
+  // and GET /api/secrets/:id returns plaintext values. A proxied secrets request
+  // would read a remote node's decrypted values as the node-proxy admin, and the
+  // routes' own requireAdmin gate lives in the local handler the proxy skips.
+  // Cover the collection (no trailing slash) and a sub-path.
+  it('rejects /api/secrets with 403 when nodeId targets a remote node', async () => {
+    const res = await request(app)
+      .get('/api/secrets')
+      .set('Authorization', authHeader)
+      .set('x-node-id', String(remoteNodeId));
+
+    expect(res.status).toBe(403);
+    expect(res.body?.code).toBe('HUB_ONLY_ENDPOINT');
+  });
+
+  it('rejects a secrets sub-path (/api/secrets/5) with 403 when nodeId targets a remote node', async () => {
+    const res = await request(app)
+      .get('/api/secrets/5')
+      .set('Authorization', authHeader)
+      .set('x-node-id', String(remoteNodeId));
+
+    expect(res.status).toBe(403);
+    expect(res.body?.code).toBe('HUB_ONLY_ENDPOINT');
+  });
+
   it('does not interfere with non-hub paths even when nodeId targets a remote node', async () => {
     // /api/stacks is not hub-only and should be forwarded by the proxy.
     // The exact upstream-error status is not the contract here; what

--- a/backend/src/__tests__/secrets.test.ts
+++ b/backend/src/__tests__/secrets.test.ts
@@ -14,11 +14,9 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } 
 import request from 'supertest';
 import path from 'path';
 import fs from 'fs';
-import crypto from 'crypto';
 import jwt from 'jsonwebtoken';
 import { setupTestDb, cleanupTestDb, TEST_USERNAME, TEST_JWT_SECRET } from './helpers/setupTestDb';
 import { getAuditSummary } from '../utils/audit-summaries';
-import { generateApiToken } from '../utils/apiTokenFormat';
 import { parseEnv, serializeEnv, applyOverlay, computeDiff } from '../services/SecretsService';
 
 let tmpDir: string;
@@ -462,20 +460,16 @@ describe('Routes /api/secrets admin-role gating', () => {
 describe('Routes /api/secrets machine-credential rejection', () => {
     // A full-admin API token resolves to role 'admin' and would otherwise pass
     // requireAdmin and reach the decrypted-value GET. requireUserSession runs
-    // first and blocks it.
-    function fullAdminApiToken(): string {
-        const db = DatabaseService.getInstance();
-        const rawToken = generateApiToken();
-        db.addApiToken({
-            token_hash: crypto.createHash('sha256').update(rawToken).digest('hex'),
-            name: `secrets-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-            scope: 'full-admin',
-            user_id: db.getUserByUsername(TEST_USERNAME)!.id,
-            created_at: Date.now(),
-            expires_at: null,
-        });
-        return rawToken;
-    }
+    // first and blocks it. Mint the token through the real endpoint so the test
+    // exercises the production creation path and carries no hashing of its own.
+    let fullAdminToken: string;
+    beforeAll(async () => {
+        const res = await request(app)
+            .post('/api/api-tokens')
+            .set('Authorization', `Bearer ${adminToken()}`)
+            .send({ name: `secrets-rejection-${Date.now()}`, scope: 'full-admin' });
+        fullAdminToken = res.body.token as string;
+    });
 
     // node_proxy / pilot_tunnel JWTs are signed with this instance's secret and
     // map to { username: 'node-proxy', role: 'admin', userId: 0 } in authMiddleware.
@@ -485,7 +479,7 @@ describe('Routes /api/secrets machine-credential rejection', () => {
     }
 
     it.each(SECRET_ENDPOINTS)('403s a full-admin API token on %s %s with SESSION_REQUIRED', async (method, p) => {
-        const res = await callWithToken(method, p, fullAdminApiToken());
+        const res = await callWithToken(method, p, fullAdminToken);
         expect(res.status).toBe(403);
         expect(res.body.code).toBe('SESSION_REQUIRED');
     });

--- a/backend/src/__tests__/secrets.test.ts
+++ b/backend/src/__tests__/secrets.test.ts
@@ -5,7 +5,7 @@
  *  - encrypt round-trip via CryptoService
  *  - DatabaseService secret + version + push CRUD
  *  - SecretsService versioning, importFromStack, executePush aggregation
- *  - Route guards (requirePaid 403, requireAdmin 403, push lock 409)
+ *  - Route guards (requirePaid 403, requireAdmin 403, requireUserSession 403, push lock 409)
  *  - Hub-only enforcement is covered in hub-only-guard.test.ts
  *  - developer_mode diagnostics gating (and that diagnostics never log the secret value)
  *  - getAuditSummary patterns for /secrets routes
@@ -44,6 +44,30 @@ function clearSecretsTables(): void {
     db.prepare('DELETE FROM secret_pushes').run();
     db.prepare('DELETE FROM secret_versions').run();
     db.prepare('DELETE FROM secrets').run();
+}
+
+// Shared by the admin-role and machine-credential matrices: one representative
+// call per secrets endpoint. requireUserSession and requireAdmin both run before
+// requireBody and param parsing, so a bodyless request still surfaces the guard.
+const SECRET_ENDPOINTS: Array<[string, string]> = [
+    ['get', '/api/secrets'],
+    ['post', '/api/secrets'],
+    ['get', '/api/secrets/1'],
+    ['put', '/api/secrets/1'],
+    ['delete', '/api/secrets/1'],
+    ['get', '/api/secrets/1/versions'],
+    ['post', '/api/secrets/1/import-from-stack'],
+    ['post', '/api/secrets/1/push/preview'],
+    ['post', '/api/secrets/1/push'],
+];
+
+function callWithToken(method: string, p: string, token: string) {
+    const agent = request(app);
+    const r = method === 'get' ? agent.get(p)
+        : method === 'post' ? agent.post(p)
+        : method === 'put' ? agent.put(p)
+        : agent.delete(p);
+    return r.set('Authorization', `Bearer ${token}`);
 }
 
 beforeAll(async () => {
@@ -407,20 +431,6 @@ describe('Routes /api/secrets tier gating and lock', () => {
 // ---- Admin-role gating: secrets reveal decrypted values, so every route is admin-only ----
 
 describe('Routes /api/secrets admin-role gating', () => {
-    // One representative call per endpoint. requireAdmin runs before requireBody
-    // and param parsing, so a bodyless request still surfaces ADMIN_REQUIRED.
-    const SECRET_ENDPOINTS: Array<[string, string]> = [
-        ['get', '/api/secrets'],
-        ['post', '/api/secrets'],
-        ['get', '/api/secrets/1'],
-        ['put', '/api/secrets/1'],
-        ['delete', '/api/secrets/1'],
-        ['get', '/api/secrets/1/versions'],
-        ['post', '/api/secrets/1/import-from-stack'],
-        ['post', '/api/secrets/1/push/preview'],
-        ['post', '/api/secrets/1/push'],
-    ];
-
     // authMiddleware resolves the role from the DB (not the JWT), so a real
     // non-admin user must exist for the gate to see a non-admin role.
     function viewerToken(): string {
@@ -433,17 +443,8 @@ describe('Routes /api/secrets admin-role gating', () => {
         return authToken('sec-viewer', 'viewer', user.token_version);
     }
 
-    function call(method: string, p: string, token: string) {
-        const agent = request(app);
-        const r = method === 'get' ? agent.get(p)
-            : method === 'post' ? agent.post(p)
-            : method === 'put' ? agent.put(p)
-            : agent.delete(p);
-        return r.set('Authorization', `Bearer ${token}`);
-    }
-
     it.each(SECRET_ENDPOINTS)('403s a non-admin paid user on %s %s', async (method, p) => {
-        const res = await call(method, p, viewerToken());
+        const res = await callWithToken(method, p, viewerToken());
         expect(res.status).toBe(403);
         expect(res.body.code).toBe('ADMIN_REQUIRED');
     });
@@ -456,12 +457,12 @@ describe('Routes /api/secrets admin-role gating', () => {
     });
 });
 
-// ---- API-token rejection: secrets are a session-admin surface, not a token surface ----
+// ---- Machine-credential rejection: secrets need a real signed-in user session ----
 
-describe('Routes /api/secrets API-token rejection', () => {
+describe('Routes /api/secrets machine-credential rejection', () => {
     // A full-admin API token resolves to role 'admin' and would otherwise pass
-    // requireAdmin and reach the decrypted-value GET; rejectApiTokenScope runs
-    // first and blocks every API token, mirroring registry credentials.
+    // requireAdmin and reach the decrypted-value GET. requireUserSession runs
+    // first and blocks it.
     function fullAdminApiToken(): string {
         const db = DatabaseService.getInstance();
         const rawToken = generateApiToken();
@@ -476,20 +477,29 @@ describe('Routes /api/secrets API-token rejection', () => {
         return rawToken;
     }
 
-    it('403s a full-admin API token on the list route with SCOPE_DENIED', async () => {
-        const res = await request(app)
-            .get('/api/secrets')
-            .set('Authorization', `Bearer ${fullAdminApiToken()}`);
+    // node_proxy / pilot_tunnel JWTs are signed with this instance's secret and
+    // map to { username: 'node-proxy', role: 'admin', userId: 0 } in authMiddleware.
+    // They carry no apiTokenScope, so only the userId-0 check blocks them.
+    function machineJwt(scope: 'node_proxy' | 'pilot_tunnel'): string {
+        return jwt.sign({ scope }, TEST_JWT_SECRET, { expiresIn: '1m' });
+    }
+
+    it.each(SECRET_ENDPOINTS)('403s a full-admin API token on %s %s with SESSION_REQUIRED', async (method, p) => {
+        const res = await callWithToken(method, p, fullAdminApiToken());
         expect(res.status).toBe(403);
-        expect(res.body.code).toBe('SCOPE_DENIED');
+        expect(res.body.code).toBe('SESSION_REQUIRED');
     });
 
-    it('403s a full-admin API token on the decrypted-value GET with SCOPE_DENIED', async () => {
+    it.each([
+        ['node_proxy', '/api/secrets'],
+        ['node_proxy', '/api/secrets/1'],
+        ['pilot_tunnel', '/api/secrets/1'],
+    ] as const)('403s a %s JWT on %s with SESSION_REQUIRED', async (scope, p) => {
         const res = await request(app)
-            .get('/api/secrets/1')
-            .set('Authorization', `Bearer ${fullAdminApiToken()}`);
+            .get(p)
+            .set('Authorization', `Bearer ${machineJwt(scope)}`);
         expect(res.status).toBe(403);
-        expect(res.body.code).toBe('SCOPE_DENIED');
+        expect(res.body.code).toBe('SESSION_REQUIRED');
     });
 });
 

--- a/backend/src/__tests__/secrets.test.ts
+++ b/backend/src/__tests__/secrets.test.ts
@@ -5,16 +5,20 @@
  *  - encrypt round-trip via CryptoService
  *  - DatabaseService secret + version + push CRUD
  *  - SecretsService versioning, importFromStack, executePush aggregation
- *  - Route guards (requirePaid 403, push lock 409)
+ *  - Route guards (requirePaid 403, requireAdmin 403, push lock 409)
+ *  - Hub-only enforcement is covered in hub-only-guard.test.ts
+ *  - developer_mode diagnostics gating (and that diagnostics never log the secret value)
  *  - getAuditSummary patterns for /secrets routes
  */
-import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
 import request from 'supertest';
 import path from 'path';
 import fs from 'fs';
+import crypto from 'crypto';
 import jwt from 'jsonwebtoken';
 import { setupTestDb, cleanupTestDb, TEST_USERNAME, TEST_JWT_SECRET } from './helpers/setupTestDb';
 import { getAuditSummary } from '../utils/audit-summaries';
+import { generateApiToken } from '../utils/apiTokenFormat';
 import { parseEnv, serializeEnv, applyOverlay, computeDiff } from '../services/SecretsService';
 
 let tmpDir: string;
@@ -397,5 +401,139 @@ describe('Routes /api/secrets tier gating and lock', () => {
             .set('Authorization', `Bearer ${adminToken()}`)
             .send({ name: 'x', kv: 'not-an-object' });
         expect(res.status).toBe(400);
+    });
+});
+
+// ---- Admin-role gating: secrets reveal decrypted values, so every route is admin-only ----
+
+describe('Routes /api/secrets admin-role gating', () => {
+    // One representative call per endpoint. requireAdmin runs before requireBody
+    // and param parsing, so a bodyless request still surfaces ADMIN_REQUIRED.
+    const SECRET_ENDPOINTS: Array<[string, string]> = [
+        ['get', '/api/secrets'],
+        ['post', '/api/secrets'],
+        ['get', '/api/secrets/1'],
+        ['put', '/api/secrets/1'],
+        ['delete', '/api/secrets/1'],
+        ['get', '/api/secrets/1/versions'],
+        ['post', '/api/secrets/1/import-from-stack'],
+        ['post', '/api/secrets/1/push/preview'],
+        ['post', '/api/secrets/1/push'],
+    ];
+
+    // authMiddleware resolves the role from the DB (not the JWT), so a real
+    // non-admin user must exist for the gate to see a non-admin role.
+    function viewerToken(): string {
+        const db = DatabaseService.getInstance();
+        let user = db.getUserByUsername('sec-viewer');
+        if (!user) {
+            db.addUser({ username: 'sec-viewer', password_hash: 'x', role: 'viewer' });
+            user = db.getUserByUsername('sec-viewer')!;
+        }
+        return authToken('sec-viewer', 'viewer', user.token_version);
+    }
+
+    function call(method: string, p: string, token: string) {
+        const agent = request(app);
+        const r = method === 'get' ? agent.get(p)
+            : method === 'post' ? agent.post(p)
+            : method === 'put' ? agent.put(p)
+            : agent.delete(p);
+        return r.set('Authorization', `Bearer ${token}`);
+    }
+
+    it.each(SECRET_ENDPOINTS)('403s a non-admin paid user on %s %s', async (method, p) => {
+        const res = await call(method, p, viewerToken());
+        expect(res.status).toBe(403);
+        expect(res.body.code).toBe('ADMIN_REQUIRED');
+    });
+
+    it('lets an admin paid user list (200)', async () => {
+        const res = await request(app)
+            .get('/api/secrets')
+            .set('Authorization', `Bearer ${adminToken()}`);
+        expect(res.status).toBe(200);
+    });
+});
+
+// ---- API-token rejection: secrets are a session-admin surface, not a token surface ----
+
+describe('Routes /api/secrets API-token rejection', () => {
+    // A full-admin API token resolves to role 'admin' and would otherwise pass
+    // requireAdmin and reach the decrypted-value GET; rejectApiTokenScope runs
+    // first and blocks every API token, mirroring registry credentials.
+    function fullAdminApiToken(): string {
+        const db = DatabaseService.getInstance();
+        const rawToken = generateApiToken();
+        db.addApiToken({
+            token_hash: crypto.createHash('sha256').update(rawToken).digest('hex'),
+            name: `secrets-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+            scope: 'full-admin',
+            user_id: db.getUserByUsername(TEST_USERNAME)!.id,
+            created_at: Date.now(),
+            expires_at: null,
+        });
+        return rawToken;
+    }
+
+    it('403s a full-admin API token on the list route with SCOPE_DENIED', async () => {
+        const res = await request(app)
+            .get('/api/secrets')
+            .set('Authorization', `Bearer ${fullAdminApiToken()}`);
+        expect(res.status).toBe(403);
+        expect(res.body.code).toBe('SCOPE_DENIED');
+    });
+
+    it('403s a full-admin API token on the decrypted-value GET with SCOPE_DENIED', async () => {
+        const res = await request(app)
+            .get('/api/secrets/1')
+            .set('Authorization', `Bearer ${fullAdminApiToken()}`);
+        expect(res.status).toBe(403);
+        expect(res.body.code).toBe('SCOPE_DENIED');
+    });
+});
+
+// ---- developer_mode diagnostics gating ----
+
+describe('SecretsService.executePush developer_mode diagnostics', () => {
+    beforeEach(() => {
+        const composeDir = process.env.COMPOSE_DIR!;
+        const stackDir = path.join(composeDir, 'devmodestack');
+        fs.mkdirSync(stackDir, { recursive: true });
+        fs.writeFileSync(path.join(stackDir, '.env'), 'EXISTING=keep\n');
+        fs.writeFileSync(path.join(stackDir, 'compose.yaml'), 'services:\n  app:\n    image: nginx\n');
+    });
+
+    afterEach(() => {
+        DatabaseService.getInstance().updateGlobalSetting('developer_mode', '0');
+    });
+
+    async function runPush(name: string): Promise<void> {
+        const db = DatabaseService.getInstance();
+        const localNode = db.getNodes().find(n => n.type === 'local')!;
+        const svc = SecretsService.getInstance();
+        const { id } = svc.create({ name, kv: { TOKEN: 'supersecretvalue' }, user: TEST_USERNAME });
+        await svc.executePush(id, { type: 'nodes', ids: [localNode.id] }, 'devmodestack', '.env', TEST_USERNAME);
+    }
+
+    it('emits [Secrets:diag] only when developer_mode is on, and never the secret value', async () => {
+        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+        try {
+            DatabaseService.getInstance().updateGlobalSetting('developer_mode', '0');
+            await runPush('devmode-off');
+            const offLogs = logSpy.mock.calls.map(c => c.join(' '));
+            expect(offLogs.some(l => l.includes('[Secrets:diag]'))).toBe(false);
+
+            logSpy.mockClear();
+            DatabaseService.getInstance().updateGlobalSetting('developer_mode', '1');
+            await runPush('devmode-on');
+            const onLogs = logSpy.mock.calls.map(c => c.join(' '));
+            expect(onLogs.some(l => l.includes('[Secrets:diag]'))).toBe(true);
+
+            // Diagnostics summarize counts only; the decrypted value must never appear.
+            expect([...offLogs, ...onLogs].some(l => l.includes('supersecretvalue'))).toBe(false);
+        } finally {
+            logSpy.mockRestore();
+        }
     });
 });

--- a/backend/src/helpers/proxyExemptPaths.ts
+++ b/backend/src/helpers/proxyExemptPaths.ts
@@ -32,9 +32,10 @@ export function isProxyExemptPath(path: string): boolean {
 // nodeId resolves to a remote node so a script/curl call cannot trick the proxy
 // into forwarding the request across a node boundary. This matters for the logs
 // feed (its admin gate lives in the local route handler, which the proxy would
-// skip when forwarding a remote nodeId) and for registries (a proxied registry
-// request would otherwise carry a plaintext secret to, or read stored
-// credentials from, the remote).
+// skip when forwarding a remote nodeId) and for registries and Fleet Secrets (a
+// proxied request would otherwise carry a plaintext secret to, or read stored
+// secret values from, the remote; the secrets routes' admin gate also lives in
+// the local route handler, which the proxy would skip).
 //
 // Entries are stored with a trailing slash; the matcher accepts the exact
 // collection path (without the trailing slash) AND any sub-path under it,
@@ -54,6 +55,7 @@ export const HUB_ONLY_PREFIXES: readonly string[] = [
   '/api/logs/global/',
   '/api/system/log-stream-metrics/',
   '/api/registries/',
+  '/api/secrets/',
 ];
 
 /** Returns true when the path is hub-only and must not be proxied to a remote node. */

--- a/backend/src/middleware/tierGates.ts
+++ b/backend/src/middleware/tierGates.ts
@@ -51,6 +51,20 @@ export const requireAdmin = (req: Request, res: Response): boolean => {
 };
 
 /**
+ * Require a genuine signed-in user session. Rejects opaque API tokens
+ * (`req.apiTokenScope`) and node_proxy / pilot_tunnel machine credentials,
+ * which authMiddleware maps to role 'admin' with userId 0. Endpoints that
+ * expose decrypted secrets use this so a long-lived machine credential cannot
+ * reach them; the admin role itself is still enforced separately by requireAdmin.
+ */
+export const requireUserSession = (req: Request, res: Response): boolean => {
+  if (req.apiTokenScope || !req.user || req.user.userId === 0) {
+    return deny(res, 'SESSION_REQUIRED', 'This action requires a signed-in user session.');
+  }
+  return true;
+};
+
+/**
  * Accept only calls from a sibling Sencho using its node_proxy Bearer token.
  * Browser sessions, API tokens, and console tokens are all rejected.
  */

--- a/backend/src/routes/secrets.ts
+++ b/backend/src/routes/secrets.ts
@@ -1,7 +1,6 @@
 import { Router, type Request, type Response } from 'express';
 import { authMiddleware } from '../middleware/auth';
-import { requirePaid, requireAdmin, requireBody } from '../middleware/tierGates';
-import { rejectApiTokenScope } from '../middleware/apiTokenScope';
+import { requirePaid, requireAdmin, requireUserSession, requireBody } from '../middleware/tierGates';
 import { SecretsService, PushBusyError, type SecretKv } from '../services/SecretsService';
 import { DatabaseService, type BlueprintSelector } from '../services/DatabaseService';
 import { isValidStackName } from '../utils/validation';
@@ -12,9 +11,9 @@ import { sanitizeForLog } from '../utils/safeLog';
 export const secretsRouter = Router();
 
 // Fleet Secrets reveals decrypted values and writes credentials fleet-wide, so
-// it is a session-admin surface only: long-lived API tokens are rejected outright
-// (same posture as registry credentials), before any tier/role gate.
-const SECRETS_SCOPE_MESSAGE = 'API tokens cannot manage Fleet Secrets.';
+// every route requires a signed-in admin user. requireUserSession rejects API
+// tokens and node_proxy / pilot_tunnel machine credentials (authMiddleware maps
+// the latter to role 'admin'), then requireAdmin enforces the role.
 
 const NAME_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9 _.-]{0,62}[a-zA-Z0-9]$/;
 
@@ -66,7 +65,7 @@ function parsePushBody(body: unknown): PushBody | { error: string } {
 }
 
 secretsRouter.get('/', authMiddleware, async (req: Request, res: Response): Promise<void> => {
-    if (rejectApiTokenScope(req, res, SECRETS_SCOPE_MESSAGE)) return;
+    if (!requireUserSession(req, res)) return;
     if (!requirePaid(req, res)) return;
     if (!requireAdmin(req, res)) return;
     try {
@@ -79,7 +78,7 @@ secretsRouter.get('/', authMiddleware, async (req: Request, res: Response): Prom
 });
 
 secretsRouter.post('/', authMiddleware, async (req: Request, res: Response): Promise<void> => {
-    if (rejectApiTokenScope(req, res, SECRETS_SCOPE_MESSAGE)) return;
+    if (!requireUserSession(req, res)) return;
     if (!requirePaid(req, res)) return;
     if (!requireAdmin(req, res)) return;
     if (!requireBody(req, res)) return;
@@ -121,7 +120,7 @@ secretsRouter.post('/', authMiddleware, async (req: Request, res: Response): Pro
 });
 
 secretsRouter.get('/:id', authMiddleware, async (req: Request, res: Response): Promise<void> => {
-    if (rejectApiTokenScope(req, res, SECRETS_SCOPE_MESSAGE)) return;
+    if (!requireUserSession(req, res)) return;
     if (!requirePaid(req, res)) return;
     if (!requireAdmin(req, res)) return;
     try {
@@ -141,7 +140,7 @@ secretsRouter.get('/:id', authMiddleware, async (req: Request, res: Response): P
 });
 
 secretsRouter.put('/:id', authMiddleware, async (req: Request, res: Response): Promise<void> => {
-    if (rejectApiTokenScope(req, res, SECRETS_SCOPE_MESSAGE)) return;
+    if (!requireUserSession(req, res)) return;
     if (!requirePaid(req, res)) return;
     if (!requireAdmin(req, res)) return;
     if (!requireBody(req, res)) return;
@@ -181,7 +180,7 @@ secretsRouter.put('/:id', authMiddleware, async (req: Request, res: Response): P
 });
 
 secretsRouter.delete('/:id', authMiddleware, async (req: Request, res: Response): Promise<void> => {
-    if (rejectApiTokenScope(req, res, SECRETS_SCOPE_MESSAGE)) return;
+    if (!requireUserSession(req, res)) return;
     if (!requirePaid(req, res)) return;
     if (!requireAdmin(req, res)) return;
     try {
@@ -201,7 +200,7 @@ secretsRouter.delete('/:id', authMiddleware, async (req: Request, res: Response)
 });
 
 secretsRouter.get('/:id/versions', authMiddleware, async (req: Request, res: Response): Promise<void> => {
-    if (rejectApiTokenScope(req, res, SECRETS_SCOPE_MESSAGE)) return;
+    if (!requireUserSession(req, res)) return;
     if (!requirePaid(req, res)) return;
     if (!requireAdmin(req, res)) return;
     try {
@@ -219,7 +218,7 @@ secretsRouter.get('/:id/versions', authMiddleware, async (req: Request, res: Res
 });
 
 secretsRouter.post('/:id/import-from-stack', authMiddleware, async (req: Request, res: Response): Promise<void> => {
-    if (rejectApiTokenScope(req, res, SECRETS_SCOPE_MESSAGE)) return;
+    if (!requireUserSession(req, res)) return;
     if (!requirePaid(req, res)) return;
     if (!requireAdmin(req, res)) return;
     if (!requireBody(req, res)) return;
@@ -249,7 +248,7 @@ secretsRouter.post('/:id/import-from-stack', authMiddleware, async (req: Request
 });
 
 secretsRouter.post('/:id/push/preview', authMiddleware, async (req: Request, res: Response): Promise<void> => {
-    if (rejectApiTokenScope(req, res, SECRETS_SCOPE_MESSAGE)) return;
+    if (!requireUserSession(req, res)) return;
     if (!requirePaid(req, res)) return;
     if (!requireAdmin(req, res)) return;
     if (!requireBody(req, res)) return;
@@ -274,7 +273,7 @@ secretsRouter.post('/:id/push/preview', authMiddleware, async (req: Request, res
 });
 
 secretsRouter.post('/:id/push', authMiddleware, async (req: Request, res: Response): Promise<void> => {
-    if (rejectApiTokenScope(req, res, SECRETS_SCOPE_MESSAGE)) return;
+    if (!requireUserSession(req, res)) return;
     if (!requirePaid(req, res)) return;
     if (!requireAdmin(req, res)) return;
     if (!requireBody(req, res)) return;

--- a/backend/src/routes/secrets.ts
+++ b/backend/src/routes/secrets.ts
@@ -1,6 +1,7 @@
 import { Router, type Request, type Response } from 'express';
 import { authMiddleware } from '../middleware/auth';
-import { requirePaid, requireBody } from '../middleware/tierGates';
+import { requirePaid, requireAdmin, requireBody } from '../middleware/tierGates';
+import { rejectApiTokenScope } from '../middleware/apiTokenScope';
 import { SecretsService, PushBusyError, type SecretKv } from '../services/SecretsService';
 import { DatabaseService, type BlueprintSelector } from '../services/DatabaseService';
 import { isValidStackName } from '../utils/validation';
@@ -9,6 +10,11 @@ import { parseIntParam } from '../utils/parseIntParam';
 import { sanitizeForLog } from '../utils/safeLog';
 
 export const secretsRouter = Router();
+
+// Fleet Secrets reveals decrypted values and writes credentials fleet-wide, so
+// it is a session-admin surface only: long-lived API tokens are rejected outright
+// (same posture as registry credentials), before any tier/role gate.
+const SECRETS_SCOPE_MESSAGE = 'API tokens cannot manage Fleet Secrets.';
 
 const NAME_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9 _.-]{0,62}[a-zA-Z0-9]$/;
 
@@ -60,7 +66,9 @@ function parsePushBody(body: unknown): PushBody | { error: string } {
 }
 
 secretsRouter.get('/', authMiddleware, async (req: Request, res: Response): Promise<void> => {
+    if (rejectApiTokenScope(req, res, SECRETS_SCOPE_MESSAGE)) return;
     if (!requirePaid(req, res)) return;
+    if (!requireAdmin(req, res)) return;
     try {
         const items = SecretsService.getInstance().list();
         res.json(items);
@@ -71,7 +79,9 @@ secretsRouter.get('/', authMiddleware, async (req: Request, res: Response): Prom
 });
 
 secretsRouter.post('/', authMiddleware, async (req: Request, res: Response): Promise<void> => {
+    if (rejectApiTokenScope(req, res, SECRETS_SCOPE_MESSAGE)) return;
     if (!requirePaid(req, res)) return;
+    if (!requireAdmin(req, res)) return;
     if (!requireBody(req, res)) return;
     try {
         const { name, description, kv, note } = req.body as { name?: unknown; description?: unknown; kv?: unknown; note?: unknown };
@@ -98,6 +108,7 @@ secretsRouter.post('/', authMiddleware, async (req: Request, res: Response): Pro
             user: getActor(req),
             note: typeof note === 'string' ? note : undefined,
         });
+        console.log(`[Secrets] Created bundle ${sanitizeForLog(name)} (v${result.version}) by ${sanitizeForLog(getActor(req))}`);
         res.status(201).json(result);
     } catch (err) {
         if (isSqliteUniqueViolation(err)) {
@@ -110,7 +121,9 @@ secretsRouter.post('/', authMiddleware, async (req: Request, res: Response): Pro
 });
 
 secretsRouter.get('/:id', authMiddleware, async (req: Request, res: Response): Promise<void> => {
+    if (rejectApiTokenScope(req, res, SECRETS_SCOPE_MESSAGE)) return;
     if (!requirePaid(req, res)) return;
+    if (!requireAdmin(req, res)) return;
     try {
         const id = parseIntParam(req, res, 'id', 'secret ID');
         if (id === null) return;
@@ -128,7 +141,9 @@ secretsRouter.get('/:id', authMiddleware, async (req: Request, res: Response): P
 });
 
 secretsRouter.put('/:id', authMiddleware, async (req: Request, res: Response): Promise<void> => {
+    if (rejectApiTokenScope(req, res, SECRETS_SCOPE_MESSAGE)) return;
     if (!requirePaid(req, res)) return;
+    if (!requireAdmin(req, res)) return;
     if (!requireBody(req, res)) return;
     try {
         const id = parseIntParam(req, res, 'id', 'secret ID');
@@ -157,6 +172,7 @@ secretsRouter.put('/:id', authMiddleware, async (req: Request, res: Response): P
             user: getActor(req),
             note: typeof note === 'string' ? note : undefined,
         });
+        console.log(`[Secrets] Updated bundle ${sanitizeForLog(existing.name)} to v${result.version} by ${sanitizeForLog(getActor(req))}`);
         res.json(result);
     } catch (err) {
         console.error('[Secrets] Update error:', err);
@@ -165,7 +181,9 @@ secretsRouter.put('/:id', authMiddleware, async (req: Request, res: Response): P
 });
 
 secretsRouter.delete('/:id', authMiddleware, async (req: Request, res: Response): Promise<void> => {
+    if (rejectApiTokenScope(req, res, SECRETS_SCOPE_MESSAGE)) return;
     if (!requirePaid(req, res)) return;
+    if (!requireAdmin(req, res)) return;
     try {
         const id = parseIntParam(req, res, 'id', 'secret ID');
         if (id === null) return;
@@ -174,6 +192,7 @@ secretsRouter.delete('/:id', authMiddleware, async (req: Request, res: Response)
             res.status(404).json({ error: 'Secret not found' });
             return;
         }
+        console.log(`[Secrets] Deleted bundle id=${id} by ${sanitizeForLog(getActor(req))}`);
         res.json({ ok: true });
     } catch (err) {
         console.error('[Secrets] Delete error:', err);
@@ -182,7 +201,9 @@ secretsRouter.delete('/:id', authMiddleware, async (req: Request, res: Response)
 });
 
 secretsRouter.get('/:id/versions', authMiddleware, async (req: Request, res: Response): Promise<void> => {
+    if (rejectApiTokenScope(req, res, SECRETS_SCOPE_MESSAGE)) return;
     if (!requirePaid(req, res)) return;
+    if (!requireAdmin(req, res)) return;
     try {
         const id = parseIntParam(req, res, 'id', 'secret ID');
         if (id === null) return;
@@ -198,7 +219,9 @@ secretsRouter.get('/:id/versions', authMiddleware, async (req: Request, res: Res
 });
 
 secretsRouter.post('/:id/import-from-stack', authMiddleware, async (req: Request, res: Response): Promise<void> => {
+    if (rejectApiTokenScope(req, res, SECRETS_SCOPE_MESSAGE)) return;
     if (!requirePaid(req, res)) return;
+    if (!requireAdmin(req, res)) return;
     if (!requireBody(req, res)) return;
     try {
         const id = parseIntParam(req, res, 'id', 'secret ID');
@@ -226,7 +249,9 @@ secretsRouter.post('/:id/import-from-stack', authMiddleware, async (req: Request
 });
 
 secretsRouter.post('/:id/push/preview', authMiddleware, async (req: Request, res: Response): Promise<void> => {
+    if (rejectApiTokenScope(req, res, SECRETS_SCOPE_MESSAGE)) return;
     if (!requirePaid(req, res)) return;
+    if (!requireAdmin(req, res)) return;
     if (!requireBody(req, res)) return;
     try {
         const id = parseIntParam(req, res, 'id', 'secret ID');
@@ -249,7 +274,9 @@ secretsRouter.post('/:id/push/preview', authMiddleware, async (req: Request, res
 });
 
 secretsRouter.post('/:id/push', authMiddleware, async (req: Request, res: Response): Promise<void> => {
+    if (rejectApiTokenScope(req, res, SECRETS_SCOPE_MESSAGE)) return;
     if (!requirePaid(req, res)) return;
+    if (!requireAdmin(req, res)) return;
     if (!requireBody(req, res)) return;
     try {
         const id = parseIntParam(req, res, 'id', 'secret ID');
@@ -266,7 +293,9 @@ secretsRouter.post('/:id/push', authMiddleware, async (req: Request, res: Respon
         }
         try {
             const result = await SecretsService.getInstance().executePush(id, parsed.selector, parsed.stackName, parsed.envFileBasename, getActor(req));
-            console.log(`[Secrets] Push ${sanitizeForLog(secret.name)} v${secret.current_version}: ${result.results.length} nodes`);
+            const failedCount = result.results.filter(r => r.status === 'failed').length;
+            console.log(`[Secrets] Push ${sanitizeForLog(secret.name)} v${secret.current_version}: ${result.results.length} node(s), ${failedCount} failed (by ${sanitizeForLog(getActor(req))})`);
+            if (failedCount > 0) console.warn(`[Secrets] Push ${sanitizeForLog(secret.name)} v${secret.current_version}: ${failedCount} node(s) failed`);
             res.json(result);
         } catch (err) {
             if (err instanceof PushBusyError) {

--- a/backend/src/services/SecretsService.ts
+++ b/backend/src/services/SecretsService.ts
@@ -8,6 +8,7 @@ import { NodeRegistry } from './NodeRegistry';
 import { resolveAllEnvFilePaths } from '../routes/stacks';
 import { getErrorMessage } from '../utils/errors';
 import { formatNoTargetError } from '../utils/remoteTarget';
+import { isDebugEnabled } from '../utils/debug';
 
 export type SecretKv = Record<string, string>;
 export type DiffStatus = 'added' | 'changed' | 'removed' | 'unchanged';
@@ -427,6 +428,7 @@ export class SecretsService {
         const db = DatabaseService.getInstance();
         const overlay = this.getDecryptedKv(id);
         const matched = NodeLabelService.getInstance().matchSelector(selector, db.getNodes());
+        if (isDebugEnabled()) console.log(`[Secrets:diag] preview id=${id} targets=${matched.length}`);
 
         // Preview is read-only and per-node; fan out in parallel for snappier wizard UX.
         return Promise.all(matched.map(async (node): Promise<SecretPushPlanEntry> => {
@@ -472,6 +474,7 @@ export class SecretsService {
         const overlay = decryptKv(versionRow.encrypted_payload);
         const matched = NodeLabelService.getInstance().matchSelector(selector, db.getNodes());
         const pushId = crypto.randomUUID();
+        if (isDebugEnabled()) console.log(`[Secrets:diag] push id=${id} v${versionRow.version} targets=${matched.length}`);
         const results: SecretPushResultEntry[] = [];
         const rows: Array<Parameters<typeof db.insertSecretPushes>[0][number]> = [];
         const pushedAt = Date.now();
@@ -525,6 +528,10 @@ export class SecretsService {
             db.insertSecretPushes(rows);
         } finally {
             activePushes.delete(id);
+        }
+        if (isDebugEnabled()) {
+            const okCount = results.filter(r => r.status === 'ok').length;
+            console.log(`[Secrets:diag] push id=${id} done in ${Date.now() - pushedAt}ms ok=${okCount} failed=${results.length - okCount}`);
         }
         return { pushId, results };
     }

--- a/frontend/src/components/FleetView.tsx
+++ b/frontend/src/components/FleetView.tsx
@@ -117,7 +117,7 @@ export function FleetView({ onNavigateToNode }: FleetViewProps) {
                                     <Wrench className="w-4 h-4 mr-1.5" />Fleet Actions
                                 </TabsTrigger>
                             </TabsHighlightItem>
-                            {isPaid && (
+                            {isPaid && isAdmin && (
                                 <TabsHighlightItem value="secrets">
                                     <TabsTrigger value="secrets">
                                         <KeyRound className="w-4 h-4 mr-1.5" />Secrets
@@ -224,7 +224,7 @@ export function FleetView({ onNavigateToNode }: FleetViewProps) {
                 <TabsContent value="actions">
                     <FleetActionsTab nodes={overview.allNodes} />
                 </TabsContent>
-                {isPaid && (
+                {isPaid && isAdmin && (
                     <TabsContent value="secrets">
                         <SecretsTab />
                     </TabsContent>


### PR DESCRIPTION
## Summary

Fleet Secrets bundles environment variables, reveals their decrypted values in the editor, and pushes credentials to every node a label selector matches. This change locks the feature down to the surface it is documented for: an admin operator signed into the controlling instance. Three gates move together so the UI never offers an action the API refuses:

- **Admin role.** Every secrets route requires an admin user, and the Secrets tab renders only for admins.
- **Hub-only.** `/api/secrets/` is no longer proxied to a remote node, so a request carrying a remote node id cannot read another node's decrypted bundle values. Same handling as registry credentials.
- **Sessions only.** Long-lived API tokens are rejected on every secrets route; bundle management is a browser admin-session action, again matching registry credentials.

It also adds standard lifecycle logging and developer-mode diagnostics for create / update / delete / push (counts and names only, never the secret values).

## Test plan

- Backend (Vitest): an admin-role matrix over all nine routes (a non-admin paid user is refused on each, an admin succeeds), API-token rejection on the list and decrypted-value routes, hub-only rejection for the secrets collection and its sub-paths, and a developer-mode on/off diagnostics test that asserts the secret value never reaches a log line. Full backend suite green aside from one pre-existing Windows-only teardown flake unrelated to this change.
- `tsc` and lint clean in both packages.

## Notes

No schema changes. The frontend gate mirrors the existing admin-only Snapshots tab in the same view. Bundle push behavior, encryption at rest, and the audit trail are unchanged.
