### PR TITLE
docs(mesh): note admin-only management, dev-mode diagnostics, and the subnet env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -127,6 +127,13 @@ SENCHO_EXPERIMENTAL=false
 # the next mesh dial re-opens it. Default 0 (persistent).
 SENCHO_MESH_PROXY_TUNNEL_IDLE_MS=0
 
+# Mesh network subnet for this node. Leave unset to let Sencho pick the first
+# free /24 from its candidate list (172.30.0.0/24, 172.31.0.0/24, 10.42.0.0/24,
+# 10.43.0.0/24), or adopt the existing sencho_mesh network's subnet when it is
+# already present. Set a specific CIDR only when you need to avoid an overlap
+# with another network on this host. Configured independently per node.
+# SENCHO_MESH_SUBNET=10.42.0.0/24
+
 # Maximum bytes a single Git Source clone may download from the Git host before
 # it is aborted. This bounds network transfer and abuse, not the decompressed
 # on-disk size. A shallow clone of a compose repo is tiny; raise this only if

--- a/docs/features/sencho-mesh.mdx
+++ b/docs/features/sencho-mesh.mdx
@@ -42,7 +42,7 @@ App-layer authentication is **not** in scope. Postgres still needs a password, R
 
 ## Enable the mesh
 
-Mesh lives under **Fleet → Routing**.
+Mesh lives under **Fleet → Routing**. Managing it (the per-node mesh toggle and stack opt-in or opt-out) requires an administrator; non-admin users see the Routing tab as read-only.
 
 <Frame caption="Fleet → Routing, Table view. Each node card shows mesh stack count, published aliases, per-alias Test probe, and an Add stack to mesh action.">
   <img src="/images/sencho-mesh/routing-tab-overview.png" alt="Sencho Mesh Routing tab Table view with node cards" />
@@ -88,6 +88,8 @@ The sheet shows:
 - **Resolver cache** showing the aliases currently registered on this node and the backend `host:port` they resolve to.
 
 Mesh runs in-process on each node; there is no separate mesh container to inspect with `docker ps`.
+
+Enable **Developer Mode** under **Settings → Developer** to surface `[Mesh:diag]` lines in the container logs covering the forwarder's routing decisions (same-node versus cross-node, and which node-identity resolution won) and the timing of opt-in, opt-out, and alias-refresh operations (`docker logs sencho 2>&1 | grep '\[Mesh:diag\]'`). They are off by default and meant for one-off debugging; turn developer mode back off when you are done to keep log volume manageable.
 
 ## Mesh activity log
 


### PR DESCRIPTION
## Summary

Three small mesh documentation fixes:

- The Sencho Mesh feature page now states that managing the mesh (the per-node toggle and stack opt-in or opt-out) requires an administrator, and that non-admin users see the Routing tab as read-only.
- The Diagnostics section documents the developer-mode `[Mesh:diag]` logs so an operator can trace routing decisions and operation timing from the container logs.
- `SENCHO_MESH_SUBNET` is added to `.env.example`; it was already documented on the feature page but missing from the env template.

## Test plan

- Prose reviewed against the documentation style guide; the developer-mode note follows the same pattern as the other diagnostic-log docs.
- No code changes.