### PR TITLE
fix(stacks): name the body field in the stack-create required error

### DIFF
--- a/backend/src/__tests__/stacks-create-validation.test.ts
+++ b/backend/src/__tests__/stacks-create-validation.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Validation tests for POST /api/stacks (create).
+ *
+ * The create endpoint reads the new stack name from the body field `stackName`.
+ * When that field is missing or not a string it must reject with a 400 whose
+ * message names the field, so an operator or a script automating against the
+ * stacks API can see they sent the wrong field rather than a badly typed value.
+ * These cases short-circuit before any FileSystemService call, but the route
+ * gates on the `stack:create` permission first, so the test logs in as the
+ * seeded admin to reach the validation branch.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import { setupTestDb, cleanupTestDb, loginAsTestAdmin } from './helpers/setupTestDb';
+
+let tmpDir: string;
+let app: import('express').Express;
+let authCookie: string;
+
+beforeAll(async () => {
+  tmpDir = await setupTestDb();
+  ({ app } = await import('../index'));
+  authCookie = await loginAsTestAdmin(app);
+});
+
+afterAll(() => {
+  cleanupTestDb(tmpDir);
+});
+
+describe('POST /api/stacks required-field validation', () => {
+  it('rejects a missing stackName with a 400 that names the field', async () => {
+    const res = await request(app).post('/api/stacks').set('Cookie', authCookie).send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Field 'stackName' is required/);
+  });
+
+  it('rejects a non-string stackName with the same field-named 400', async () => {
+    const res = await request(app)
+      .post('/api/stacks')
+      .set('Cookie', authCookie)
+      .send({ stackName: 123 });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Field 'stackName' is required/);
+  });
+});

--- a/backend/src/routes/stacks.ts
+++ b/backend/src/routes/stacks.ts
@@ -618,7 +618,7 @@ stacksRouter.post('/', async (req: Request, res: Response) => {
   try {
     const { stackName } = req.body;
     if (!stackName || typeof stackName !== 'string') {
-      return res.status(400).json({ error: 'Stack name is required and must be a string' });
+      return res.status(400).json({ error: "Field 'stackName' is required and must be a string" });
     }
     if (!isValidStackName(stackName)) {
       return res.status(400).json({ error: 'Stack name can only contain alphanumeric characters, hyphens, and underscores' });


### PR DESCRIPTION
## Summary

`POST /api/stacks` reads the new stack name from the body field `stackName`. When that field was missing or not a string, the endpoint returned `Stack name is required and must be a string`. That wording points at a value problem, so anyone scripting against the stacks API assumes they sent a badly typed value rather than the wrong field name, which costs real debugging time.

The error now names the field: `Field 'stackName' is required and must be a string`. The field name and request shape are unchanged, so existing callers keep working.

## Test plan

- Added `backend/src/__tests__/stacks-create-validation.test.ts` with two regression cases: a missing `stackName` and a non-string `stackName`, both asserting a 400 whose message names the field.
- Ran the new suite and the existing `cache-endpoints` suite (whose happy-path create still sends `stackName` and returns 200): all green.
- `tsc --noEmit` on the backend passes.

## Notes

Reword only, no API shape change. No frontend change: the create dialog already sends `stackName`, and its in-form "Stack name is required" toast is a separate client-side empty-input check, not the API error.