### PR TITLE
test(stacks): fix flaky download-metric test isolation

### DIFF
--- a/backend/src/__tests__/stack-files-routes.test.ts
+++ b/backend/src/__tests__/stack-files-routes.test.ts
@@ -15,7 +15,7 @@
  * Community-tier success, input validation, upload size limit, and happy-path
  * 204/200 responses.
  */
-import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
 import request from 'supertest';
 import bcrypt from 'bcrypt';
 import { promises as fs } from 'fs';
@@ -406,6 +406,26 @@ describe('GET /api/stacks/:stackName/files/content', () => {
 // ── GET /:stackName/files/download ────────────────────────────────────────────
 
 describe('GET /api/stacks/:stackName/files/download', () => {
+  // The download metric is recorded asynchronously, on the file stream's
+  // end/close and the response's close event, so it can land after a test's
+  // request has already resolved. Drain any such pending record before the next
+  // test runs: a prior download must not leak a count across the next test's
+  // resetFileExplorerMetrics() and inflate its "exactly once" assertion. Poll
+  // until the download count holds steady across several reads (bounded).
+  afterEach(async () => {
+    let prev = -1;
+    let stableReads = 0;
+    for (let i = 0; i < 50 && stableReads < 3; i++) {
+      const current = (await getDownloadMetric())?.count ?? 0;
+      stableReads = current === prev ? stableReads + 1 : 0;
+      prev = current;
+      await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    }
+    // If the count never settled, a record is firing repeatedly (a real bug);
+    // surface it here rather than letting the bound silently swallow it.
+    expect(stableReads).toBeGreaterThanOrEqual(3);
+  });
+
   class CloseBeforeEndStream extends Readable {
     public bytesRead: number;
 


### PR DESCRIPTION
## Summary

Fixes an intermittent failure in `stack-files-routes.test.ts`: the test "records the download metric exactly once per successful file read" occasionally failed with `expected 2 to be 1`.

**Root cause (test isolation, not a product bug):** the download route records its file-explorer metric asynchronously, on the file stream's `end`/`close` and the response's `close` event. So a download test's metric record can land *after* the test's request has already resolved. Two earlier tests in the download suite perform a real download without awaiting the metric; their pending record could fire after the next test called `resetFileExplorerMetrics()`, leaking a count across the reset and inflating the "exactly once" assertion to 2. The route's per-request recording is correct (a synchronous `downloadRecorded` guard prevents double-recording within one request); the leak was purely cross-test.

**Fix:** an `afterEach` in the download suite that waits for the download count to settle (bounded poll until it holds steady across consecutive reads) before the next test runs, so no pending record survives into the next test's reset. It also asserts the count actually settled, so a genuine runaway-record bug would surface here rather than being silently swallowed by the loop bound. Test-only change; no production code is touched.

## Test plan

- Ran `stack-files-routes.test.ts` repeatedly; passes consistently (87 passed, 4 Windows-skipped locally).
- Backend type-check and lint clean.

## Notes

- No production change. The async metric recorder and its per-request guard are correct; this only closes a cross-test timing gap in the suite.
