### PR TITLE
fix(ui): center create-stack label and drop duplicate plus on mesh CTA

### DIFF
--- a/frontend/src/components/EditorLayout.tsx
+++ b/frontend/src/components/EditorLayout.tsx
@@ -315,7 +315,7 @@ export default function EditorLayout() {
         className="rounded-lg w-full"
         onClick={() => openCreateDialog('empty')}
       >
-        <Plus className="w-4 h-4 mr-2" />
+        <Plus className="w-4 h-4" />
         Create Stack
       </Button>
       <CreateStackDialog

--- a/frontend/src/components/ui/routing-node-card.tsx
+++ b/frontend/src/components/ui/routing-node-card.tsx
@@ -544,7 +544,7 @@ function emptyStateCopy(state: RoutingNodeState, name: string, offlineReason?: s
             return {
                 headline: 'No services routed yet.',
                 sub: 'Mesh is on. Opt a stack in to start publishing aliases.',
-                cta: '+ Add stack to mesh',
+                cta: 'Add stack to mesh',
             };
         case 'degraded':
             return {


### PR DESCRIPTION
## Summary

Two small UI rendering fixes on button glyphs:

- **Create Stack button**: the `Plus` icon carried a redundant `mr-2` on top of the Button component's built-in `gap-2`, doubling the icon-to-label spacing. On the full-width button this shifted the centered icon-plus-label block right of center, so "Create Stack" looked indented to the right. Removed `mr-2`.
- **Routing "Add stack to mesh" CTA**: the meshed-state empty-state CTA showed two plus signs, one from the rendered `Plus` icon and one from a literal `"+ "` prefix in the text string. Removed the literal prefix so only the icon renders.

## Test plan

- `tsc -b --noEmit` passes clean.
- `routing-node-card.test.tsx` passes (8/8); its CTA assertion is unaffected by dropping the literal `+`.
- Verified the diff is limited to the two glyph fixes.

## Notes

Cosmetic only. No behavior, gating, or API changes.