### PR TITLE
chore: drop stale prototype path from mobile-ui comment

### DIFF
--- a/frontend/src/components/mobile/mobile-ui.tsx
+++ b/frontend/src/components/mobile/mobile-ui.tsx
@@ -1,7 +1,6 @@
 // Shared building blocks for the bespoke mobile (<md) screens. These translate
-// the approved prototype's inline-styled primitives (docs/design/mobile-reference)
-// onto our design tokens. No new colors or fonts. Rendered only on the mobile
-// shell surfaces.
+// the approved prototype's inline-styled primitives onto our design tokens.
+// No new colors or fonts. Rendered only on the mobile shell surfaces.
 import type { ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 import { Sparkline } from '@/components/ui/sparkline';


### PR DESCRIPTION
## Summary

The header comment in `frontend/src/components/mobile/mobile-ui.tsx` pointed at a design-prototype folder that no longer exists. This removes the dead path reference and reflows the comment. The comment still records that the primitives originated from the approved prototype.

No behavior change: comment-only edit.

## Test plan

- Comment-only change; no logic, types, or runtime behavior affected.
- `tsc` and the build are unaffected by a comment edit.