### PR TITLE
chore: raise dev auth rate limit so the full E2E suite is not blocked

### DIFF
--- a/backend/src/middleware/rateLimiters.ts
+++ b/backend/src/middleware/rateLimiters.ts
@@ -162,10 +162,11 @@ export const webhookTriggerLimiter = rateLimit({
 });
 
 // Tier 3: Auth endpoint limiter. 15-minute window to blunt brute-force attacks.
-// Prod: 5 attempts/15min/IP. Dev: 100 attempts so E2E tests and local tooling are not blocked.
+// Prod: 5 attempts/15min/IP. Dev: 1000 attempts so the full E2E suite, which logs
+// in per test and has outgrown a 100-attempt window, plus local tooling, are not blocked.
 export const authRateLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
-  max: process.env.NODE_ENV === 'production' ? 5 : 100,
+  max: process.env.NODE_ENV === 'production' ? 5 : 1000,
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: 'Too many attempts. Please try again in 15 minutes.' },


### PR DESCRIPTION
## Summary

The Playwright E2E suite logs in once per test (a fresh browser context each time) and has grown past the **100-attempt / 15-minute** dev cap on the auth rate limiter. The cumulative login count now reaches the cap before the suite finishes, so the last test in a run is blocked with *"Too many attempts. Please try again in 15 minutes."* and fails at `loginAs`.

This raises the **non-production** cap from 100 to 1000, restoring headroom for the full suite and local tooling. **Production is unchanged at 5 attempts / 15 min**, so brute-force protection is identical.

## Change
- `backend/src/middleware/rateLimiters.ts`: `authRateLimiter.max` non-production branch `100 -> 1000` (production stays `5`), comment updated.

## Test plan
- `backend`: `tsc --noEmit` and `eslint` clean. No test pins the dev cap value.
- Unblocks the E2E suite, which was failing its final test on the login limiter once the per-test login count crossed 100.