### PR TITLE
feat(fleet): tidy the Overview toolbar and shorten tab labels

### DIFF
--- a/docs/features/fleet-actions.mdx
+++ b/docs/features/fleet-actions.mdx
@@ -3,7 +3,7 @@ title: "Fleet Actions"
 description: "Bulk operations across the fleet from one tab: stop stacks by label, replace labels on a batch of stacks, and reclaim Docker disk space on every node."
 ---
 
-The **Fleet Actions** tab on the Fleet view groups bulk operations that touch more than a single stack on a single node. Each action lives in its own card, runs from the control instance, and reports per-node and per-stack results inline so you never have to click through a modal to learn what happened.
+The **Actions** tab on the Fleet view groups bulk operations that touch more than a single stack on a single node. Each action lives in its own card, runs from the control instance, and reports per-node and per-stack results inline so you never have to click through a modal to learn what happened.
 
 Three cards ship today: **Stop fleet by label**, **Bulk label assign**, and **Prune Docker resources fleet-wide**.
 
@@ -45,7 +45,7 @@ Stop every stack that carries a given label name on every node where that label 
 
 ### Step by step
 
-1. Open **Fleet → Fleet Actions**.
+1. Open **Fleet → Actions**.
 2. Type a label name in the **Label name** field. The input autocompletes against label names that already exist on any **online** node; an offline node with an unseen label still receives the request, it just won't show up in the suggestions.
 3. Click **Stop matching stacks**.
 4. A confirmation appears with the kicker **Fleet stop** and the title `Stop all stacks labeled "<name>"?`. Click **Stop fleet** to commit.
@@ -207,5 +207,5 @@ Fleet Actions is one slice of the Fleet view. Each adjacent surface answers a di
 | [Fleet Federation](/features/fleet-federation) | Operator-driven placement controls (cordon, pin) for [Blueprints](/features/blueprint-model). | Federation steers declarative placement; Fleet Actions runs imperative operations on what already exists. |
 | [Fleet Sync](/features/fleet-sync) | Push-only replication of security rules from a control instance to its replicas. | Fleet Sync replicates state; Fleet Actions runs operations. |
 | [Multi-Node Management](/features/multi-node) | How nodes get added to the fleet (proxy or pilot mode) and how the license tier propagates. | Multi-Node Management is the prerequisite; Fleet Actions runs against whatever Multi-Node Management already configured. |
-| [Fleet View](/features/fleet-view) | The masthead, tab strip, and node grid that host the Fleet Actions tab. | Fleet Actions is one tab inside Fleet View. |
+| [Fleet View](/features/fleet-view) | The masthead, tab strip, and node grid that host the Actions tab. | Fleet Actions is one tab inside Fleet View. |
 | [Licensing](/features/licensing) | The full tier matrix and what each tier unlocks. | Licensing covers tier coverage across the product; Fleet Actions only cites the admin role check above. |

--- a/docs/features/fleet-view.mdx
+++ b/docs/features/fleet-view.mdx
@@ -3,7 +3,7 @@ title: Fleet View
 description: Monitor every node in your Sencho deployment from one screen, drill into stacks and containers, and orchestrate Sencho version updates across the fleet.
 ---
 
-The **Fleet** tab is the single page you open when you want to see the whole estate at once: every node's health, every stack, every container, and which boxes need a Sencho update. It is the home for fleet-wide tabs that go beyond monitoring (Snapshots, Status, Deployments, Routing, Federation, Fleet Actions, Secrets), each linking out to its own dedicated page.
+The **Fleet** tab is the single page you open when you want to see the whole estate at once: every node's health, every stack, every container, and which boxes need a Sencho update. It is the home for fleet-wide tabs that go beyond monitoring (Snapshots, Status, Deployments, Routing, Federation, Actions, Secrets), each linking out to its own dedicated page.
 
 <Note>
   Fleet is hub-only and is hidden from the nav strip when a remote node is the active selection. See [Multi-Node Management](/features/multi-node#what-top-level-views-show-when-a-remote-node-is-active).
@@ -45,11 +45,11 @@ The Fleet view is a tab strip. Five tab triggers are visible to every tier; the 
 | **Overview** | Community | The grid or topology view of every node and its health. Covered in the next section. |
 | **Snapshots** | Community | Snapshot every compose file across the fleet. See [Fleet-Wide Backups](/features/fleet-backups). |
 | **Status** | Community | One card per node summarising which automations and security features are configured. Covered below. |
-| **Dependencies** | Community | A read-only map of how stacks, services, networks, volumes, and ports relate across the fleet, with anomaly flags. Covered below. |
+| **Map** | Community | A read-only map of how stacks, services, networks, volumes, and ports relate across the fleet, with anomaly flags. Covered below. |
 | **Deployments** | Admiral | Blueprint deployments and reconciler state. See [Blueprints](/features/blueprint-model). |
 | **Routing** | Admiral | Cross-node service routing via Sencho Mesh. See [Sencho Mesh](/features/sencho-mesh). |
 | **Federation** | Admiral | Cordon nodes and pin blueprints to specific hosts. See [Fleet Federation](/features/fleet-federation). |
-| **Fleet Actions** | Community (admin role) | Fleet-wide bulk operations: stop stacks by label, bulk-assign labels, prune Docker resources. See [Fleet Actions](/features/fleet-actions). |
+| **Actions** | Community (admin role) | Fleet-wide bulk operations: stop stacks by label, bulk-assign labels, prune Docker resources. See [Fleet Actions](/features/fleet-actions). |
 | **Secrets** | Admiral | Encrypted env-var bundles you push to labeled nodes. See [Fleet Secrets](/features/fleet-secrets). |
 
 ### Action buttons
@@ -203,9 +203,9 @@ Offline nodes show a muted card with the heading and the message `Node is unreac
 
 The tab fetches each node's configuration in parallel; a single dead node does not block the rest from rendering.
 
-## The Dependency Map tab
+## The Map tab
 
-The **Dependencies** tab draws a read-only map of how everything on the fleet fits together: each node, the stacks on it, and how those stacks' services connect to networks, volumes, and published ports. It is built for troubleshooting ("which stacks share this network?", "what is still claiming port 8080?", "why is this volume sitting unused?") rather than for editing anything. Nothing on this tab changes your stacks.
+The **Map** tab draws a read-only diagram of how everything on the fleet fits together: each node, the stacks on it, and how those stacks' services connect to networks, volumes, and published ports. It is built for troubleshooting ("which stacks share this network?", "what is still claiming port 8080?", "why is this volume sitting unused?") rather than for editing anything. Nothing on this tab changes your stacks.
 
 The map is assembled from what Docker and your compose files already describe, so it reflects the live state every time you open the tab or press **Refresh**.
 

--- a/docs/features/licensing.mdx
+++ b/docs/features/licensing.mdx
@@ -28,7 +28,7 @@ See [the pricing page](https://sencho.io/pricing) for current pricing.
 - Multi-node management in both Proxy and Pilot Agent modes
 - Fleet View with search, sort, filter, and node-card drill-down
 - Manual and scheduled fleet snapshots (create, browse, restore, delete) and Remote OTA node updates (per-node and **Update all**)
-- Fleet Actions tab (stop stacks fleet-wide by label, bulk-assign labels to many stacks on a node, prune Docker resources fleet-wide; admin role required), plus fleet-wide bulk Sencho restart
+- Actions tab (stop stacks fleet-wide by label, bulk-assign labels to many stacks on a node, prune Docker resources fleet-wide; admin role required), plus fleet-wide bulk Sencho restart
 - Bulk actions on a label (deploy, stop, or restart every stack tagged with it)
 - Atomic deployments with automatic rollback, and one-click rollback to the previous deployment
 - Auto-update policies for stack images and auto-heal policies for failed containers

--- a/docs/features/stack-labels.mdx
+++ b/docs/features/stack-labels.mdx
@@ -85,7 +85,7 @@ A stack can carry multiple labels and will then appear under each label's group 
   The Fleet Actions cards run admin-only on every tier. Operator and viewer roles see the cards but cannot apply them.
 </Note>
 
-Two cards in the **Fleet · Fleet Actions** tab use labels to drive cross-node operations. See [Fleet Actions](/features/fleet-actions) for the full reference.
+Two cards in the **Fleet · Actions** tab use labels to drive cross-node operations. See [Fleet Actions](/features/fleet-actions) for the full reference.
 
 <Frame>
   <img src="/images/stack-labels/fleet-actions.png" alt="Fleet Actions tab with two cards side by side. Left card 'Stop fleet by label' (rose accent rail) has a Label name combobox containing 'Media' and a Stop matching stacks button beneath. Right card 'Bulk label assign' (purple accent rail) has a node selector reading Local (local), a stacks checklist showing plex and radarr ticked, a Labels row with a highlighted Media pill plus inactive Network and Utilities, and an Apply to 3 stacks button." />

--- a/frontend/src/components/FleetView.tsx
+++ b/frontend/src/components/FleetView.tsx
@@ -1,5 +1,5 @@
 import {
-    RefreshCw, Search, Camera, Plus, FileDown,
+    RefreshCw, RefreshCcwDot, Camera, FileDown,
     Network, SlidersHorizontal,
     Send, KeyRound, ArrowLeftRight, Wrench, Workflow,
 } from 'lucide-react';
@@ -29,7 +29,6 @@ import { FleetActionsTab } from './fleet/FleetActions/FleetActionsTab';
 import { SecretsTab } from './fleet/secrets/SecretsTab';
 import { DependencyMapTab } from './fleet/DependencyMapTab';
 import { useNodeActions } from './nodes/useNodeActions';
-import { SettingsPrimaryButton } from './settings/SettingsActions';
 
 interface FleetViewProps {
     onNavigateToNode: (nodeId: number, stackName: string) => void;
@@ -94,7 +93,7 @@ export function FleetView({ onNavigateToNode }: FleetViewProps) {
                             </TabsHighlightItem>
                             <TabsHighlightItem value="dependencies">
                                 <TabsTrigger value="dependencies">
-                                    <Workflow className="w-4 h-4 mr-1.5" />Dependencies
+                                    <Workflow className="w-4 h-4 mr-1.5" />Map
                                 </TabsTrigger>
                             </TabsHighlightItem>
                             <span aria-hidden className="self-center mx-1 h-4 w-px bg-border" />
@@ -121,7 +120,7 @@ export function FleetView({ onNavigateToNode }: FleetViewProps) {
                             )}
                             <TabsHighlightItem value="actions">
                                 <TabsTrigger value="actions">
-                                    <Wrench className="w-4 h-4 mr-1.5" />Fleet Actions
+                                    <Wrench className="w-4 h-4 mr-1.5" />Actions
                                 </TabsTrigger>
                             </TabsHighlightItem>
                             {isPaid && isAdmin && (
@@ -140,7 +139,7 @@ export function FleetView({ onNavigateToNode }: FleetViewProps) {
                             onClick={updateStatus.checkUpdates}
                             className="gap-2"
                         >
-                            <Search className="w-4 h-4" />
+                            <RefreshCcwDot className="w-4 h-4" />
                             Check Updates
                         </Button>
                         <Button
@@ -164,16 +163,6 @@ export function FleetView({ onNavigateToNode }: FleetViewProps) {
                                 <FileDown className={`w-4 h-4 ${exporting ? 'animate-pulse' : ''}`} />
                                 {exporting ? 'Exporting…' : 'Export Dossier'}
                             </Button>
-                        )}
-                        {isAdmin && (
-                            <SettingsPrimaryButton
-                                size="sm"
-                                onClick={openCreate}
-                                className="gap-1"
-                            >
-                                <Plus className="w-4 h-4" />
-                                Add node
-                            </SettingsPrimaryButton>
                         )}
                     </div>
                 </div>
@@ -205,6 +194,7 @@ export function FleetView({ onNavigateToNode }: FleetViewProps) {
                         onCordonChange={() => { void overview.fetchOverview(true); }}
                         onEditNode={isAdmin ? openEdit : undefined}
                         onDeleteNode={isAdmin ? openDelete : undefined}
+                        onAddNode={isAdmin ? openCreate : undefined}
                         topologyMode={topology.prefs.mode}
                         onTopologyModeChange={topology.setMode}
                         topologyPositions={topology.prefs.positions}

--- a/frontend/src/components/FleetView/OverviewTab.tsx
+++ b/frontend/src/components/FleetView/OverviewTab.tsx
@@ -39,6 +39,7 @@ interface OverviewTabProps {
     onTopologyModeChange: (mode: LayoutMode) => void;
     topologyPositions: SavedPositions;
     onTopologyPositionsChange: (positions: SavedPositions) => void;
+    onAddNode?: () => void;
 }
 
 export function OverviewTab({
@@ -71,6 +72,7 @@ export function OverviewTab({
     onTopologyModeChange,
     topologyPositions,
     onTopologyPositionsChange,
+    onAddNode,
 }: OverviewTabProps) {
     return (
         <>
@@ -113,6 +115,7 @@ export function OverviewTab({
                         labelFilters={labelFilters}
                         onLabelFiltersChange={onLabelFiltersChange}
                         onClearFilters={onClearFilters}
+                        onAddNode={onAddNode}
                     />
 
                     {viewMode === 'topology' && processedNodes.length > 0 ? (

--- a/frontend/src/components/FleetView/OverviewToolbar.tsx
+++ b/frontend/src/components/FleetView/OverviewToolbar.tsx
@@ -1,7 +1,7 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
     Search, ArrowUpDown, AlertTriangle, Play, Square,
-    LayoutGrid, Network, SlidersHorizontal,
+    LayoutGrid, Network, SlidersHorizontal, Plus,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -49,6 +49,7 @@ interface OverviewToolbarProps {
     labelFilters: Set<string>;
     onLabelFiltersChange: (filters: Set<string>) => void;
     onClearFilters: () => void;
+    onAddNode?: () => void;
 }
 
 export function OverviewToolbar({
@@ -62,6 +63,7 @@ export function OverviewToolbar({
     labelFilters,
     onLabelFiltersChange,
     onClearFilters,
+    onAddNode,
 }: OverviewToolbarProps) {
     const showGridControls = viewMode === 'grid';
     const activeFilterCount =
@@ -75,29 +77,56 @@ export function OverviewToolbar({
         [fleetPalette],
     );
 
+    // Collapsed by default to a single icon button; expands to the full input on
+    // click and collapses again on blur once the query is cleared. An active
+    // query keeps it open so the filter stays visible and editable.
+    const [searchExpanded, setSearchExpanded] = useState(false);
+    const searchInputRef = useRef<HTMLInputElement>(null);
+    const searchOpen = searchExpanded || searchQuery !== '';
+
+    useEffect(() => {
+        if (searchExpanded) searchInputRef.current?.focus();
+    }, [searchExpanded]);
+
     return (
         <div className="flex flex-wrap items-center gap-2 mb-4">
             {showGridControls && (
                 <>
-                    <div className="relative flex-1 min-w-[200px] max-w-sm">
-                        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
-                        <Input
-                            placeholder="Search nodes or stacks..."
-                            value={searchQuery}
-                            onChange={(e) => onSearchQueryChange(e.target.value)}
-                            className="pl-9 h-9"
-                        />
-                    </div>
+                    {searchOpen ? (
+                        <div className="relative flex-1 min-w-[200px] max-w-sm">
+                            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
+                            <Input
+                                ref={searchInputRef}
+                                placeholder="Search nodes or stacks..."
+                                value={searchQuery}
+                                onChange={(e) => onSearchQueryChange(e.target.value)}
+                                onBlur={() => { if (searchQuery === '') setSearchExpanded(false); }}
+                                className="pl-9 h-9"
+                            />
+                        </div>
+                    ) : (
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            className="h-9 w-9 p-0 shrink-0"
+                            onClick={() => setSearchExpanded(true)}
+                            title="Search nodes or stacks"
+                            aria-label="Search nodes or stacks"
+                        >
+                            <Search className="w-4 h-4" />
+                        </Button>
+                    )}
                     <div className="w-40">
                         <Combobox
                             options={SORT_OPTIONS}
                             value={prefs.sortBy}
                             onValueChange={(v) => onPrefsChange({ sortBy: v as SortField })}
                             placeholder="Sort by..."
+                            className="[&>button]:!bg-background"
                         />
                     </div>
                     <Button
-                        variant="ghost"
+                        variant="outline"
                         size="sm"
                         className="h-9 w-9 p-0 shrink-0"
                         onClick={() => onPrefsChange({ sortDir: prefs.sortDir === 'asc' ? 'desc' : 'asc' })}
@@ -204,6 +233,13 @@ export function OverviewToolbar({
                 options={VIEW_MODE_OPTIONS}
                 className="ml-auto shrink-0 shadow-card-bevel"
             />
+
+            {onAddNode && (
+                <Button size="sm" className="gap-1.5 shrink-0 h-9" onClick={onAddNode}>
+                    <Plus className="w-4 h-4" strokeWidth={1.5} />
+                    Add node
+                </Button>
+            )}
         </div>
     );
 }

--- a/frontend/src/components/FleetView/__tests__/OverviewToolbar.test.tsx
+++ b/frontend/src/components/FleetView/__tests__/OverviewToolbar.test.tsx
@@ -23,9 +23,36 @@ function props(overrides: Partial<React.ComponentProps<typeof OverviewToolbar>> 
 }
 
 describe('OverviewToolbar', () => {
-  it('shows search and sort controls in grid mode', () => {
+  it('collapses the search to an icon button by default and expands it on click', () => {
     render(<OverviewToolbar {...props()} />);
+    expect(screen.queryByPlaceholderText('Search nodes or stacks...')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Search nodes or stacks' }));
     expect(screen.getByPlaceholderText('Search nodes or stacks...')).toBeInTheDocument();
+  });
+
+  it('renders the search expanded when a query is already active', () => {
+    render(<OverviewToolbar {...props({ searchQuery: 'plex' })} />);
+    expect(screen.getByDisplayValue('plex')).toBeInTheDocument();
+  });
+
+  it('focuses the input when the search expands', () => {
+    render(<OverviewToolbar {...props()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Search nodes or stacks' }));
+    expect(screen.getByPlaceholderText('Search nodes or stacks...')).toHaveFocus();
+  });
+
+  it('collapses back to the icon button on blur when the query is empty', () => {
+    render(<OverviewToolbar {...props()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Search nodes or stacks' }));
+    fireEvent.blur(screen.getByPlaceholderText('Search nodes or stacks...'));
+    expect(screen.queryByPlaceholderText('Search nodes or stacks...')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Search nodes or stacks' })).toBeInTheDocument();
+  });
+
+  it('stays expanded on blur while a query is active', () => {
+    render(<OverviewToolbar {...props({ searchQuery: 'plex' })} />);
+    fireEvent.blur(screen.getByPlaceholderText('Search nodes or stacks...'));
+    expect(screen.getByDisplayValue('plex')).toBeInTheDocument();
   });
 
   it('hides grid controls in topology mode', () => {
@@ -33,9 +60,10 @@ describe('OverviewToolbar', () => {
     expect(screen.queryByPlaceholderText('Search nodes or stacks...')).not.toBeInTheDocument();
   });
 
-  it('forwards search input changes', () => {
+  it('forwards search input changes once expanded', () => {
     const onSearchQueryChange = vi.fn();
     render(<OverviewToolbar {...props({ onSearchQueryChange })} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Search nodes or stacks' }));
     fireEvent.change(screen.getByPlaceholderText('Search nodes or stacks...'), { target: { value: 'web' } });
     expect(onSearchQueryChange).toHaveBeenCalledWith('web');
   });
@@ -52,5 +80,17 @@ describe('OverviewToolbar', () => {
     render(<OverviewToolbar {...props()} />);
     fireEvent.click(screen.getByRole('button', { name: /Filters/ }));
     expect(screen.queryByText('Tags')).not.toBeInTheDocument();
+  });
+
+  it('renders the Add node button and fires onAddNode when provided', () => {
+    const onAddNode = vi.fn();
+    render(<OverviewToolbar {...props({ onAddNode })} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Add node' }));
+    expect(onAddNode).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits the Add node button when onAddNode is not provided', () => {
+    render(<OverviewToolbar {...props()} />);
+    expect(screen.queryByRole('button', { name: 'Add node' })).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Refines the Fleet Overview toolbar and shortens two tab labels.

- **Add node** moves out of the always-visible top toolbar into the Overview toolbar, next to the Grid/Topology toggle, so it sits with the view it acts on instead of appearing on every Fleet tab. It stays admin-only.
- The node **search** collapses to an icon button by default and expands to the full input on click, collapsing again on blur once the query is empty (an active query keeps it open). This reclaims toolbar width.
- The **sort-direction toggle** and the **sort dropdown** now share the outlined dark fill of the Filters button for a consistent toolbar row.
- The **Check Updates** icon changes to the refresh-with-dot glyph.
- Two tabs are renamed: **Fleet Actions** to **Actions** and **Dependencies** to **Map**. Display labels only; the internal tab keys are unchanged, so saved tab state and deep links are unaffected.
- The feature docs are updated to the new tab labels.

## Test plan

- `tsc -b` and ESLint pass on the changed files.
- Unit tests pass for the `OverviewToolbar` and `OverviewTab` suites, including new coverage for the collapsible search (collapse on empty blur, stays open with an active query, focuses on expand) and the Add node affordance (renders and fires when provided, omitted otherwise).
- Verified in the running app: the collapsed and expanded search, the dark sort dropdown, the relocated white Add node button, and the renamed Map and Actions tabs.

## Notes

- Doc screenshots under `/images/fleet-view/` and `/images/fleet-actions/` still show the previous tab labels and should be regenerated; the prose and alt text already reflect the new labels.
