### PR TITLE
feat(settings): add Stacks section for stack workflow preferences

### DIFF
--- a/docs/features/app-store.mdx
+++ b/docs/features/app-store.mdx
@@ -117,7 +117,7 @@ Clicking **Deploy** runs the following sequence:
 
 ## Watching the deploy
 
-Sencho can stream the live `docker compose` output for every template install. Open **Settings › Appearance › Display** and enable **Deploy progress**; from then on, every App Store deploy streams its output. In Modal style it opens a structured log modal you can minimise to a pill that follows you across navigation; in Inline style it shows as that pill, which opens the same log on click. See [Deploy Progress](/features/deploy-progress) for the full reference.
+Sencho can stream the live `docker compose` output for every template install. Open **Settings › Infrastructure › Stacks** and enable **Deploy progress**; from then on, every App Store deploy streams its output. In Modal style it opens a structured log modal you can minimise to a pill that follows you across navigation; in Inline style it shows as that pill, which opens the same log on click. See [Deploy Progress](/features/deploy-progress) for the full reference.
 
 <Note>
   Deploying a template requires the `stack:create` permission on the target node, which **admin** and **node-admin** roles hold by default. The Deploy button stays disabled when your account does not have it.

--- a/docs/features/appearance.mdx
+++ b/docs/features/appearance.mdx
@@ -50,5 +50,5 @@ The **Display** group holds the remaining per-browser preferences:
 
 - **Density** switches between **Comfortable** (roomy rows, the default) and **Compact** (tighter rows and tiles that fit more on screen for dense dashboards).
 - **Top navigation labels** shows text labels beside the top navigation icons. Turn it off for an icon-only bar; the destinations stay reachable by hover tooltip, accessible name, and the command palette. On the phone layout the navigation always keeps its labels. With labels off, **Top navigation alignment** chooses whether the icon-only bar sits to the left or centered.
-- **Deploy progress** toggles live output streaming for deploy, restart, update, install, and Git operations, and **Progress style** chooses Modal or Inline presentation.
-- **Diff preview before save** toggles a side-by-side diff of compose and env edits before they are written to disk.
+
+Deploy-progress behavior and the diff-preview-before-save step are stack workflow preferences, so they live in **Settings → Infrastructure → Stacks**, not here.

--- a/docs/features/deploy-progress.mdx
+++ b/docs/features/deploy-progress.mdx
@@ -7,7 +7,7 @@ When you trigger a stack action that runs through `docker compose` (Deploy, Upda
 
 ## Showing, hiding, and styling deploy progress
 
-Deploy progress is **on by default**. To run operations without it, open **Settings > Appearance > Display** and turn off **Deploy progress**. While it is on, **Progress style** chooses how it appears:
+Deploy progress is **on by default**. To run operations without it, open **Settings > Infrastructure > Stacks** and turn off **Deploy progress**. While it is on, **Progress style** chooses how it appears:
 
 - **Modal** (the default): a centered overlay that opens automatically and streams the full structured log.
 - **Inline**: a quiet status band on the stack detail itself, with the full log a click away under **View output**.
@@ -15,7 +15,7 @@ Deploy progress is **on by default**. To run operations without it, open **Setti
 The choices are saved to the current browser only and synced across tabs in the same browser without a reload.
 
 <Frame>
-  <img src="/images/deploy-progress/setting-toggle.png" alt="Settings Appearance Display panel with the deploy progress toggle." />
+  <img src="/images/deploy-progress/setting-toggle.png" alt="Settings Stacks panel with the deploy progress toggle." />
 </Frame>
 
 ## Using the modal

--- a/docs/features/editor.mdx
+++ b/docs/features/editor.mdx
@@ -127,7 +127,7 @@ The same controls apply to the `compose.yaml` and `.env` editors.
 
 ## Diff preview before save
 
-When **Diff preview before save** is enabled in **Settings → Appearance**, clicking **Save & Deploy** or **Save Only** opens a side-by-side diff modal before anything is written to disk. The left pane is the on-disk content; the right pane is your unsaved edits with additions highlighted in green. The footer reads `ON DISK → UNSAVED` so the panes are unambiguous.
+When **Diff preview before save** is enabled in **Settings → Infrastructure → Stacks**, clicking **Save & Deploy** or **Save Only** opens a side-by-side diff modal before anything is written to disk. The left pane is the on-disk content; the right pane is your unsaved edits with additions highlighted in green. The footer reads `ON DISK → UNSAVED` so the panes are unambiguous.
 
 <Frame>
   <img src="/images/compose-diff-preview/diff-modal.png" alt="Diff preview modal showing side-by-side YAML diff with the unsaved version on the right and an ON DISK to UNSAVED legend in the footer" />

--- a/docs/reference/settings.mdx
+++ b/docs/reference/settings.mdx
@@ -15,7 +15,7 @@ Open the Settings Hub by clicking the **Profile** icon in the top bar and select
 |-------|----------------|
 | **Personal** | Account, Appearance |
 | **Access** | License, Users, SSO, API Tokens |
-| **Infrastructure** | Nodes, Fleet Mesh, Registries, Cloud Backup, App Store |
+| **Infrastructure** | Nodes, Fleet Mesh, Registries, Cloud Backup, App Store, Stacks |
 | **Monitoring** | Host Alerts, Docker & Storage |
 | **Notifications** | Channels, Notification Routing |
 | **Automation** | Webhooks |
@@ -33,7 +33,7 @@ Every section renders inside the same masthead-and-sidebar layout. The masthead 
 
 | Pill | Meaning |
 |------|---------|
-| **SCOPE** `operator` / `global` | Setting applies to your account or this browser (Personal sections) or to the whole instance (every other non-node group) |
+| **SCOPE** `operator` / `browser` / `global` | Setting applies to your account (`operator`), to this browser only (`browser`, for browser-local sections such as Appearance and Stacks), or to the whole instance (`global`, every other non-node group) |
 | **NODE** `<node name>` | Setting is per-node and is currently being edited against this node |
 | **EDITED** `<count>` pending / `saved` | The current section has unsaved changes |
 | Section-specific stats | Each section can publish its own pills: `2FA on`/`off` and `BACKUP <n> left` (Account); `PLAN`, `TRIAL <n>d left`, `RENEWS`, `STATUS` (License); `OPERATORS` (Users); `CHANNELS` (Channels); `ROUTES` (Notification Routing); `WEBHOOKS` and `ENABLED` (Webhooks); `LABELS` (Labels); `PROVIDER`, `USED`, `SNAPSHOTS` (Cloud Backup); `DEV MODE` (Developer Diagnostics) |
@@ -100,7 +100,7 @@ See [Two-Factor Authentication](/features/two-factor-authentication) for the enr
 Control how dense and how interactive the workspace feels. Each browser remembers its own choices so a compact laptop setup does not force the same rhythm on a larger desktop.
 
 <Frame>
-  <img src="/images/settings/appearance-density.png" alt="Appearance settings showing the Density selector, the Deploy progress toggle, and the Diff preview toggle" />
+  <img src="/images/settings/appearance-density.png" alt="Appearance settings showing the Density selector" />
 </Frame>
 
 ### Density
@@ -112,25 +112,7 @@ Control how dense and how interactive the workspace feels. Each browser remember
 
 Density affects the dashboard stack table, the resource gauge strip, the Settings Hub sidebar, the Schedules and Audit Log tables, and every other data table in Sencho. Typography, color, and layout structure stay the same; only vertical padding compresses.
 
-### Deploy progress
-
-Sencho streams live output whenever you deploy, restart, update, install, or run a Git operation. It is on by default; turn it off to run operations without it. When it is on, **Progress style** chooses how it appears: **Modal** (a centered overlay that closes automatically on success or stays open on failure) or **Inline** (a quiet status band on the stack detail). See [Deploy Progress](/features/deploy-progress) for the full reference.
-
-| Value | Behavior |
-|-------|----------|
-| **Enabled** (default) | A progress surface (the Modal overlay or the Inline band, per Progress style) shows for every long-running operation |
-| **Disabled** | Operations run without it; results surface via toast notifications, and a failed operation still shows recovery actions on the stack page |
-
-### Diff preview before save
-
-When enabled, clicking **Save & Deploy** or **Save Only** in the compose or env editor opens a side-by-side diff modal before writing anything to disk. The left pane shows the current on-disk content; the right pane shows your unsaved edits, with additions highlighted green and removals highlighted red.
-
-| Value | Behavior |
-|-------|----------|
-| **Enabled** | Diff modal opens on every save that has unsaved changes |
-| **Disabled** (default) | File is saved directly without a review step |
-
-If there are no unsaved changes the modal is skipped and the save proceeds immediately. See [Diff preview before save](/features/editor#diff-preview-before-save) in the Editor guide for the full workflow.
+Deploy-progress behavior and the diff-preview-before-save step are stack workflow preferences and live in their own [Stacks](#stacks) section under Infrastructure.
 
 ---
 
@@ -478,6 +460,34 @@ Configure the template source used by the App Store.
 | **Save & refresh** | Saves the URL and immediately refreshes the cached template list. |
 
 See [App Store](/features/app-store#custom-template-registry) for more on custom registries.
+
+---
+
+## Stacks
+
+**Scope:** This browser (preferences are saved to local storage)
+
+Stack editor and lifecycle workflow preferences. Each browser remembers its own choices, so they follow you across tabs but never change what other operators see. The masthead reads `SCOPE browser`.
+
+### Deploy progress
+
+Sencho streams live output whenever you deploy, restart, update, install, or run a Git operation. It is on by default; turn it off to run operations without it. When it is on, **Progress style** chooses how it appears: **Modal** (a centered overlay that closes automatically on success or stays open on failure) or **Inline** (a quiet status band on the stack detail). See [Deploy Progress](/features/deploy-progress) for the full reference.
+
+| Value | Behavior |
+|-------|----------|
+| **Enabled** (default) | A progress surface (the Modal overlay or the Inline band, per Progress style) shows for every long-running operation |
+| **Disabled** | Operations run without it; results surface via toast notifications, and a failed operation still shows recovery actions on the stack page |
+
+### Diff preview before save
+
+When enabled, clicking **Save & Deploy** or **Save Only** in the compose or env editor opens a side-by-side diff modal before writing anything to disk. The left pane shows the current on-disk content; the right pane shows your unsaved edits, with additions highlighted green and removals highlighted red.
+
+| Value | Behavior |
+|-------|----------|
+| **Enabled** | Diff modal opens on every save that has unsaved changes |
+| **Disabled** (default) | File is saved directly without a review step |
+
+If there are no unsaved changes the modal is skipped and the save proceeds immediately. See [Diff preview before save](/features/editor#diff-preview-before-save) in the Editor guide for the full workflow.
 
 ---
 

--- a/frontend/src/components/settings/AppearanceSection.tsx
+++ b/frontend/src/components/settings/AppearanceSection.tsx
@@ -1,13 +1,9 @@
 import { Combobox } from '@/components/ui/combobox';
-import { Checkbox } from '@/components/ui/checkbox';
 import { Slider } from '@/components/ui/slider';
 import { SegmentedControl } from '@/components/ui/segmented-control';
 import { TogglePill } from '@/components/ui/toggle-pill';
 import { useDensity } from '@/hooks/use-density';
 import type { Density } from '@/hooks/use-density';
-import { useDeployFeedbackEnabled } from '@/hooks/use-deploy-feedback-enabled';
-import { useDeployFeedbackStyle, type DeployFeedbackStyle } from '@/hooks/use-deploy-feedback-style';
-import { useComposeDiffPreviewEnabled } from '@/hooks/use-compose-diff-preview-enabled';
 import { useTopNavLabels } from '@/hooks/use-top-nav-labels';
 import { useTopNavAlign, type TopNavAlign } from '@/hooks/use-top-nav-align';
 import { useTheme, THEME_MODE_OPTIONS, ACCENTS, CONTRAST, BORDER_BOOST, GLOW, TYPE_SCALE } from '@/hooks/use-theme';
@@ -29,11 +25,6 @@ const DENSITY_DESCRIPTIONS: Record<Density, string> = {
     compact: 'Tighter rows and tiles. Fits more on screen for dense dashboards.',
 };
 
-const DEPLOY_STYLE_OPTIONS: { value: DeployFeedbackStyle; label: string }[] = [
-    { value: 'modal', label: 'Modal' },
-    { value: 'inline', label: 'Inline' },
-];
-
 const TOP_NAV_ALIGN_OPTIONS: { value: TopNavAlign; label: string }[] = [
     { value: 'left', label: 'Left' },
     { value: 'center', label: 'Center' },
@@ -43,9 +34,6 @@ const fmtSigned = (v: number) => `${v > 0 ? '+' : ''}${v.toFixed(2)}`;
 
 export function AppearanceSection() {
     const [density, setDensity] = useDensity();
-    const [isEnabled, setEnabled] = useDeployFeedbackEnabled();
-    const [feedbackStyle, setFeedbackStyle] = useDeployFeedbackStyle();
-    const [diffPreviewEnabled, setDiffPreviewEnabled] = useComposeDiffPreviewEnabled();
     const [topNavLabels, setTopNavLabels] = useTopNavLabels();
     const [topNavAlign, setTopNavAlign] = useTopNavAlign();
     const {
@@ -223,58 +211,6 @@ export function AppearanceSection() {
                         />
                     </SettingsField>
                 )}
-
-                <SettingsField
-                    label="Deploy progress"
-                    helper="Stream live output for deploy, restart, update, install, and Git operations, with a warning when an operation goes quiet. On by default; turn it off to run operations without it."
-                >
-                    <div className="flex items-center gap-2">
-                        <Checkbox
-                            id="deploy-feedback"
-                            checked={isEnabled}
-                            onCheckedChange={(v) => setEnabled(v === true)}
-                        />
-                        <label
-                            htmlFor="deploy-feedback"
-                            className="text-sm text-stat-value cursor-pointer select-none"
-                        >
-                            {isEnabled ? 'Enabled' : 'Disabled'}
-                        </label>
-                    </div>
-                </SettingsField>
-
-                {isEnabled && (
-                    <SettingsField
-                        label="Progress style"
-                        helper="Modal opens a centered overlay. Inline shows a quiet status on the stack detail with the full log a click away under View output."
-                    >
-                        <SegmentedControl
-                            value={feedbackStyle}
-                            options={DEPLOY_STYLE_OPTIONS}
-                            onChange={setFeedbackStyle}
-                            ariaLabel="Deploy progress style"
-                        />
-                    </SettingsField>
-                )}
-
-                <SettingsField
-                    label="Diff preview before save"
-                    helper="Show a side-by-side diff of compose and env edits before they reach disk."
-                >
-                    <div className="flex items-center gap-2">
-                        <Checkbox
-                            id="compose-diff-preview"
-                            checked={diffPreviewEnabled}
-                            onCheckedChange={(v) => setDiffPreviewEnabled(v === true)}
-                        />
-                        <label
-                            htmlFor="compose-diff-preview"
-                            className="text-sm text-stat-value cursor-pointer select-none"
-                        >
-                            {diffPreviewEnabled ? 'Enabled' : 'Disabled'}
-                        </label>
-                    </div>
-                </SettingsField>
             </SettingsSection>
 
             <p className="font-mono text-[10px] leading-3 uppercase tracking-[0.18em] text-stat-subtitle/70">

--- a/frontend/src/components/settings/SettingsPage.tsx
+++ b/frontend/src/components/settings/SettingsPage.tsx
@@ -21,6 +21,7 @@ import {
     getSettingsGroup,
     isItemVisible,
     isItemLocked,
+    scopeLabel,
 } from './index';
 import type { SectionId, SettingsItemMeta, VisibilityContext } from './index';
 import { SettingsSidebar } from './SettingsSidebar';
@@ -226,14 +227,6 @@ function SettingsPageInner({ currentSection, onSectionChange }: SettingsPageProp
             </CommandDialog>
         </div>
     );
-}
-
-function scopeLabel(item: SettingsItemMeta): string {
-    // Personal sections (account, appearance) apply to the signed-in operator or
-    // this browser. Access sections (license, users, sso, api-tokens) are
-    // instance-global, so they read as global like every other non-node group.
-    if (item.group === 'personal') return 'operator';
-    return 'global';
 }
 
 function SettingsCommandItem({

--- a/frontend/src/components/settings/SettingsSectionContent.tsx
+++ b/frontend/src/components/settings/SettingsSectionContent.tsx
@@ -13,6 +13,7 @@ import {
     DeveloperSection,
     DataRetentionSection,
     AppStoreSection,
+    StacksSection,
     SupportSection,
     AboutSection,
     RecoverySection,
@@ -90,6 +91,7 @@ function renderSection(
         case 'data-retention': return <DataRetentionSection onDirtyChange={(d) => onDirtyChange('data-retention', d)} />;
         case 'nodes': return <NodeManager />;
         case 'app-store': return <AppStoreSection />;
+        case 'stacks': return <StacksSection />;
         case 'recovery': return <RecoverySection />;
         case 'support': return <SupportSection />;
         case 'about': return <AboutSection />;

--- a/frontend/src/components/settings/StacksSection.tsx
+++ b/frontend/src/components/settings/StacksSection.tsx
@@ -1,0 +1,80 @@
+import { Checkbox } from '@/components/ui/checkbox';
+import { SegmentedControl } from '@/components/ui/segmented-control';
+import { useDeployFeedbackEnabled } from '@/hooks/use-deploy-feedback-enabled';
+import { useDeployFeedbackStyle, type DeployFeedbackStyle } from '@/hooks/use-deploy-feedback-style';
+import { useComposeDiffPreviewEnabled } from '@/hooks/use-compose-diff-preview-enabled';
+import { SettingsSection } from './SettingsSection';
+import { SettingsField } from './SettingsField';
+
+const DEPLOY_STYLE_OPTIONS: { value: DeployFeedbackStyle; label: string }[] = [
+    { value: 'modal', label: 'Modal' },
+    { value: 'inline', label: 'Inline' },
+];
+
+export function StacksSection() {
+    const [isEnabled, setEnabled] = useDeployFeedbackEnabled();
+    const [feedbackStyle, setFeedbackStyle] = useDeployFeedbackStyle();
+    const [diffPreviewEnabled, setDiffPreviewEnabled] = useComposeDiffPreviewEnabled();
+
+    return (
+        <div className="flex flex-col gap-10">
+            <SettingsSection title="Workflow" kicker="this browser">
+                <SettingsField
+                    label="Deploy progress"
+                    helper="Stream live output for deploy, restart, update, install, and Git operations, with a warning when an operation goes quiet. On by default; turn it off to run operations without it."
+                >
+                    <div className="flex items-center gap-2">
+                        <Checkbox
+                            id="deploy-feedback"
+                            checked={isEnabled}
+                            onCheckedChange={(v) => setEnabled(v === true)}
+                        />
+                        <label
+                            htmlFor="deploy-feedback"
+                            className="text-sm text-stat-value cursor-pointer select-none"
+                        >
+                            {isEnabled ? 'Enabled' : 'Disabled'}
+                        </label>
+                    </div>
+                </SettingsField>
+
+                {isEnabled && (
+                    <SettingsField
+                        label="Progress style"
+                        helper="Modal opens a centered overlay. Inline shows a quiet status on the stack detail with the full log a click away under View output."
+                    >
+                        <SegmentedControl
+                            value={feedbackStyle}
+                            options={DEPLOY_STYLE_OPTIONS}
+                            onChange={setFeedbackStyle}
+                            ariaLabel="Deploy progress style"
+                        />
+                    </SettingsField>
+                )}
+
+                <SettingsField
+                    label="Diff preview before save"
+                    helper="Show a side-by-side diff of compose and env edits before they reach disk."
+                >
+                    <div className="flex items-center gap-2">
+                        <Checkbox
+                            id="compose-diff-preview"
+                            checked={diffPreviewEnabled}
+                            onCheckedChange={(v) => setDiffPreviewEnabled(v === true)}
+                        />
+                        <label
+                            htmlFor="compose-diff-preview"
+                            className="text-sm text-stat-value cursor-pointer select-none"
+                        >
+                            {diffPreviewEnabled ? 'Enabled' : 'Disabled'}
+                        </label>
+                    </div>
+                </SettingsField>
+            </SettingsSection>
+
+            <p className="font-mono text-[10px] leading-3 uppercase tracking-[0.18em] text-stat-subtitle/70">
+                ⓘ saved to this browser only · every device remembers its own choice
+            </p>
+        </div>
+    );
+}

--- a/frontend/src/components/settings/__tests__/StacksSection.test.tsx
+++ b/frontend/src/components/settings/__tests__/StacksSection.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Guards the move of the stack-workflow controls out of Appearance into Stacks.
+ *
+ * The three controls (Deploy progress, Progress style, Diff preview before save)
+ * are browser-local localStorage preferences. Moving the JSX must not change the
+ * storage keys they write, so the deploy/editor consumers keep reading the same
+ * values. These tests assert the controls render in Stacks, still flip the same
+ * keys, and no longer render in Appearance.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { StacksSection } from '../StacksSection';
+import { AppearanceSection } from '../AppearanceSection';
+import { DEPLOY_FEEDBACK_KEY } from '@/hooks/use-deploy-feedback-enabled';
+import { DEPLOY_FEEDBACK_STYLE_KEY } from '@/hooks/use-deploy-feedback-style';
+import { COMPOSE_DIFF_PREVIEW_KEY } from '@/hooks/use-compose-diff-preview-enabled';
+
+beforeEach(() => {
+    window.localStorage.clear();
+});
+
+afterEach(() => {
+    window.localStorage.clear();
+});
+
+describe('StacksSection', () => {
+    it('renders the three workflow controls (Progress style while deploy progress is on)', () => {
+        render(<StacksSection />);
+        expect(screen.getByText('Deploy progress')).toBeInTheDocument();
+        // Deploy progress defaults on, so Progress style is visible.
+        expect(screen.getByText('Progress style')).toBeInTheDocument();
+        expect(screen.getByText('Diff preview before save')).toBeInTheDocument();
+    });
+
+    it('flips the deploy-progress key and hides Progress style when disabled', () => {
+        const { container } = render(<StacksSection />);
+        const toggle = container.querySelector('#deploy-feedback') as HTMLElement;
+        // Default on => no stored value yet.
+        expect(window.localStorage.getItem(DEPLOY_FEEDBACK_KEY)).toBeNull();
+        fireEvent.click(toggle);
+        expect(window.localStorage.getItem(DEPLOY_FEEDBACK_KEY)).toBe('false');
+        // Progress style is gated on the enabled state and drops out.
+        expect(screen.queryByText('Progress style')).not.toBeInTheDocument();
+    });
+
+    it('round-trips the progress-style key between Inline and Modal', () => {
+        render(<StacksSection />);
+        fireEvent.click(screen.getByRole('radio', { name: 'Inline' }));
+        expect(window.localStorage.getItem(DEPLOY_FEEDBACK_STYLE_KEY)).toBe('inline');
+        fireEvent.click(screen.getByRole('radio', { name: 'Modal' }));
+        expect(window.localStorage.getItem(DEPLOY_FEEDBACK_STYLE_KEY)).toBe('modal');
+    });
+
+    it('hydrates each control from its stored value (read path survives the move)', () => {
+        window.localStorage.setItem(DEPLOY_FEEDBACK_KEY, 'false');
+        window.localStorage.setItem(COMPOSE_DIFF_PREVIEW_KEY, 'true');
+        const { container } = render(<StacksSection />);
+        // Deploy progress reads its stored 'false': checkbox unchecked, Progress style hidden.
+        expect(container.querySelector('#deploy-feedback')?.getAttribute('aria-checked')).toBe('false');
+        expect(screen.queryByText('Progress style')).not.toBeInTheDocument();
+        // Diff preview reads its stored 'true': checkbox checked.
+        expect(container.querySelector('#compose-diff-preview')?.getAttribute('aria-checked')).toBe('true');
+    });
+
+    it('flips the diff-preview key when enabled', () => {
+        const { container } = render(<StacksSection />);
+        const toggle = container.querySelector('#compose-diff-preview') as HTMLElement;
+        expect(window.localStorage.getItem(COMPOSE_DIFF_PREVIEW_KEY)).toBeNull();
+        fireEvent.click(toggle);
+        expect(window.localStorage.getItem(COMPOSE_DIFF_PREVIEW_KEY)).toBe('true');
+    });
+});
+
+describe('AppearanceSection no longer owns stack-workflow controls', () => {
+    it('does not render Deploy progress, Progress style, or Diff preview before save', () => {
+        render(<AppearanceSection />);
+        expect(screen.queryByText('Deploy progress')).not.toBeInTheDocument();
+        expect(screen.queryByText('Progress style')).not.toBeInTheDocument();
+        expect(screen.queryByText('Diff preview before save')).not.toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/settings/__tests__/registry.test.ts
+++ b/frontend/src/components/settings/__tests__/registry.test.ts
@@ -7,7 +7,8 @@
  * Data Retention, and the renamed labels are applied.
  */
 import { describe, it, expect } from 'vitest';
-import { SETTINGS_GROUPS, SETTINGS_ITEMS } from '../registry';
+import { SETTINGS_GROUPS, SETTINGS_ITEMS, scopeLabel } from '../registry';
+import type { SettingsItemMeta } from '../registry';
 
 describe('settings registry', () => {
     it('points every item at a defined group', () => {
@@ -73,5 +74,39 @@ describe('settings registry', () => {
         const registries = SETTINGS_ITEMS.find(i => i.id === 'registries');
         expect(registries?.tier).toBeNull();
         expect(registries?.adminOnly).toBe(true);
+    });
+
+    it('registers the Stacks section under Infrastructure with searchable workflow keywords', () => {
+        const stacks = SETTINGS_ITEMS.find(i => i.id === 'stacks');
+        expect(stacks?.group).toBe('infrastructure');
+        expect(stacks?.tier).toBeNull();
+        for (const term of ['stack', 'deploy', 'progress', 'diff', 'save']) {
+            expect(stacks?.keywords, `keyword ${term}`).toContain(term);
+        }
+    });
+
+    it('scopes the browser-local sections (Appearance, Stacks) to the browser', () => {
+        expect(SETTINGS_ITEMS.find(i => i.id === 'appearance')?.scope).toBe('browser');
+        expect(SETTINGS_ITEMS.find(i => i.id === 'stacks')?.scope).toBe('browser');
+    });
+});
+
+describe('scopeLabel', () => {
+    const item = (over: Partial<SettingsItemMeta>): SettingsItemMeta => ({
+        id: 'stacks', group: 'infrastructure', label: 'X', description: '',
+        keywords: [], tier: null, scope: 'global', ...over,
+    });
+
+    it('reads browser for browser-scoped sections regardless of their group', () => {
+        expect(scopeLabel(item({ scope: 'browser', group: 'personal' }))).toBe('browser');
+        expect(scopeLabel(item({ scope: 'browser', group: 'infrastructure' }))).toBe('browser');
+    });
+
+    it('reads operator for the signed-in Account (personal group)', () => {
+        expect(scopeLabel(item({ scope: 'global', group: 'personal' }))).toBe('operator');
+    });
+
+    it('reads global for other non-node, non-browser groups', () => {
+        expect(scopeLabel(item({ scope: 'global', group: 'access' }))).toBe('global');
     });
 });

--- a/frontend/src/components/settings/index.ts
+++ b/frontend/src/components/settings/index.ts
@@ -10,6 +10,7 @@ export { NotificationsSection } from './NotificationsSection';
 export { DeveloperSection } from './DeveloperSection';
 export { DataRetentionSection } from './DataRetentionSection';
 export { AppStoreSection } from './AppStoreSection';
+export { StacksSection } from './StacksSection';
 export { SupportSection } from './SupportSection';
 export { AboutSection } from './AboutSection';
 export { RecoverySection } from './RecoverySection';
@@ -30,6 +31,7 @@ export {
     getSettingsGroup,
     isItemVisible,
     isItemLocked,
+    scopeLabel,
 } from './registry';
 export type {
     SettingsGroupId,

--- a/frontend/src/components/settings/registry.ts
+++ b/frontend/src/components/settings/registry.ts
@@ -31,7 +31,7 @@ export const SETTINGS_GROUPS: readonly SettingsGroupMeta[] = [
 ];
 
 export type TierGate = 'paid' | null;
-export type Scope = 'global' | 'node';
+export type Scope = 'global' | 'node' | 'browser';
 
 export interface SettingsItemMeta {
     id: SectionId;
@@ -64,7 +64,7 @@ export const SETTINGS_ITEMS: readonly SettingsItemMeta[] = [
         description: 'Theme, accent, density, and display preferences saved to this browser.',
         keywords: ['theme', 'dim', 'oled', 'light', 'dark', 'accent', 'color', 'glow', 'border', 'contrast', 'density', 'comfortable', 'compact', 'spacing', 'display'],
         tier: null,
-        scope: 'global',
+        scope: 'browser',
     },
     // Access
     {
@@ -161,6 +161,15 @@ export const SETTINGS_ITEMS: readonly SettingsItemMeta[] = [
         keywords: ['templates', 'registry', 'catalog', 'featured'],
         tier: null,
         scope: 'node',
+    },
+    {
+        id: 'stacks',
+        group: 'infrastructure',
+        label: 'Stacks',
+        description: 'Stack editor and lifecycle workflow preferences saved to this browser.',
+        keywords: ['stack', 'compose', 'deploy', 'progress', 'modal', 'inline', 'diff', 'preview', 'save', 'editor', 'workflow'],
+        tier: null,
+        scope: 'browser',
     },
     // Monitoring
     {
@@ -296,4 +305,18 @@ export function isItemVisible(item: SettingsItemMeta, ctx: VisibilityContext): b
 
 export function isItemLocked(item: SettingsItemMeta, ctx: VisibilityContext): boolean {
     return item.tier === 'paid' ? !ctx.isPaid : false;
+}
+
+/**
+ * The masthead SCOPE value for a non-node section. Browser-local sections
+ * (Appearance, Stacks) persist to this browser's localStorage and read as
+ * browser regardless of their group; the signed-in Account is operator-scoped;
+ * Access sections (license, users, sso, api-tokens) are instance-global, so
+ * they read as global like every other non-node group. Node-scoped sections
+ * render a NODE pill instead and never reach here.
+ */
+export function scopeLabel(item: SettingsItemMeta): string {
+    if (item.scope === 'browser') return 'browser';
+    if (item.group === 'personal') return 'operator';
+    return 'global';
 }

--- a/frontend/src/components/settings/types.ts
+++ b/frontend/src/components/settings/types.ts
@@ -59,6 +59,7 @@ export type SectionId =
     | 'data-retention'
     | 'nodes'
     | 'app-store'
+    | 'stacks'
     | 'notification-routing'
     | 'recovery'
     | 'support'


### PR DESCRIPTION
## Summary

The **Appearance** settings section mixed two unrelated concerns: under its **Display** block it rendered three controls that have nothing to do with visual style.

This moves those three browser-local controls out of Appearance into a new **Stacks** settings section under the **Infrastructure** group (alongside Nodes, Fleet, Registries, Cloud Backup, App Store):

- **Deploy progress** (on/off)
- **Progress style** (Modal / Inline)
- **Diff preview before save**

They are stack lifecycle and editor workflow preferences, so Settings now groups them where operators expect. Appearance stays focused on theme, typography, density, and the top-navigation display options.

This is an information-architecture move only. Each control keeps its exact behavior, its `localStorage` key, and its backing hook. Nothing about how the preferences work changes.

### Browser-local scope

These sections persist to the browser's `localStorage`, not to the instance or a node. The masthead previously labelled a non-personal section as `SCOPE global`, which would misread as instance-wide for the new Stacks section. A `browser` scope value was added so both Appearance and Stacks now read `SCOPE browser`. The `scopeLabel` helper moved to the registry module (co-located with the `Scope` type) so it is unit-testable.

## Test plan

- `tsc -b` and ESLint clean on the changed frontend.
- Unit tests: new `StacksSection.test.tsx` asserts the three controls render in Stacks, flip the same `localStorage` keys, hydrate from stored values, gate Progress style on the enabled state, and no longer render in Appearance. `registry.test.ts` covers the new section's group/keywords, the `browser` scope on both sections, and `scopeLabel` across its branches.
- Manual walkthrough (desktop + phone layout): the Stacks section appears under Infrastructure and renders all three controls; the masthead reads `SCOPE browser`; Appearance no longer shows them; the settings command palette finds Stacks via `deploy` / `progress` / `diff` / `save` / `stack`; toggling each control still flips its `localStorage` key.

## Notes

- No backend change (these are browser-local preferences, not server settings).
- No tier or role gate change.
- Docs updated: the Settings reference gains a Stacks section and the Appearance, Deploy Progress, Editor, and App Store pages point at the new location. Two settings screenshots that show the controls in their old place are flagged for recapture.
