### PR TITLE
fix(mobile): keep the bottom tab bar visible with dynamic viewport height

### DIFF
--- a/frontend/src/components/EditorLayout.tsx
+++ b/frontend/src/components/EditorLayout.tsx
@@ -880,7 +880,9 @@ export default function EditorLayout() {
 
       if (isMobile) {
         return (
-          <div className="flex h-screen w-screen flex-col overflow-hidden app-canvas text-foreground">
+          // h-dvh tracks the visible viewport as the address bar shows and hides, so
+          // the bottom tab bar stays on screen (100vh would push it behind the bar).
+          <div className="flex h-dvh w-screen flex-col overflow-hidden app-canvas text-foreground">
             {commandPaletteEl}
             {mobileSurface === 'content' && !bespokeContent && topBarEl}
             <div className="flex-1 min-h-0 flex flex-col overflow-hidden">


### PR DESCRIPTION
## Summary

On mobile browsers that place the address bar at the bottom (Safari, Chrome), `100vh` measures the largest viewport with the bar retracted. The mobile shell used `h-screen` (`100vh`), so it ran taller than the visible area and the bottom tab bar sat behind the address bar, out of reach.

This switches the mobile shell container to `h-dvh` (dynamic viewport height), which tracks the visible area as the bar shows and hides, keeping the tab bar on screen.

## What changed

- `frontend/src/components/EditorLayout.tsx`: the mobile shell container (inside the `isMobile` branch) now uses `h-dvh` instead of `h-screen`.

## Test plan

- `tsc -b --noEmit` and ESLint clean.
- Desktop is untouched: only the mobile branch changed; the desktop shell stays `h-screen`. The tab bar already pads for the home-indicator safe area.
- This reproduces only on a real mobile browser with a bottom address bar, so verify on iOS Safari and Android Chrome that the tab bar stays visible as the address bar collapses and expands.
