### PR TITLE
feat(fleet): reorder Overview toolbar actions so Add node sits far right

### DIFF
--- a/frontend/src/components/FleetView/OverviewToolbar.tsx
+++ b/frontend/src/components/FleetView/OverviewToolbar.tsx
@@ -255,13 +255,6 @@ export function OverviewToolbar({
                 className="ml-auto shrink-0 shadow-card-bevel"
             />
 
-            {onAddNode && (
-                <Button size="sm" className="gap-1.5 shrink-0 h-9" onClick={onAddNode}>
-                    <Plus className="w-4 h-4" strokeWidth={1.5} />
-                    Add node
-                </Button>
-            )}
-
             {onCheckUpdates && (
                 <Button
                     variant="outline"
@@ -272,6 +265,13 @@ export function OverviewToolbar({
                 >
                     <RefreshCcwDot className={`w-4 h-4 ${checkingUpdates ? 'animate-spin' : ''}`} />
                     Check Updates
+                </Button>
+            )}
+
+            {onAddNode && (
+                <Button size="sm" className="gap-1.5 shrink-0 h-9" onClick={onAddNode}>
+                    <Plus className="w-4 h-4" strokeWidth={1.5} />
+                    Add node
                 </Button>
             )}
         </div>


### PR DESCRIPTION
## Summary

Reorders the trailing action buttons in the Fleet Overview toolbar. The order after the view-mode (Grid/Topology) toggle is now **Check Updates** then **Add node**, with **Add node** anchored at the far right edge. Previously the order was Add node then Check Updates.

This is a pure JSX reorder of two sibling conditional button blocks. No logic, props, handlers, conditionals, or styling changed; both blocks are byte-identical to before, only repositioned. The `ml-auto` right-alignment anchor stays on the segmented control.

## Test plan

- Frontend type check (`tsc -b --noEmit`) passes clean.
- Existing `OverviewToolbar` tests assert button presence and click handlers (not ordering), so they remain valid and green.
- Visual check: with both handlers present, the toolbar renders ... Grid/Topology toggle, Check Updates, Add node (far right).

## Notes

No behavioral change; purely a layout adjustment to the action button order.