### PR TITLE
fix(stacks): return a handled response when saving env to a stack with no env file

### DIFF
--- a/backend/src/__tests__/stack-compose-mtime.test.ts
+++ b/backend/src/__tests__/stack-compose-mtime.test.ts
@@ -209,6 +209,24 @@ describe('PUT /api/stacks/:stackName/env optimistic concurrency', () => {
     expect(fs.readFileSync(envPath, 'utf-8')).toBe('FOO=2');
   });
 
+  it('returns a clean 404 (not a 500) when the stack has no env file yet', async () => {
+    // Compose exists with no env_file directive and no .env on disk, so
+    // resolveAllEnvFilePaths filters the synthesized default out and returns [],
+    // leaving the env path undefined. The save must surface a handled response
+    // rather than crashing on a write to an undefined path.
+    seedStack(STACK, 'services:\n  web:\n    image: nginx\n');
+
+    const putRes = await request(app)
+      .put(`/api/stacks/${STACK}/env`)
+      .set('Cookie', authCookie)
+      .send({ content: 'FOO=1' });
+
+    expect(putRes.status).toBe(404);
+    expect(putRes.body.error).toMatch(/no env file/i);
+    // The guard must short-circuit before any write touches disk.
+    expect(fs.existsSync(path.join(composeDir, STACK, '.env'))).toBe(false);
+  });
+
   it('returns 412 on env-file mtime mismatch', async () => {
     seedStack(STACK, 'services: {}');
     const envPath = seedEnv(STACK, 'FOO=1');

--- a/backend/src/routes/stacks.ts
+++ b/backend/src/routes/stacks.ts
@@ -644,6 +644,14 @@ stacksRouter.put('/:stackName/env', async (req: Request, res: Response) => {
       }
     }
 
+    // No env file resolved: the stack has no .env yet and the editor only edits
+    // an existing env file. GET treats this same case as an empty 200; PUT cannot,
+    // since there is no resolved path to write. Reply with a clean, handled response
+    // instead of writing to an undefined path, which would otherwise surface as an opaque 500.
+    if (!envPath) {
+      return res.status(404).json({ error: 'No env file exists for this stack' });
+    }
+
     const fsService = FileSystemService.getInstance(req.nodeId);
     const expectedMtimeMs = parseIfMatchMtime(req.header('if-match'));
     const result = await fsService.writeFileIfUnchanged(envPath, content, expectedMtimeMs);


### PR DESCRIPTION
## Summary

Saving an env file to a stack that has a compose file but no `.env` yet returned an opaque `500`. `resolveAllEnvFilePaths` filters env candidates to files that exist on disk, so it returns `[]` for such a stack; the `PUT /api/stacks/:stackName/env` handler then resolved an undefined path and called `writeFileIfUnchanged(undefined, ...)`, where `path.resolve(base, undefined)` throws and is flattened to a generic 500.

This adds a single early-return guard: when no env path resolves, the handler replies `404 { error: 'No env file exists for this stack' }`. The guard sits after the explicit `?file=` resolution (so those requests keep their existing 400/404) and before the write sink.

No new capability is introduced. The editor still edits only an existing env file (the `.env` tab is disabled on desktop and hidden on mobile when no `.env` exists), so the UI is unchanged. The fix only affects direct API callers, who now get an actionable response instead of a crash.

## Test plan

- New regression test in `stack-compose-mtime.test.ts`: seeds a compose file with no `.env`, asserts a `404` with a `/no env file/i` body, and asserts no `.env` was written to disk.
- Confirmed red/green: the test fails (500) without the guard and passes (404) with it.
- `vitest` on the target suite (10/10) and adjacent stack-route suites (8/8) pass.
- `tsc --noEmit` on the backend is clean.

## Notes

- 404 (rather than 400) matches the existing convention in this handler, where an explicit `?file=` miss also returns 404.
- The parallel `GET` handler deliberately returns an empty `200` for the same no-env case; `PUT` cannot, since there is no resolved path to write. This asymmetry is documented inline.
- Safe for fresh installs and upgrades from v0.91.1: the guard only changes the response for a request that previously crashed.