### PR TITLE
ci: retry E2E tests in CI to absorb flaky real-Docker timing

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,6 +19,10 @@ export default defineConfig({
   expect: { timeout: 5_000 },
   // Run tests serially - Sencho is a single-user app and tests share DB state
   workers: 1,
+  // Retry only in CI: the deploy/health-gate specs drive real Docker container
+  // runs, so image-pull and gate-window timing varies on shared runners. A retry
+  // absorbs the transient blip; trace: 'on-first-retry' captures the retried run.
+  retries: process.env.CI ? 2 : 0,
   reporter: [['list'], ['html', { outputFolder: 'e2e/report', open: 'never' }]],
 
   use: {


### PR DESCRIPTION
## Summary

Enable Playwright test retries in CI (`retries: process.env.CI ? 2 : 0`). The E2E suite includes real-Docker deploy and health-gate specs (`e2e/deploy-log-panel.spec.ts`, `e2e/stack-deploy.spec.ts`) whose timing varies on shared CI runners: cold image pulls and the post-deploy health-gate observation window. With no `retries` configured, the Playwright job ran at the default of 0, so a single transient timing blip reds the entire job.

This is a known-flaky surface, not a code regression. The same spec has failed on completely unrelated branches (including a docs-only branch), and the suite has a history of pass/fail flip-flopping on identical code. Two retries in CI absorb the transient blips while still surfacing genuine failures (a real break fails all three attempts). Local runs stay at 0 for fast, deterministic feedback.

The config already sets `trace: 'on-first-retry'`, which never fired with 0 retries; it now captures the retried attempt for triage.

## Test plan

- `npx playwright test --list` loads the config cleanly (93 tests across 17 files), confirming no config error.
- Local runs are unchanged: `process.env.CI` is undefined locally, so `retries` resolves to 0.
- Retry behavior is exercised by CI itself, where `CI=true` yields 2 retries.

## Notes

Scope is deliberately limited to the retry policy. The individual deploy specs are already heavily timing-hardened; a uniform CI retry is the higher-leverage fix and avoids guessing at per-assertion timeout bumps. No application code, routes, or UI are touched.