### PR TITLE
docs: retire the public-beta label and document v0.92.0 capabilities

### DIFF
--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -1,15 +1,17 @@
 # Known limitations
 
 > [!NOTE]
-> Sencho is currently in public beta on the path to v1.0. Core workflows are actively tested, but early users should review the known limitations and avoid deploying it blindly on critical infrastructure without testing in their own environment first.
+> Sencho is used in production for day-to-day Docker Compose and fleet management. As a pre-1.0 project it still evolves quickly, so review the limitations below and validate against your own setup before deploying it on critical infrastructure.
 
 Below are the limitations we know about today. If you hit something that is not here, please file a bug.
 
 ## Scale
 
-- Single-instance use: not benchmarked yet beyond typical homelab loads. Expect comfortable operation on tens of stacks and a few hundred containers per node; very large nodes may show UI slowdowns.
-- Fleet: not benchmarked yet. Comfortably tested with small fleets (a handful of nodes); larger fleets work but are less exercised.
-- Container log streaming: not benchmarked yet at sustained high log rates; very chatty containers may lag the UI.
+Sencho's core workflows are validated through QA, repeated security and code audits, and end-to-end journey testing, so day-to-day correctness is well exercised. What is not yet characterized is performance at large scale: the figures below are ranges we have run comfortably, not hard ceilings.
+
+- Single instance: comfortable at typical homelab and small-team loads (tens of stacks and a few hundred containers per node). Very large nodes are not yet benchmarked and may show UI slowdowns.
+- Fleet: validated on small fleets (a handful of nodes). Larger fleets work but are less exercised, and fleet-wide operations are not yet benchmarked at scale.
+- Container log streaming: handles normal log volumes smoothly. Sustained high log rates are not yet benchmarked, and very chatty containers may lag the UI.
 
 ## Platform support
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 </picture>
 
 > [!NOTE]
-> Sencho is currently in public beta on the path to v1.0. Core workflows are actively tested, but early users should review the known limitations and avoid deploying it blindly on critical infrastructure without testing in their own environment first.
+> Sencho is used in production for day-to-day Docker Compose and fleet management. As a pre-1.0 project it still evolves quickly, so review the known limitations and validate against your own setup before deploying it on critical infrastructure.
 
 ---
 
@@ -62,17 +62,20 @@ See [KNOWN_LIMITATIONS.md](KNOWN_LIMITATIONS.md) for the current limitation list
 ### Stacks
 - Full Compose lifecycle: create, deploy, restart, stop, pull
 - Monaco editor with diff preview before save and one-click rollback
-- [Git-sourced stacks](https://docs.sencho.io/features/git-sources) pulled and synced from any repository
-- File explorer for compose, env, and supporting files
+- [Health-gated updates](https://docs.sencho.io/features/health-gated-updates) that hold a rollout until health checks pass, with stalled-update detection and in-app recovery
+- [Git-sourced stacks](https://docs.sencho.io/features/git-sources) pulled and synced from any repository, with ordered multi-file Compose
+- [File explorer](https://docs.sencho.io/features/stack-file-explorer) for compose, env, and supporting files, with move and rename across directories
+- [Compose Doctor](https://docs.sencho.io/features/compose-doctor) preflight checks that catch compose problems before deploy
 - [Stack labels](https://docs.sencho.io/features/stack-labels) for grouping and bulk operations
 - [App Store](https://docs.sencho.io/features/app-store) with LinuxServer.io templates
 
 ### Observability
 - Aggregated [log search and stream](https://docs.sencho.io/features/global-observability) across every container in the fleet
-- Live container stats, health checks, and image-update notifications
+- Live container stats, health checks, and image-update notifications on a configurable cadence, with links from each image to its registry and source
 - Threshold alerts for CPU, memory, and network
 - Read-only [audit log](https://docs.sencho.io/features/audit-log) of every action **(Admiral)**
 - [Network topology](https://docs.sencho.io/features/fleet-view) view of containers, networks, and nodes
+- Documentation-drift flags when a [stack dossier](https://docs.sencho.io/features/stack-dossier) diverges from the running stack
 
 ### Fleet
 - Multi-node management via authenticated HTTP and WebSocket proxy
@@ -93,7 +96,10 @@ See [KNOWN_LIMITATIONS.md](KNOWN_LIMITATIONS.md) for the current limitation list
 - [SSO](https://docs.sencho.io/features/sso): custom OIDC, presets for Google, GitHub, and Okta, plus LDAP and Active Directory
 - [Two-factor authentication](https://docs.sencho.io/features/two-factor-authentication) with TOTP and backup codes
 - [RBAC](https://docs.sencho.io/features/rbac) with admin (full control) and viewer (read-only) roles; deployer, node-admin, and auditor roles plus scoped permissions **(Admiral)**
-- [Vulnerability scanning](https://docs.sencho.io/features/vulnerability-scanning) via Trivy on every tier with VEX-based suppression; SARIF export and SBOM upload **(Admiral)**
+- [Security overview](https://docs.sencho.io/features/security) with a chart-led scan summary, sortable images, and searchable scan history
+- [Vulnerability scanning](https://docs.sencho.io/features/vulnerability-scanning) via Trivy on every tier, with on-demand node-wide scans and VEX-based suppression; SARIF export and SBOM upload **(Admiral)**
+- [Compose network inspector](https://docs.sencho.io/features/compose-networking) with an exposure-intent guard for unintended published ports
+- Scan policy packs for reusable security rules **(Admiral)**
 - [Private registries](https://docs.sencho.io/features/private-registries) and [deploy enforcement](https://docs.sencho.io/features/deploy-enforcement) for non-compliant images **(Admiral)**
 - [API tokens](https://docs.sencho.io/features/api-tokens) for automation
 

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -6,7 +6,7 @@ description: Get Sencho running in under five minutes.
 This walks you from a clean Docker host to a working Sencho console. Five minutes if your Compose directory is already in the right place, ten if you need to lay it out first.
 
 <Note>
-  Sencho is currently in public beta on the path to v1.0. Core workflows are actively tested, but early users should review the [known limitations](https://github.com/studio-saelix/sencho/blob/main/KNOWN_LIMITATIONS.md) and avoid deploying it blindly on critical infrastructure without testing in their own environment first.
+  Sencho is used in production for day-to-day Docker Compose and fleet management. As a pre-1.0 project it still evolves quickly, so review the [known limitations](https://github.com/studio-saelix/sencho/blob/main/KNOWN_LIMITATIONS.md) and validate against your own setup before deploying it on critical infrastructure.
 </Note>
 
 ## Prerequisites

--- a/docs/operations/troubleshooting.mdx
+++ b/docs/operations/troubleshooting.mdx
@@ -4,7 +4,7 @@ description: Solutions to the most common Sencho setup and runtime problems.
 ---
 
 <Note>
-  Sencho is currently in public beta on the path to v1.0. Core workflows are actively tested, but early users should review the [known limitations](https://github.com/studio-saelix/sencho/blob/main/KNOWN_LIMITATIONS.md) and avoid deploying it blindly on critical infrastructure without testing in their own environment first.
+  Sencho is used in production for day-to-day Docker Compose and fleet management. As a pre-1.0 project it still evolves quickly, so review the [known limitations](https://github.com/studio-saelix/sencho/blob/main/KNOWN_LIMITATIONS.md) and validate against your own setup before deploying it on critical infrastructure.
 </Note>
 
 If something has broken and you want a quick "what do I do now?" overview rather than a specific symptom, start with the [Recovery guide](/operations/recovery). It walks through getting back to a working state when Sencho, a deploy, sign-in, Docker, or a remote node fails, and links back here for the details.

--- a/docs/operations/upgrade.mdx
+++ b/docs/operations/upgrade.mdx
@@ -4,7 +4,7 @@ description: How to update Sencho, what happens during upgrades, and the version
 ---
 
 <Note>
-  Sencho is currently in public beta on the path to v1.0. Core workflows are actively tested, but early users should review the [known limitations](https://github.com/studio-saelix/sencho/blob/main/KNOWN_LIMITATIONS.md) and avoid deploying it blindly on critical infrastructure without testing in their own environment first.
+  Sencho is used in production for day-to-day Docker Compose and fleet management. As a pre-1.0 project it still evolves quickly, so review the [known limitations](https://github.com/studio-saelix/sencho/blob/main/KNOWN_LIMITATIONS.md) and validate against your own setup before deploying it on critical infrastructure.
 </Note>
 
 ## Upgrade steps

--- a/docs/reference/security.mdx
+++ b/docs/reference/security.mdx
@@ -6,7 +6,7 @@ description: How Sencho protects your infrastructure with layered authentication
 Sencho applies defense-in-depth across authentication, authorization, encryption, and auditing. All security features ship with sensible defaults and work out of the box on a fresh install.
 
 <Note>
-  Sencho is currently in public beta on the path to v1.0. Core workflows are actively tested, but early users should review the [known limitations](https://github.com/studio-saelix/sencho/blob/main/KNOWN_LIMITATIONS.md) and avoid deploying it blindly on critical infrastructure without testing in their own environment first.
+  Sencho is used in production for day-to-day Docker Compose and fleet management. As a pre-1.0 project it still evolves quickly, so review the [known limitations](https://github.com/studio-saelix/sencho/blob/main/KNOWN_LIMITATIONS.md) and validate against your own setup before deploying it on critical infrastructure.
 </Note>
 
 ## The authentication stack


### PR DESCRIPTION
## Summary

- Sencho exits public beta after a clean v0.92.0 QA pass. The global "public beta on the path to v1.0" callout is replaced with scoped maturity language (used in production, still honestly pre-1.0, no blanket "stable" claim) across the README, KNOWN_LIMITATIONS, quickstart, troubleshooting, upgrade, and the security-architecture reference.
- The KNOWN_LIMITATIONS Scale section is reframed to credit QA, audit, and end-to-end validation while keeping the honest caveat that large-scale performance is not yet benchmarked. No invented numbers.
- New v0.92.0 capabilities folded into the README Capabilities section (Stacks / Observability / Security): Compose Doctor preflight checks, health-gated updates with stalled-update recovery, file move/rename in the explorer, ordered multi-file Compose for Git sources, the Security overview, on-demand node-wide scans, the Compose network inspector with an exposure-intent guard, scan policy packs, documentation-drift flags, and configurable image-update cadence with registry/source links.

## Test plan

- Prose review pass: markdown/MDX correctness, link integrity, tier-tag accuracy, and output hygiene all clean.
- Confirmed every newly added docs link resolves to an existing `docs/features/*` page.
- Verified no "public beta" / "path to v1.0" / "early users" phrasing remains in the repo outside the website.
- Tier tags verified against the gate code: all new features are Community except scan policy packs, which are paid.

## Notes

- Marketing-site feature updates land separately in the website repo; the site already carries no beta language, so nothing there needs the maturity-copy change.