### PR TITLE
chore(deps): bump bundled containerd to v2.2.5 to clear CVE-2026-53488/53489/53492

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -153,10 +153,13 @@ RUN cp vendor.mod go.mod && cp vendor.sum go.sum && \
 #
 # Compose v5.1.3 also pins github.com/containerd/containerd/v2 v2.2.3, which
 # carries CVE-2026-46680 (runAsNonRoot evasion in containerd's runtime
-# executor). The same go get step bumps containerd/v2 to v2.2.4 to clear it.
-# v2.2.3 to v2.2.4 is a patch-level fix; the release notes name CVE-2026-46680
-# as the headline item. The vulnerable code path is daemon-side and not reached
-# by compose at all, so this is defense-in-depth rather than a live exposure.
+# executor). v2.2.4 cleared that one, but a later containerd advisory cluster
+# (CVE-2026-53488, CVE-2026-53489, CVE-2026-53492, all CRI checkpoint/restore
+# and restart-monitor issues) affects v2.2.4 and is fixed in v2.2.5. The go get
+# step below bumps containerd/v2 to v2.2.5 to clear all four. These are
+# patch-level fixes with no breaking API changes. Every vulnerable code path is
+# daemon-side (containerd's CRI service) and is not reached by compose at all,
+# so this is defense-in-depth rather than a live exposure.
 # Base image pinned by digest (same image as cli-builder above) so both
 # source builds share an identical, immutable Go toolchain.
 FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine@sha256:f1ddd9fe14fffc091dd98cb4bfa999f32c5fc77d2f2305ea9f0e2595c5437c14 AS compose-builder
@@ -179,9 +182,9 @@ WORKDIR /src/docker-compose
 RUN mkdir -p /build
 
 # Patch otel/sdk and exporters from v1.42.0 → v1.43.0 to clear CVE-2026-39883
-# and CVE-2026-39882, and bump containerd/v2 from v2.2.3 → v2.2.4 to clear
-# CVE-2026-46680. Both are targeted patch-level security bumps with no
-# breaking API changes.
+# and CVE-2026-39882, and bump containerd/v2 from v2.2.3 → v2.2.5 to clear
+# CVE-2026-46680 plus the CVE-2026-53488 / 53489 / 53492 cluster. All are
+# targeted patch-level security bumps with no breaking API changes.
 RUN --mount=type=cache,id=go-mod,sharing=locked,target=/go/pkg/mod \
     go get go.opentelemetry.io/otel@v1.43.0 \
            go.opentelemetry.io/otel/sdk@v1.43.0 \
@@ -193,7 +196,7 @@ RUN --mount=type=cache,id=go-mod,sharing=locked,target=/go/pkg/mod \
            go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp@v1.43.0 \
            go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc@v1.43.0 \
            go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp@v1.43.0 \
-           github.com/containerd/containerd/v2@v2.2.4 && \
+           github.com/containerd/containerd/v2@v2.2.5 && \
     go mod tidy
 
 # Build target is ./cmd (the package main with plugin.Run), per docker/compose's


### PR DESCRIPTION
## Summary

A CI Trivy image scan started hard-failing because three newly published HIGH containerd advisories now affect the `github.com/containerd/containerd/v2` v2.2.4 that the `compose-builder` stage pins via `go get`:

- **CVE-2026-53488** — containerd CRI image-config `LABEL` flows to restart-monitor `binary://` logger (host-root command)
- **CVE-2026-53489** — arbitrary host CRI log file read via symlink following in CRI checkpoint
- **CVE-2026-53492** — CRI checkpoint restore CDI annotation smuggling

All three are fixed in containerd **v2.2.5** (and v2.3.2). This was vulnerability-database drift against a pinned dependency: an earlier build the same day passed and no image content changed, only Trivy's CVE feed advanced. It would fail any PR and a fresh `main` build, not just one branch.

## Change

- `Dockerfile` (compose-builder stage): bump `github.com/containerd/containerd/v2` from `v2.2.4` to `v2.2.5` in the existing `go get ... && go mod tidy` step.
- Update the two adjacent comment blocks to record the new CVE cluster and the v2.2.4 to v2.2.5 reason.

v2.2.5 is a published patch release (tagged 2026-06-18), confirmed on the Go module proxy. The bump is patch-level with no breaking API changes, consistent with the existing otel and prior containerd bumps in the same step.

## Test plan

- Docker Build & Scan ran green on this branch: the image build, the Trivy scan (HIGH/CRITICAL, exit-code 1, OpenVEX-aware), and the binary smoke test all pass. The three CVEs no longer appear in the bundled `docker-compose` binary's SBOM.
- The vulnerable code paths are daemon-side (containerd's CRI service) and are not reached by compose, so there is no runtime behavior change.

## Notes

Typed `chore(deps)` on purpose: this is a build-time bundled-dependency bump with no product behavior change, so it should not trigger a release-please version bump or land in the user-facing changelog (the repo's release config hides `chore`).

Surfaced while investigating a docs PR whose CI failed on this scan; the failure is repo-wide, so it is fixed here as its own change off `main` rather than bundled into unrelated work.
