### PR TITLE
feat(drift): add an opt-in background drift scanner

### DIFF
--- a/backend/src/__tests__/compose-service.test.ts
+++ b/backend/src/__tests__/compose-service.test.ts
@@ -118,6 +118,7 @@ vi.mock('../services/MeshService', () => ({
 }));
 
 import { ComposeService, getComposeRollbackInfo } from '../services/ComposeService';
+import { DriftLedgerService } from '../services/DriftLedgerService';
 
 const originalComposeTimeout = process.env.SENCHO_COMPOSE_COMMAND_TIMEOUT_MS;
 const originalStallTimeout = process.env.SENCHO_COMPOSE_STALL_TIMEOUT_MS;
@@ -619,6 +620,36 @@ describe('ComposeService - updateStack prune-on-update', () => {
 });
 
 // ── withRegistryAuth ───────────────────────────────────────────────────
+
+describe('ComposeService - drift reconcile hook', () => {
+  it('reconciles the drift ledger after a successful update', async () => {
+    setupAutoCloseSpawn();
+    mockListContainers.mockResolvedValue([]);
+    mockGetGlobalSettings.mockReturnValue({});
+    const spy = vi.spyOn(DriftLedgerService.getInstance(), 'reconcileStack').mockResolvedValue({ detected: 0, resolved: 0 });
+
+    const promise = ComposeService.getInstance(1).updateStack('my-stack');
+    await vi.advanceTimersByTimeAsync(3100);
+    await promise;
+
+    expect(spy).toHaveBeenCalledWith(1, 'my-stack');
+    spy.mockRestore();
+  });
+
+  it('reconciles the drift ledger after a successful deploy', async () => {
+    setupAutoCloseSpawn();
+    mockListContainers.mockResolvedValue([]);
+    mockGetGlobalSettings.mockReturnValue({});
+    const spy = vi.spyOn(DriftLedgerService.getInstance(), 'reconcileStack').mockResolvedValue({ detected: 0, resolved: 0 });
+
+    const promise = ComposeService.getInstance(1).deployStack('my-stack');
+    await vi.advanceTimersByTimeAsync(3100);
+    await promise;
+
+    expect(spy).toHaveBeenCalledWith(1, 'my-stack');
+    spy.mockRestore();
+  });
+});
 
 describe('ComposeService - withRegistryAuth', () => {
   it('passes default env when no registries configured', async () => {

--- a/backend/src/__tests__/compose-service.test.ts
+++ b/backend/src/__tests__/compose-service.test.ts
@@ -649,6 +649,18 @@ describe('ComposeService - drift reconcile hook', () => {
     expect(spy).toHaveBeenCalledWith(1, 'my-stack');
     spy.mockRestore();
   });
+
+  it('does not reconcile the ledger when a deploy fails', async () => {
+    setupAutoCloseSpawn(1); // non-zero exit => the deploy rejects before the post-success hook
+    mockListContainers.mockResolvedValue([]);
+    mockGetGlobalSettings.mockReturnValue({});
+    const spy = vi.spyOn(DriftLedgerService.getInstance(), 'reconcileStack').mockResolvedValue({ detected: 0, resolved: 0 });
+
+    const result = await ComposeService.getInstance(1).deployStack('my-stack').then(() => null, (e: Error) => e);
+    expect(result).toBeInstanceOf(Error);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
 });
 
 describe('ComposeService - withRegistryAuth', () => {

--- a/backend/src/__tests__/drift-ledger.test.ts
+++ b/backend/src/__tests__/drift-ledger.test.ts
@@ -228,6 +228,57 @@ describe('DriftLedgerService.reconcile', () => {
     expect(res).toEqual({ detected: 0, resolved: 0 });
     expect(db().getOpenDriftFindings(nodeId, 'rec')).toHaveLength(1);
   });
+
+  it('stamps the dossier last-checked time on every authoritative reconcile, including a no-op', () => {
+    expect(db().getStackDossier(nodeId, 'rec')?.last_drift_check_at ?? null).toBeNull();
+    ledger().reconcile(nodeId, 'rec', reportWith([finding('image-mismatch', 'web')], { stack: 'rec' }));
+    const first = db().getStackDossier(nodeId, 'rec')?.last_drift_check_at;
+    expect(typeof first).toBe('number');
+    // A repeat check that records nothing new still advances the last-checked stamp.
+    ledger().reconcile(nodeId, 'rec', reportWith([finding('image-mismatch', 'web')], { stack: 'rec' }));
+    const second = db().getStackDossier(nodeId, 'rec')?.last_drift_check_at;
+    expect(second as number).toBeGreaterThanOrEqual(first as number);
+  });
+
+  it('does not stamp last-checked for a non-authoritative (unreachable) report', () => {
+    ledger().reconcile(nodeId, 'rec', { stack: 'rec', status: 'unreachable', hasComposeFile: true, hasContainers: false, findings: [] });
+    expect(db().getStackDossier(nodeId, 'rec')?.last_drift_check_at ?? null).toBeNull();
+  });
+});
+
+describe('DriftLedgerService.reconcileStack', () => {
+  const STACK_A = 'recstacka';
+  let dirA: string;
+
+  const composeDir = () => process.env.COMPOSE_DIR as string;
+
+  // A running container on a different image than compose declares => image-mismatch.
+  const driftedContainer = (stack: string) => ({
+    id: `${stack}-c1`, name: `${stack}-web-1`, service: 'web', composeProject: stack, stack,
+    state: 'running', image: 'nginx:1.26', networks: [], volumes: [], ports: [],
+  });
+
+  beforeEach(() => {
+    clearLedger(STACK_A);
+    dirA = path.join(composeDir(), STACK_A);
+    fs.mkdirSync(dirA, { recursive: true });
+    fs.writeFileSync(path.join(dirA, 'compose.yaml'), 'services:\n  web:\n    image: nginx:1.27\n');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(dirA, { recursive: true, force: true });
+  });
+
+  it('reconcileStack builds the report, persists drift, and stamps last-checked', async () => {
+    vi.spyOn(DockerController, 'getInstance').mockReturnValue({
+      getDependencySnapshot: vi.fn().mockResolvedValue({ containers: [driftedContainer(STACK_A)], networks: [], volumes: [] }),
+    } as unknown as DockerController);
+    const res = await DriftLedgerService.getInstance().reconcileStack(nodeId, STACK_A);
+    expect(res).toEqual({ detected: 1, resolved: 0 });
+    expect(db().getOpenDriftFindings(nodeId, STACK_A)).toHaveLength(1);
+    expect(typeof db().getStackDossier(nodeId, STACK_A)?.last_drift_check_at).toBe('number');
+  });
 });
 
 describe('DriftLedgerService.recordBaseline', () => {
@@ -286,6 +337,8 @@ describe('drift route (GET read-only, POST recheck persists)', () => {
     // A passive read must not persist anything.
     expect(db().getOpenDriftFindings(nodeId, STACK)).toHaveLength(0);
     expect(driftActivity(STACK)).toHaveLength(0);
+    // Never reconciled, so the history has no "as of" time.
+    expect(res.body.lastCheckedAt).toBeNull();
   });
 
   it('POST recheck persists the current drift and returns temporal + ledger', async () => {
@@ -297,6 +350,8 @@ describe('drift route (GET read-only, POST recheck persists)', () => {
     expect(Array.isArray(res.body.ledger)).toBe(true);
     expect(res.body.ledger).toHaveLength(1);
     expect(res.body.ledger[0]).toMatchObject({ service: 'web', kind: 'image-mismatch', resolvedAt: null });
+    // The recheck reconciled, so the history carries an "as of" timestamp.
+    expect(typeof res.body.lastCheckedAt).toBe('number');
 
     // The transition was recorded exactly once in the activity timeline.
     const acts = driftActivity(STACK);

--- a/backend/src/__tests__/drift-ledger.test.ts
+++ b/backend/src/__tests__/drift-ledger.test.ts
@@ -246,9 +246,11 @@ describe('DriftLedgerService.reconcile', () => {
   });
 });
 
-describe('DriftLedgerService.reconcileStack', () => {
+describe('DriftLedgerService.reconcileStack / reconcileNode', () => {
   const STACK_A = 'recstacka';
+  const STACK_B = 'recstackb';
   let dirA: string;
+  let dirB: string;
 
   const composeDir = () => process.env.COMPOSE_DIR as string;
 
@@ -260,14 +262,19 @@ describe('DriftLedgerService.reconcileStack', () => {
 
   beforeEach(() => {
     clearLedger(STACK_A);
+    clearLedger(STACK_B);
     dirA = path.join(composeDir(), STACK_A);
-    fs.mkdirSync(dirA, { recursive: true });
-    fs.writeFileSync(path.join(dirA, 'compose.yaml'), 'services:\n  web:\n    image: nginx:1.27\n');
+    dirB = path.join(composeDir(), STACK_B);
+    for (const d of [dirA, dirB]) {
+      fs.mkdirSync(d, { recursive: true });
+      fs.writeFileSync(path.join(d, 'compose.yaml'), 'services:\n  web:\n    image: nginx:1.27\n');
+    }
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     fs.rmSync(dirA, { recursive: true, force: true });
+    fs.rmSync(dirB, { recursive: true, force: true });
   });
 
   it('reconcileStack builds the report, persists drift, and stamps last-checked', async () => {
@@ -278,6 +285,47 @@ describe('DriftLedgerService.reconcileStack', () => {
     expect(res).toEqual({ detected: 1, resolved: 0 });
     expect(db().getOpenDriftFindings(nodeId, STACK_A)).toHaveLength(1);
     expect(typeof db().getStackDossier(nodeId, STACK_A)?.last_drift_check_at).toBe('number');
+  });
+
+  it('reconcileNode reconciles every stack against a single shared snapshot', async () => {
+    const getSnap = vi.fn().mockResolvedValue({
+      containers: [driftedContainer(STACK_A), driftedContainer(STACK_B)], networks: [], volumes: [],
+    });
+    vi.spyOn(DockerController, 'getInstance').mockReturnValue({ getDependencySnapshot: getSnap } as unknown as DockerController);
+    const res = await DriftLedgerService.getInstance().reconcileNode(nodeId);
+    expect(getSnap).toHaveBeenCalledTimes(1); // one snapshot for the whole node, not one per stack
+    expect(res.detected).toBe(2);
+    expect(db().getOpenDriftFindings(nodeId, STACK_A)).toHaveLength(1);
+    expect(db().getOpenDriftFindings(nodeId, STACK_B)).toHaveLength(1);
+  });
+
+  it('reconcileNode logs and skips a stack that fails mid-scan, still scanning the rest', async () => {
+    // Make STACK_B unreadable (no compose file); STACK_A stays valid and drifted.
+    fs.rmSync(path.join(dirB, 'compose.yaml'), { force: true });
+    vi.spyOn(DockerController, 'getInstance').mockReturnValue({
+      getDependencySnapshot: vi.fn().mockResolvedValue({ containers: [driftedContainer(STACK_A)], networks: [], volumes: [] }),
+    } as unknown as DockerController);
+    const res = await DriftLedgerService.getInstance().reconcileNode(nodeId);
+    // STACK_A scanned and recorded; STACK_B failed and is excluded, the scan continued.
+    expect(db().getOpenDriftFindings(nodeId, STACK_A)).toHaveLength(1);
+    expect(db().getOpenDriftFindings(nodeId, STACK_B)).toHaveLength(0);
+    expect(res.detected).toBe(1);
+  });
+
+  it('reconcileNode skips the whole node when Docker is unreachable (open findings are not falsely resolved)', async () => {
+    vi.spyOn(DockerController, 'getInstance').mockReturnValue({
+      getDependencySnapshot: vi.fn().mockResolvedValue({ containers: [driftedContainer(STACK_A)], networks: [], volumes: [] }),
+    } as unknown as DockerController);
+    await DriftLedgerService.getInstance().reconcileStack(nodeId, STACK_A);
+    expect(db().getOpenDriftFindings(nodeId, STACK_A)).toHaveLength(1);
+
+    vi.restoreAllMocks();
+    vi.spyOn(DockerController, 'getInstance').mockReturnValue({
+      getDependencySnapshot: vi.fn().mockRejectedValue(new Error('docker down')),
+    } as unknown as DockerController);
+    const res = await DriftLedgerService.getInstance().reconcileNode(nodeId);
+    expect(res).toEqual({ stacks: 0, detected: 0, resolved: 0 });
+    expect(db().getOpenDriftFindings(nodeId, STACK_A)).toHaveLength(1);
   });
 });
 

--- a/backend/src/__tests__/drift-scan-service.test.ts
+++ b/backend/src/__tests__/drift-scan-service.test.ts
@@ -1,0 +1,91 @@
+/**
+ * DriftScanService: the opt-in background scanner that periodically reconciles
+ * every local stack. These tests drive tick() directly (not the timer) and stub
+ * reconcileNode, so they assert the gating and due-interval logic without touching
+ * Docker: off => no scan, on+due => one reconcile per local node, and a second
+ * tick inside the interval is skipped.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+import { setupTestDb, cleanupTestDb } from './helpers/setupTestDb';
+
+let tmpDir: string;
+let DatabaseService: typeof import('../services/DatabaseService').DatabaseService;
+let DriftLedgerService: typeof import('../services/DriftLedgerService').DriftLedgerService;
+let DriftScanService: typeof import('../services/DriftScanService').DriftScanService;
+
+beforeAll(async () => {
+  tmpDir = await setupTestDb();
+  ({ DatabaseService } = await import('../services/DatabaseService'));
+  ({ DriftLedgerService } = await import('../services/DriftLedgerService'));
+  ({ DriftScanService } = await import('../services/DriftScanService'));
+});
+
+afterAll(() => cleanupTestDb(tmpDir));
+
+function db() {
+  return DatabaseService.getInstance();
+}
+
+function localNodeCount(): number {
+  return db().getNodes().filter(n => n.type === 'local').length;
+}
+
+describe('DriftScanService', () => {
+  beforeEach(() => {
+    // Reset the singleton so each test starts with lastScanAt = 0 (a scan is due).
+    (DriftScanService as unknown as { instance: unknown }).instance = null;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    db().updateGlobalSetting('drift_scan_enabled', '0');
+    db().updateGlobalSetting('drift_scan_interval_minutes', '60');
+  });
+
+  it('does not scan when drift_scan_enabled is off', async () => {
+    db().updateGlobalSetting('drift_scan_enabled', '0');
+    const spy = vi.spyOn(DriftLedgerService.getInstance(), 'reconcileNode').mockResolvedValue({ stacks: 0, detected: 0, resolved: 0 });
+    await DriftScanService.getInstance().tick();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('reconciles every local node when enabled and a scan is due', async () => {
+    db().updateGlobalSetting('drift_scan_enabled', '1');
+    db().updateGlobalSetting('drift_scan_interval_minutes', '60');
+    const spy = vi.spyOn(DriftLedgerService.getInstance(), 'reconcileNode').mockResolvedValue({ stacks: 0, detected: 0, resolved: 0 });
+    await DriftScanService.getInstance().tick();
+    const locals = db().getNodes().filter(n => n.type === 'local');
+    expect(locals.length).toBeGreaterThan(0);
+    expect(spy).toHaveBeenCalledTimes(locals.length);
+    for (const n of locals) expect(spy).toHaveBeenCalledWith(n.id);
+  });
+
+  it('reconciles local nodes only, never a remote node', async () => {
+    db().updateGlobalSetting('drift_scan_enabled', '1');
+    db().updateGlobalSetting('drift_scan_interval_minutes', '60');
+    const remoteId = db().getDb().prepare(
+      "INSERT INTO nodes (name, type, compose_dir, is_default, status, created_at) VALUES ('remote-scan-x', 'remote', '', 0, 'online', ?)"
+    ).run(Date.now()).lastInsertRowid as number;
+    const spy = vi.spyOn(DriftLedgerService.getInstance(), 'reconcileNode').mockResolvedValue({ stacks: 0, detected: 0, resolved: 0 });
+    try {
+      await DriftScanService.getInstance().tick();
+      const localIds = db().getNodes().filter(n => n.type === 'local').map(n => n.id);
+      expect(localIds.length).toBeGreaterThan(0);
+      for (const id of localIds) expect(spy).toHaveBeenCalledWith(id);
+      // A remote node runs its own Sencho instance and scans itself.
+      expect(spy).not.toHaveBeenCalledWith(remoteId);
+    } finally {
+      db().getDb().prepare('DELETE FROM nodes WHERE id = ?').run(remoteId);
+    }
+  });
+
+  it('skips a second tick that fires before the interval elapses', async () => {
+    db().updateGlobalSetting('drift_scan_enabled', '1');
+    db().updateGlobalSetting('drift_scan_interval_minutes', '60');
+    const spy = vi.spyOn(DriftLedgerService.getInstance(), 'reconcileNode').mockResolvedValue({ stacks: 0, detected: 0, resolved: 0 });
+    const svc = DriftScanService.getInstance();
+    await svc.tick(); // due (lastScanAt = 0) => scans
+    await svc.tick(); // within the 60-minute interval => skipped
+    expect(spy).toHaveBeenCalledTimes(localNodeCount()); // not doubled
+  });
+});

--- a/backend/src/__tests__/drift-scan-service.test.ts
+++ b/backend/src/__tests__/drift-scan-service.test.ts
@@ -88,4 +88,33 @@ describe('DriftScanService', () => {
     await svc.tick(); // within the 60-minute interval => skipped
     expect(spy).toHaveBeenCalledTimes(localNodeCount()); // not doubled
   });
+
+  it('drops a tick that fires while a scan is already running', async () => {
+    db().updateGlobalSetting('drift_scan_enabled', '1');
+    db().updateGlobalSetting('drift_scan_interval_minutes', '60');
+    let release!: () => void;
+    const gate = new Promise<void>(r => { release = r; });
+    const spy = vi.spyOn(DriftLedgerService.getInstance(), 'reconcileNode').mockImplementation(async () => {
+      await gate; // hold the scan open so a second tick overlaps it
+      return { stacks: 0, detected: 0, resolved: 0 };
+    });
+    const svc = DriftScanService.getInstance();
+    const first = svc.tick();      // starts a scan and suspends on the gate (isScanning is now true)
+    await Promise.resolve();
+    await svc.tick();              // fires mid-scan => dropped by the isScanning guard
+    release();
+    await first;
+    expect(spy).toHaveBeenCalledTimes(localNodeCount()); // only the first tick scanned
+  });
+
+  it('falls back to the default interval for an out-of-range or malformed stored value', () => {
+    const svc = DriftScanService.getInstance() as unknown as { intervalMs(): number };
+    const defaultMs = 60 * 60_000;
+    db().updateGlobalSetting('drift_scan_interval_minutes', '99999'); // above the 1440 cap
+    expect(svc.intervalMs()).toBe(defaultMs);
+    db().updateGlobalSetting('drift_scan_interval_minutes', '5'); // below the 15 floor
+    expect(svc.intervalMs()).toBe(defaultMs);
+    db().updateGlobalSetting('drift_scan_interval_minutes', 'banana'); // not a number
+    expect(svc.intervalMs()).toBe(defaultMs);
+  });
 });

--- a/backend/src/__tests__/settings-routes.test.ts
+++ b/backend/src/__tests__/settings-routes.test.ts
@@ -241,6 +241,60 @@ describe('prune_on_update (auto-prune after updates)', () => {
   });
 });
 
+describe('drift detection scan settings', () => {
+  it('seeds off with a 60 minute interval in a fresh database', () => {
+    const s = DatabaseService.getInstance().getGlobalSettings();
+    expect(s.drift_scan_enabled).toBe('0');
+    expect(s.drift_scan_interval_minutes).toBe('60');
+  });
+
+  it('exposes both keys through the settings GET projection', async () => {
+    const res = await request(app).get('/api/settings').set('Cookie', adminCookie);
+    expect(res.body.drift_scan_enabled).toBeDefined();
+    expect(res.body.drift_scan_interval_minutes).toBeDefined();
+  });
+
+  it('accepts a well-formed enable + interval write and persists it', async () => {
+    const res = await request(app)
+      .patch('/api/settings')
+      .set('Cookie', adminCookie)
+      .send({ drift_scan_enabled: '1', drift_scan_interval_minutes: '120' });
+    expect(res.status).toBe(200);
+    const s = DatabaseService.getInstance().getGlobalSettings();
+    expect(s.drift_scan_enabled).toBe('1');
+    expect(s.drift_scan_interval_minutes).toBe('120');
+    // Restore the shipped defaults so later suites observe seeded behavior.
+    DatabaseService.getInstance().updateGlobalSetting('drift_scan_enabled', '0');
+    DatabaseService.getInstance().updateGlobalSetting('drift_scan_interval_minutes', '60');
+  });
+
+  it('rejects a non-enum drift_scan_enabled value (400) and does not write it', async () => {
+    const res = await request(app)
+      .post('/api/settings')
+      .set('Cookie', adminCookie)
+      .send({ key: 'drift_scan_enabled', value: 'maybe' });
+    expect(res.status).toBe(400);
+    expect(DatabaseService.getInstance().getGlobalSettings().drift_scan_enabled).not.toBe('maybe');
+  });
+
+  it('rejects an out-of-range interval below the 15 minute floor (400)', async () => {
+    const res = await request(app)
+      .post('/api/settings')
+      .set('Cookie', adminCookie)
+      .send({ key: 'drift_scan_interval_minutes', value: '5' });
+    expect(res.status).toBe(400);
+    expect(DatabaseService.getInstance().getGlobalSettings().drift_scan_interval_minutes).not.toBe('5');
+  });
+
+  it('rejects a non-admin write (403)', async () => {
+    const res = await request(app)
+      .post('/api/settings')
+      .set('Cookie', viewerCookie)
+      .send({ key: 'drift_scan_enabled', value: '1' });
+    expect(res.status).toBe(403);
+  });
+});
+
 describe('health gate settings', () => {
   it('seeds enabled with a 90 second window in a fresh database', () => {
     const settings = DatabaseService.getInstance().getGlobalSettings();

--- a/backend/src/__tests__/settings-routes.test.ts
+++ b/backend/src/__tests__/settings-routes.test.ts
@@ -286,6 +286,15 @@ describe('drift detection scan settings', () => {
     expect(DatabaseService.getInstance().getGlobalSettings().drift_scan_interval_minutes).not.toBe('5');
   });
 
+  it('rejects an out-of-range interval above the 1440 minute cap (400)', async () => {
+    const res = await request(app)
+      .post('/api/settings')
+      .set('Cookie', adminCookie)
+      .send({ key: 'drift_scan_interval_minutes', value: '99999' });
+    expect(res.status).toBe(400);
+    expect(DatabaseService.getInstance().getGlobalSettings().drift_scan_interval_minutes).not.toBe('99999');
+  });
+
   it('rejects a non-admin write (403)', async () => {
     const res = await request(app)
       .post('/api/settings')

--- a/backend/src/bootstrap/shutdown.ts
+++ b/backend/src/bootstrap/shutdown.ts
@@ -3,6 +3,7 @@ import { DatabaseService } from '../services/DatabaseService';
 import { LicenseService } from '../services/LicenseService';
 import { MonitorService } from '../services/MonitorService';
 import { AutoHealService } from '../services/AutoHealService';
+import { DriftScanService } from '../services/DriftScanService';
 import { HealthGateService } from '../services/HealthGateService';
 import { FleetSyncRetryService } from '../services/FleetSyncRetryService';
 import { DockerEventManager } from '../services/DockerEventManager';
@@ -32,6 +33,7 @@ export function installShutdownHandlers(server: Server): void {
         console.warn('[Shutdown] MonitorService cleanup failed:', (e as Error).message);
       }
       try { AutoHealService.getInstance().stop(); } catch (e) { console.warn('[Shutdown] AutoHealService cleanup failed:', (e as Error).message); }
+      try { DriftScanService.getInstance().stop(); } catch (e) { console.warn('[Shutdown] DriftScanService cleanup failed:', (e as Error).message); }
       try { HealthGateService.getInstance().stop(); } catch (e) { console.warn('[Shutdown] HealthGateService cleanup failed:', (e as Error).message); }
       try { FleetSyncRetryService.getInstance().stop(); } catch (e) { console.warn('[Shutdown] FleetSyncRetryService cleanup failed:', (e as Error).message); }
       try { DockerEventManager.getInstance().stop(); } catch (e) {

--- a/backend/src/bootstrap/startup.ts
+++ b/backend/src/bootstrap/startup.ts
@@ -9,6 +9,7 @@ import SelfUpdateService from '../services/SelfUpdateService';
 import SelfIdentityService from '../services/SelfIdentityService';
 import { MonitorService } from '../services/MonitorService';
 import { AutoHealService } from '../services/AutoHealService';
+import { DriftScanService } from '../services/DriftScanService';
 import { HealthGateService } from '../services/HealthGateService';
 import { FleetSyncRetryService } from '../services/FleetSyncRetryService';
 import { DockerEventManager } from '../services/DockerEventManager';
@@ -119,6 +120,7 @@ export async function startServer(server: Server): Promise<void> {
   // safely run alongside the async initializers below.
   MonitorService.getInstance().start();
   AutoHealService.getInstance().start();
+  DriftScanService.getInstance().start();
   HealthGateService.getInstance().start();
   FleetSyncRetryService.getInstance().start();
   ImageUpdateService.getInstance().start();

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -30,6 +30,8 @@ const ALLOWED_SETTING_KEYS = new Set([
   'health_gate_enabled',
   'health_gate_window_seconds',
   'env_block_deploy_on_missing_required',
+  'drift_scan_enabled',
+  'drift_scan_interval_minutes',
 ]);
 
 // Keys whose write requires a paid license, not just an admin role.
@@ -58,6 +60,8 @@ const SettingsPatchSchema = z.object({
   health_gate_enabled: z.enum(['0', '1']),
   health_gate_window_seconds: z.coerce.number().int().min(15).max(600).transform(String),
   env_block_deploy_on_missing_required: z.enum(['0', '1']),
+  drift_scan_enabled: z.enum(['0', '1']),
+  drift_scan_interval_minutes: z.coerce.number().int().min(15).max(1440).transform(String),
 }).partial();
 
 export const settingsRouter = Router();

--- a/backend/src/routes/stacks.ts
+++ b/backend/src/routes/stacks.ts
@@ -990,7 +990,7 @@ async function buildDriftPayload(
   nodeId: number,
   stackName: string,
   reconcile: boolean,
-): Promise<StackDriftReport & { temporal: DriftTemporal; ledger: DriftLedgerEntry[] }> {
+): Promise<StackDriftReport & { temporal: DriftTemporal; ledger: DriftLedgerEntry[]; lastCheckedAt: number | null }> {
   const report = await buildStackDriftReport(nodeId, stackName);
   // Only the on-disk read is best-effort: an unreadable compose is already surfaced
   // by the report as a parse error, so temporal degrades to neutral. computeTemporal
@@ -1012,7 +1012,11 @@ async function buildDriftPayload(
   const ledger: DriftLedgerEntry[] = DatabaseService.getInstance()
     .getRecentDriftFindings(nodeId, stackName, 20)
     .map(r => ({ service: r.service, kind: r.finding_type as DriftFindingKind, message: r.message, detectedAt: r.detected_at, resolvedAt: r.resolved_at }));
-  return { ...report, temporal, ledger };
+  // The ledger reflects the last reconcile (re-check, deploy, or background scan),
+  // not this passive read, so surface when that was: the Drift tab labels the history
+  // "checked {time ago}" and a stale finding reads as history, not current truth.
+  const lastCheckedAt = DatabaseService.getInstance().getStackDossier(nodeId, stackName)?.last_drift_check_at ?? null;
+  return { ...report, temporal, ledger, lastCheckedAt };
 }
 
 stacksRouter.get('/:stackName/drift', async (req: Request, res: Response) => {

--- a/backend/src/services/ComposeService.ts
+++ b/backend/src/services/ComposeService.ts
@@ -455,6 +455,13 @@ export class ComposeService {
     // route: bulk, Git-source, App Store, scheduler, and webhook deploys all funnel
     // through this method. Internally guarded; awaited so it cannot race later work.
     await DriftLedgerService.getInstance().recordBaseline(this.nodeId, stackName);
+    // Reconcile the ledger against the just-deployed runtime: findings this deploy
+    // fixed are resolved and any it left are recorded (and surfaced in the activity
+    // feed) now, instead of waiting for someone to open the Drift tab. The rollback
+    // route re-deploys through this method, so it is covered; a failed atomic deploy
+    // instead restores the previous files and throws above, so that recovery path
+    // reconciles on its next deploy or scan, not here. Best-effort internally.
+    await DriftLedgerService.getInstance().reconcileStack(this.nodeId, stackName);
   }
 
   streamLogs(stackName: string, ws: WebSocket) {
@@ -652,8 +659,10 @@ export class ComposeService {
       throw updateError;
     }
     // Reached only on a successful update; re-baseline so temporal drift compares
-    // against what is now deployed (see deployStack for why this lives here).
+    // against what is now deployed (see deployStack for why this lives here), then
+    // reconcile the ledger against the updated runtime.
     await DriftLedgerService.getInstance().recordBaseline(this.nodeId, stackName);
+    await DriftLedgerService.getInstance().reconcileStack(this.nodeId, stackName);
   }
 
   public async downStack(stackName: string): Promise<void> {

--- a/backend/src/services/DatabaseService.ts
+++ b/backend/src/services/DatabaseService.ts
@@ -90,6 +90,8 @@ export interface StackDossier extends StackDossierFields {
     source_hash?: string | null;
     /** SHA-256 of the parsed compose model at the last deploy (ignores comments/whitespace). */
     rendered_hash?: string | null;
+    /** When the drift ledger was last reconciled for this stack (re-check, deploy, or background scan); null if never. */
+    last_drift_check_at?: number | null;
     created_at: number;
     updated_at: number;
 }
@@ -1284,6 +1286,7 @@ export class DatabaseService {
         custom_notes TEXT NOT NULL DEFAULT '',
         created_at INTEGER NOT NULL,
         updated_at INTEGER NOT NULL,
+        last_drift_check_at INTEGER,
         UNIQUE(node_id, stack_name)
       );
 
@@ -1669,6 +1672,7 @@ export class DatabaseService {
     private migrateStackDossierHashes(): void {
         this.tryAddColumn('stack_dossiers', 'source_hash', 'TEXT');
         this.tryAddColumn('stack_dossiers', 'rendered_hash', 'TEXT');
+        this.tryAddColumn('stack_dossiers', 'last_drift_check_at', 'INTEGER');
     }
 
     private migrateGitSourceMultiFile(): void {
@@ -2336,6 +2340,22 @@ export class DatabaseService {
                 source_hash = excluded.source_hash,
                 rendered_hash = excluded.rendered_hash`
         ).run(nodeId, stackName, sourceHash, renderedHash, now, now);
+    }
+
+    /**
+     * Stamp when the drift ledger was last reconciled for a stack (re-check, deploy,
+     * or background scan). Mirrors setStackDossierHashes: creates a notes-empty row
+     * if none exists, otherwise updates only this column so operator notes and their
+     * updated_at are left untouched.
+     */
+    public setStackDossierDriftCheck(nodeId: number, stackName: string, checkedAt: number): void {
+        const now = Date.now();
+        this.db.prepare(
+            `INSERT INTO stack_dossiers (node_id, stack_name, last_drift_check_at, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?)
+             ON CONFLICT(node_id, stack_name) DO UPDATE SET
+                last_drift_check_at = excluded.last_drift_check_at`
+        ).run(nodeId, stackName, checkedAt, now, now);
     }
 
     // --- Stack Drift Findings (the persisted drift ledger) ---

--- a/backend/src/services/DatabaseService.ts
+++ b/backend/src/services/DatabaseService.ts
@@ -1497,6 +1497,8 @@ export class DatabaseService {
         stmt.run('health_gate_window_seconds', '90');
         stmt.run('image_update_check_interval_minutes', '120');
         stmt.run('env_block_deploy_on_missing_required', '0');
+        stmt.run('drift_scan_enabled', '0');
+        stmt.run('drift_scan_interval_minutes', '60');
 
         // Seed the default local node if none exists
         const nodeCount = (this.db.prepare('SELECT COUNT(*) as count FROM nodes').get() as any)?.count || 0;

--- a/backend/src/services/DriftLedgerService.ts
+++ b/backend/src/services/DriftLedgerService.ts
@@ -1,12 +1,14 @@
 import { DatabaseService } from './DatabaseService';
 import type { StackDriftFindingRow } from './DatabaseService';
 import { FileSystemService } from './FileSystemService';
+import DockerController from './DockerController';
+import type { DependencySnapshot } from './DockerController';
 import { parseComposeDependencies } from '../helpers/composeDependencyParse';
 import type { DeclaredCompose } from '../helpers/composeDependencyParse';
 import { sha256Hex } from '../utils/hashing';
 import { sanitizeForLog } from '../utils/safeLog';
 import { getErrorMessage } from '../utils/errors';
-import { buildStackDriftReport } from './DriftDetectionService';
+import { assembleStackDrift, buildStackDriftReport } from './DriftDetectionService';
 import type { StackDriftReport, StackDriftFinding } from './DriftDetectionService';
 
 /**
@@ -31,6 +33,13 @@ export interface DriftTemporal {
 export interface DriftReconcileResult {
     detected: number;
     resolved: number;
+}
+
+/** A whole-node reconcile outcome: a stack result plus the number of stacks
+ *  scanned cleanly. A stack that throws mid-scan is logged and excluded from the
+ *  count, and the scan continues with the rest. */
+export interface DriftNodeReconcileResult extends DriftReconcileResult {
+    stacks: number;
 }
 
 /** Stable identity for a finding across checks: same service + kind is the same finding. */
@@ -194,6 +203,48 @@ export class DriftLedgerService {
             console.error('[DriftLedger] reconcileStack failed for %s:', sanitizeForLog(stackName), sanitizeForLog(getErrorMessage(error, 'unknown')));
             return { detected: 0, resolved: 0 };
         }
+    }
+
+    /**
+     * Reconcile every stack on a node against a single Docker snapshot. The
+     * background scanner drives this so drift is recorded (and its activity
+     * surfaced) without an operator opening each Drift tab. One snapshot is shared
+     * across all stacks to keep a full-node scan cheap. A Docker-unreachable node is
+     * skipped wholesale rather than falsely resolving open findings; a single stack
+     * failing (unreadable compose, etc.) is logged and the scan moves on.
+     */
+    async reconcileNode(nodeId: number): Promise<DriftNodeReconcileResult> {
+        const fs = FileSystemService.getInstance(nodeId);
+        let stacks: string[];
+        try {
+            stacks = await fs.getStacks();
+        } catch (error) {
+            console.error('[DriftLedger] reconcileNode: failed to list stacks on node %d:', nodeId, sanitizeForLog(getErrorMessage(error, 'unknown')));
+            return { stacks: 0, detected: 0, resolved: 0 };
+        }
+        let snapshot: DependencySnapshot;
+        try {
+            snapshot = await DockerController.getInstance(nodeId).getDependencySnapshot(stacks);
+        } catch (error) {
+            console.warn('[DriftLedger] reconcileNode: snapshot unavailable on node %d; scan skipped:', nodeId, sanitizeForLog(getErrorMessage(error, 'unknown')));
+            return { stacks: 0, detected: 0, resolved: 0 };
+        }
+        let detected = 0, resolved = 0, scanned = 0;
+        for (const stackName of stacks) {
+            try {
+                const content = await fs.getStackContent(stackName);
+                const declared = parseComposeDependencies(content);
+                const containers = snapshot.containers.filter(c => c.stack === stackName);
+                const report = assembleStackDrift({ stack: stackName, declared, containers, networks: snapshot.networks, parseError: declared.parseError });
+                const r = this.reconcile(nodeId, stackName, report);
+                detected += r.detected;
+                resolved += r.resolved;
+                scanned += 1;
+            } catch (error) {
+                console.error('[DriftLedger] reconcileNode: failed for stack %s:', sanitizeForLog(stackName), sanitizeForLog(getErrorMessage(error, 'unknown')));
+            }
+        }
+        return { stacks: scanned, detected, resolved };
     }
 
     /**

--- a/backend/src/services/DriftLedgerService.ts
+++ b/backend/src/services/DriftLedgerService.ts
@@ -6,6 +6,7 @@ import type { DeclaredCompose } from '../helpers/composeDependencyParse';
 import { sha256Hex } from '../utils/hashing';
 import { sanitizeForLog } from '../utils/safeLog';
 import { getErrorMessage } from '../utils/errors';
+import { buildStackDriftReport } from './DriftDetectionService';
 import type { StackDriftReport, StackDriftFinding } from './DriftDetectionService';
 
 /**
@@ -130,6 +131,11 @@ export class DriftLedgerService {
             return { detected: 0, resolved: 0 };
         }
         const db = DatabaseService.getInstance();
+        const now = Date.now();
+        // Stamp every authoritative check (even a no-op that records nothing) so the
+        // Drift tab can show "checked {time ago}"; a stale finding then reads as
+        // history rather than as the current truth it can no longer guarantee.
+        db.setStackDossierDriftCheck(nodeId, stackName, now);
         const openByKey = new Map(db.getOpenDriftFindings(nodeId, stackName).map(r => [findingKey(r.service, r.finding_type), r]));
         const currentByKey = new Map(report.findings.map(f => [findingKey(f.service, f.kind), f]));
 
@@ -145,7 +151,6 @@ export class DriftLedgerService {
             return { detected: 0, resolved: 0 };
         }
 
-        const now = Date.now();
         db.getDb().transaction(() => {
             for (const f of toInsert) {
                 db.insertDriftFinding({
@@ -174,6 +179,23 @@ export class DriftLedgerService {
                 `Drift resolved on ${stackName}: ${toResolve.length} finding${toResolve.length === 1 ? '' : 's'} cleared`, now);
         }
         return { detected: toInsert.length, resolved: toResolve.length };
+    }
+
+    /**
+     * Build the spatial report for one stack and reconcile it into the ledger.
+     * Used by the deploy and update success hooks (and the rollback route, which
+     * re-deploys through deployStack) so a change resolves the findings it fixed and
+     * records what it left behind. Best-effort: a build or reconcile failure is
+     * logged and swallowed so it never fails the deploy that triggered it.
+     */
+    async reconcileStack(nodeId: number, stackName: string): Promise<DriftReconcileResult> {
+        try {
+            const report = await buildStackDriftReport(nodeId, stackName);
+            return this.reconcile(nodeId, stackName, report);
+        } catch (error) {
+            console.error('[DriftLedger] reconcileStack failed for %s:', sanitizeForLog(stackName), sanitizeForLog(getErrorMessage(error, 'unknown')));
+            return { detected: 0, resolved: 0 };
+        }
     }
 
     /**

--- a/backend/src/services/DriftLedgerService.ts
+++ b/backend/src/services/DriftLedgerService.ts
@@ -132,10 +132,6 @@ export class DriftLedgerService {
         }
         const db = DatabaseService.getInstance();
         const now = Date.now();
-        // Stamp every authoritative check (even a no-op that records nothing) so the
-        // Drift tab can show "checked {time ago}"; a stale finding then reads as
-        // history rather than as the current truth it can no longer guarantee.
-        db.setStackDossierDriftCheck(nodeId, stackName, now);
         const openByKey = new Map(db.getOpenDriftFindings(nodeId, stackName).map(r => [findingKey(r.service, r.finding_type), r]));
         const currentByKey = new Map(report.findings.map(f => [findingKey(f.service, f.kind), f]));
 
@@ -147,11 +143,13 @@ export class DriftLedgerService {
         for (const [key, row] of openByKey) {
             if (!currentByKey.has(key)) toResolve.push(row);
         }
-        if (toInsert.length === 0 && toResolve.length === 0) {
-            return { detected: 0, resolved: 0 };
-        }
-
+        // Stamp the check time and apply any transitions in one transaction, so the
+        // "checked {time ago}" the Drift tab shows can never persist without the ledger
+        // update it describes. The stamp runs even on a no-op authoritative check (no
+        // transitions), so the history's "as of" stays honest while a stale finding
+        // reads as history rather than as live truth.
         db.getDb().transaction(() => {
+            db.setStackDossierDriftCheck(nodeId, stackName, now);
             for (const f of toInsert) {
                 db.insertDriftFinding({
                     node_id: nodeId,

--- a/backend/src/services/DriftScanService.ts
+++ b/backend/src/services/DriftScanService.ts
@@ -24,6 +24,7 @@ const BASE_TICK_MS = 60_000;          // re-read settings and check whether a sc
 const INITIAL_DELAY_MS = 45_000;      // let Docker and the node registry settle before the first scan
 const DEFAULT_INTERVAL_MINUTES = 60;
 const MIN_INTERVAL_MINUTES = 15;
+const MAX_INTERVAL_MINUTES = 1440; // matches the settings-route Zod cap; an over-cap or corrupted DB value falls back to the default rather than deferring scans indefinitely
 
 export class DriftScanService {
     private static instance: DriftScanService;
@@ -70,7 +71,7 @@ export class DriftScanService {
     private intervalMs(): number {
         try {
             const raw = Number(DatabaseService.getInstance().getGlobalSettings()['drift_scan_interval_minutes']);
-            const minutes = Number.isFinite(raw) && raw >= MIN_INTERVAL_MINUTES ? raw : DEFAULT_INTERVAL_MINUTES;
+            const minutes = Number.isFinite(raw) && raw >= MIN_INTERVAL_MINUTES && raw <= MAX_INTERVAL_MINUTES ? raw : DEFAULT_INTERVAL_MINUTES;
             return minutes * 60_000;
         } catch {
             return DEFAULT_INTERVAL_MINUTES * 60_000;

--- a/backend/src/services/DriftScanService.ts
+++ b/backend/src/services/DriftScanService.ts
@@ -1,0 +1,107 @@
+import { DatabaseService } from './DatabaseService';
+import { DriftLedgerService } from './DriftLedgerService';
+import { isDebugEnabled } from '../utils/debug';
+import { getErrorMessage } from '../utils/errors';
+
+/**
+ * Opt-in background drift scanner. The drift ledger (DriftLedgerService) only
+ * advances when something reconciles a stack: a manual re-check or a deploy. With
+ * neither, the persisted history and its activity entries never move, so the Drift
+ * tab can show live drift the history never recorded. This service closes that gap:
+ * when enabled, it periodically reconciles every stack on each local node (one
+ * reconcileNode call per node) so drift is recorded and surfaced in the activity
+ * feed without an operator opening each Drift tab.
+ *
+ * Local nodes only: a remote node runs its own Sencho instance and scans itself.
+ * Off by default (drift_scan_enabled); the interval is drift_scan_interval_minutes.
+ * A fixed base tick re-reads both settings each minute, so enabling, disabling, or
+ * changing the interval takes effect on the next tick without a restart or a timer
+ * reschedule, which is why the plain global-settings keys suffice (no side-effect
+ * endpoint needed). Detection only: it never auto-reconciles the runtime to compose.
+ */
+
+const BASE_TICK_MS = 60_000;          // re-read settings and check whether a scan is due, once a minute
+const INITIAL_DELAY_MS = 45_000;      // let Docker and the node registry settle before the first scan
+const DEFAULT_INTERVAL_MINUTES = 60;
+const MIN_INTERVAL_MINUTES = 15;
+
+export class DriftScanService {
+    private static instance: DriftScanService;
+    private tickTimer: NodeJS.Timeout | null = null;
+    private initialTimer: NodeJS.Timeout | null = null;
+    private isScanning = false;
+    private lastScanAt = 0;
+
+    private constructor() {}
+
+    static getInstance(): DriftScanService {
+        if (!DriftScanService.instance) DriftScanService.instance = new DriftScanService();
+        return DriftScanService.instance;
+    }
+
+    start(): void {
+        if (this.initialTimer || this.tickTimer) return;
+        this.initialTimer = setTimeout(() => {
+            void this.tick();
+            this.tickTimer = setInterval(() => void this.tick(), BASE_TICK_MS);
+        }, INITIAL_DELAY_MS);
+    }
+
+    stop(): void {
+        if (this.initialTimer) {
+            clearTimeout(this.initialTimer);
+            this.initialTimer = null;
+        }
+        if (this.tickTimer) {
+            clearInterval(this.tickTimer);
+            this.tickTimer = null;
+        }
+    }
+
+    /** Fail safe: a settings read error disables scanning rather than scanning unasked. */
+    private isEnabled(): boolean {
+        try {
+            return DatabaseService.getInstance().getGlobalSettings()['drift_scan_enabled'] === '1';
+        } catch {
+            return false;
+        }
+    }
+
+    private intervalMs(): number {
+        try {
+            const raw = Number(DatabaseService.getInstance().getGlobalSettings()['drift_scan_interval_minutes']);
+            const minutes = Number.isFinite(raw) && raw >= MIN_INTERVAL_MINUTES ? raw : DEFAULT_INTERVAL_MINUTES;
+            return minutes * 60_000;
+        } catch {
+            return DEFAULT_INTERVAL_MINUTES * 60_000;
+        }
+    }
+
+    /**
+     * Base-tick worker: scan only when enabled and the configured interval has
+     * elapsed since the last scan. The isScanning guard drops a tick that fires
+     * while a slow scan is still running rather than overlapping it.
+     */
+    async tick(): Promise<void> {
+        if (this.isScanning || !this.isEnabled()) return;
+        const now = Date.now();
+        if (now - this.lastScanAt < this.intervalMs()) return;
+
+        this.isScanning = true;
+        this.lastScanAt = now;
+        try {
+            const nodes = DatabaseService.getInstance().getNodes().filter(n => n.type === 'local');
+            for (const node of nodes) {
+                if (node.id === undefined) continue;
+                const result = await DriftLedgerService.getInstance().reconcileNode(node.id);
+                if (isDebugEnabled() && (result.detected > 0 || result.resolved > 0)) {
+                    console.log(`[DriftScan:diag] node ${node.id}: ${result.stacks} stack(s), +${result.detected} detected, -${result.resolved} resolved`);
+                }
+            }
+        } catch (error) {
+            console.error('[DriftScan] scan failed:', getErrorMessage(error, 'unknown'));
+        } finally {
+            this.isScanning = false;
+        }
+    }
+}

--- a/docs/features/stack-drift.mdx
+++ b/docs/features/stack-drift.mdx
@@ -47,6 +47,8 @@ Image references are compared after normalizing the implicit Docker Hub registry
 
 Each time you **re-check** a stack, and after every deploy, Sencho records the findings it sees. The **Drift history** list under the findings shows recent entries with when each was first **detected** and, once it clears, when it was **resolved**. This turns a point-in-time check into a short ledger of how a stack has drifted and recovered over time.
 
+The history is labelled with when it was last checked. The status badge at the top is always live, recomputed each time you open the tab, while the history reflects the last time the ledger was reconciled. When the two differ, re-check to bring the history up to date.
+
 Drift that appears or clears is also written to the stack's **Activity** timeline, so **Drift detected** and **Drift resolved** events sit alongside deploys and restarts.
 
 ## Accessing the Drift tab

--- a/docs/features/stack-drift.mdx
+++ b/docs/features/stack-drift.mdx
@@ -45,11 +45,15 @@ Image references are compared after normalizing the implicit Docker Hub registry
 
 ## Drift history
 
-Each time you **re-check** a stack, and after every deploy, Sencho records the findings it sees. The **Drift history** list under the findings shows recent entries with when each was first **detected** and, once it clears, when it was **resolved**. This turns a point-in-time check into a short ledger of how a stack has drifted and recovered over time.
+Sencho records the findings it sees whenever a stack is checked: each time you **re-check**, after every deploy, and on each background scan when one is enabled. The **Drift history** list under the findings shows recent entries with when each was first **detected** and, once it clears, when it was **resolved**, turning a point-in-time check into a short ledger of how a stack has drifted and recovered over time.
 
 The history is labelled with when it was last checked. The status badge at the top is always live, recomputed each time you open the tab, while the history reflects the last time the ledger was reconciled. When the two differ, re-check to bring the history up to date.
 
 Drift that appears or clears is also written to the stack's **Activity** timeline, so **Drift detected** and **Drift resolved** events sit alongside deploys and restarts.
+
+### Background drift detection
+
+Out of the box the history advances when you re-check a stack or deploy it. To keep it current without opening each tab, turn on **Drift detection** under **Settings → Automation**: each node then reconciles every stack on a schedule, recording drift and surfacing it in the activity feed on its own. Choose how often the scan runs in the same place. The scan only detects and records drift; it never changes a running stack to match its Compose file. It is off by default and configured per node.
 
 ## Accessing the Drift tab
 

--- a/frontend/src/components/settings/DriftDetectionSection.tsx
+++ b/frontend/src/components/settings/DriftDetectionSection.tsx
@@ -1,0 +1,153 @@
+import { useState, useEffect } from 'react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { RefreshCw } from 'lucide-react';
+import { apiFetch } from '@/lib/api';
+import { toast } from '@/components/ui/toast-store';
+import { useNodes } from '@/context/NodeContext';
+import { useAuth } from '@/context/AuthContext';
+import { DEFAULT_SETTINGS } from './types';
+import type { PatchableSettings } from './types';
+import { SettingsSection } from './SettingsSection';
+import { SettingsField } from './SettingsField';
+import { SettingsActions, SettingsPrimaryButton } from './SettingsActions';
+import { useMastheadStats } from './MastheadStatsContext';
+import { useSettingsDirty } from './useSettingsDirty';
+import { TogglePill } from '@/components/ui/toggle-pill';
+import { NumberChip } from './SystemControls';
+
+interface DriftDetectionSectionProps {
+    onDirtyChange?: (dirty: boolean) => void;
+}
+
+function SectionSkeleton() {
+    return (
+        <div className="space-y-3 rounded-lg border border-glass-border bg-glass p-4">
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+        </div>
+    );
+}
+
+type DriftScanFields = Pick<PatchableSettings, 'drift_scan_enabled' | 'drift_scan_interval_minutes'>;
+
+const DEFAULT_DRIFT_SCAN: DriftScanFields = {
+    drift_scan_enabled: DEFAULT_SETTINGS.drift_scan_enabled,
+    drift_scan_interval_minutes: DEFAULT_SETTINGS.drift_scan_interval_minutes,
+};
+
+export function DriftDetectionSection({ onDirtyChange }: DriftDetectionSectionProps) {
+    const { activeNode } = useNodes();
+    const { isAdmin } = useAuth();
+    const readOnly = !isAdmin;
+    const { settings, setSettings, dirtyCount, hasChanges, reset, markSaved } = useSettingsDirty<DriftScanFields>({ ...DEFAULT_DRIFT_SCAN });
+    const [isLoading, setIsLoading] = useState(false);
+    const [isSaving, setIsSaving] = useState(false);
+
+    useEffect(() => {
+        onDirtyChange?.(hasChanges);
+    }, [hasChanges, onDirtyChange]);
+
+    useMastheadStats(
+        isLoading
+            ? null
+            : [
+                {
+                    label: 'EDITED',
+                    value: hasChanges ? `${dirtyCount} pending` : 'saved',
+                    tone: hasChanges ? 'warn' : 'value',
+                },
+            ],
+    );
+
+    useEffect(() => {
+        const fetchSettings = async () => {
+            setIsLoading(true);
+            try {
+                const res = await apiFetch('/settings');
+                const data: Record<string, string> = res.ok ? await res.json() : {};
+                reset({
+                    drift_scan_enabled: (data.drift_scan_enabled as '0' | '1') ?? DEFAULT_SETTINGS.drift_scan_enabled,
+                    drift_scan_interval_minutes: data.drift_scan_interval_minutes ?? DEFAULT_SETTINGS.drift_scan_interval_minutes,
+                });
+            } catch (e) {
+                console.error('Failed to fetch drift detection settings', e);
+            } finally {
+                setIsLoading(false);
+            }
+        };
+        fetchSettings();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [activeNode?.id]);
+
+    const onSettingChange = <K extends keyof DriftScanFields>(key: K, value: DriftScanFields[K]) => {
+        setSettings(prev => ({ ...prev, [key]: value }));
+    };
+
+    const saveSettings = async () => {
+        const submitted = { ...settings };
+        setIsSaving(true);
+        try {
+            const res = await apiFetch('/settings', {
+                method: 'PATCH',
+                body: JSON.stringify(submitted),
+            });
+            if (!res.ok) {
+                const err = await res.json().catch(() => ({}));
+                toast.error(err?.error || err?.message || 'Failed to save settings.');
+                return;
+            }
+            markSaved(submitted);
+            toast.success('Drift detection settings saved.');
+        } catch (e: unknown) {
+            toast.error((e as Error)?.message || 'Something went wrong.');
+        } finally {
+            setIsSaving(false);
+        }
+    };
+
+    if (isLoading) return <SectionSkeleton />;
+
+    return (
+        <fieldset disabled={readOnly} className="m-0 flex min-w-0 flex-col gap-10 border-0 p-0">
+            <SettingsSection title="Background drift detection" kicker="node-scoped">
+                <SettingsField
+                    label="Scan stacks for drift on a schedule"
+                    helper="When on, this node periodically reconciles every stack so configuration drift is recorded in each stack's drift history and surfaced in the activity feed, without opening the Drift tab. Detection only: Sencho never changes a running stack to match its compose. Off by default."
+                >
+                    <TogglePill
+                        checked={settings.drift_scan_enabled === '1'}
+                        onChange={(next) => onSettingChange('drift_scan_enabled', next ? '1' : '0')}
+                    />
+                </SettingsField>
+                <SettingsField
+                    label="Scan every"
+                    helper="How often a background scan runs while drift detection is on. The Drift tab still re-checks on demand and after every deploy, regardless of this interval."
+                >
+                    <NumberChip
+                        value={settings.drift_scan_interval_minutes || '60'}
+                        onChange={(v) => onSettingChange('drift_scan_interval_minutes', v)}
+                        suffix="min"
+                        min={15}
+                        max={1440}
+                        step={15}
+                    />
+                </SettingsField>
+            </SettingsSection>
+
+            <SettingsActions hint={readOnly ? 'Read-only · admin access required to edit' : (hasChanges ? `${dirtyCount} unsaved` : undefined)}>
+                {!readOnly && (
+                    <SettingsPrimaryButton onClick={saveSettings} disabled={isSaving || !hasChanges}>
+                        {isSaving ? (
+                            <>
+                                <RefreshCw className="w-4 h-4 animate-spin" />
+                                Saving
+                            </>
+                        ) : (
+                            'Save settings'
+                        )}
+                    </SettingsPrimaryButton>
+                )}
+            </SettingsActions>
+        </fieldset>
+    );
+}

--- a/frontend/src/components/settings/SettingsSectionContent.tsx
+++ b/frontend/src/components/settings/SettingsSectionContent.tsx
@@ -9,6 +9,7 @@ import {
     HostAlertsSection,
     DockerStorageSection,
     UpdatesSection,
+    DriftDetectionSection,
     FleetMeshSection,
     NotificationsSection,
     DeveloperSection,
@@ -84,6 +85,7 @@ function renderSection(
         case 'host-alerts': return <HostAlertsSection onDirtyChange={(d) => onDirtyChange('host-alerts', d)} />;
         case 'docker-storage': return <DockerStorageSection onDirtyChange={(d) => onDirtyChange('docker-storage', d)} />;
         case 'image-updates': return <UpdatesSection />;
+        case 'drift-scan': return <DriftDetectionSection onDirtyChange={(d) => onDirtyChange('drift-scan', d)} />;
         case 'fleet-mesh': return <FleetMeshSection onDirtyChange={(d) => onDirtyChange('fleet-mesh', d)} />;
         case 'notifications': return <NotificationsSection />;
         case 'notification-routing': return <NotificationRoutingSection />;

--- a/frontend/src/components/settings/__tests__/SectionSavePayloads.test.tsx
+++ b/frontend/src/components/settings/__tests__/SectionSavePayloads.test.tsx
@@ -26,6 +26,7 @@ import { DockerStorageSection } from '../DockerStorageSection';
 import { FleetMeshSection } from '../FleetMeshSection';
 import { DataRetentionSection } from '../DataRetentionSection';
 import { DeveloperSection } from '../DeveloperSection';
+import { DriftDetectionSection } from '../DriftDetectionSection';
 
 const mockedFetch = apiFetch as unknown as ReturnType<typeof vi.fn>;
 const mockedLicense = useLicense as unknown as ReturnType<typeof vi.fn>;
@@ -132,5 +133,14 @@ describe('split section save payloads', () => {
         fireEvent.click(save);
         await waitFor(() => expect(mockedFetch.mock.calls.some(c => c[1]?.method === 'PATCH')).toBe(true));
         expect(patchedKeys()).toEqual(['developer_mode']);
+    });
+
+    it('DriftDetectionSection patches only the drift scan keys', async () => {
+        render(<DriftDetectionSection />);
+        const save = await screen.findByRole('button', { name: /save settings/i });
+        fireEvent.click(screen.getByRole('switch')); // drift_scan_enabled
+        fireEvent.click(save);
+        await waitFor(() => expect(mockedFetch.mock.calls.some(c => c[1]?.method === 'PATCH')).toBe(true));
+        expect(patchedKeys()).toEqual(['drift_scan_enabled', 'drift_scan_interval_minutes']);
     });
 });

--- a/frontend/src/components/settings/index.ts
+++ b/frontend/src/components/settings/index.ts
@@ -6,6 +6,7 @@ export { LicenseSection } from './LicenseSection';
 export { HostAlertsSection } from './HostAlertsSection';
 export { DockerStorageSection } from './DockerStorageSection';
 export { UpdatesSection } from './UpdatesSection';
+export { DriftDetectionSection } from './DriftDetectionSection';
 export { FleetMeshSection } from './FleetMeshSection';
 export { NotificationsSection } from './NotificationsSection';
 export { DeveloperSection } from './DeveloperSection';

--- a/frontend/src/components/settings/registry.ts
+++ b/frontend/src/components/settings/registry.ts
@@ -222,6 +222,15 @@ export const SETTINGS_ITEMS: readonly SettingsItemMeta[] = [
         scope: 'node',
     },
     {
+        id: 'drift-scan',
+        group: 'automation',
+        label: 'Drift detection',
+        description: 'Periodically reconcile each stack on this node so configuration drift is recorded and surfaced without opening every Drift tab.',
+        keywords: ['drift', 'scan', 'reconcile', 'compose', 'runtime', 'detection', 'background', 'interval', 'ledger', 'history'],
+        tier: null,
+        scope: 'node',
+    },
+    {
         id: 'webhooks',
         group: 'automation',
         label: 'Webhooks',

--- a/frontend/src/components/settings/types.ts
+++ b/frontend/src/components/settings/types.ts
@@ -18,6 +18,8 @@ export interface PatchableSettings {
     health_gate_enabled?: '0' | '1';
     health_gate_window_seconds?: string;
     env_block_deploy_on_missing_required?: '0' | '1';
+    drift_scan_enabled?: '0' | '1';
+    drift_scan_interval_minutes?: string;
 }
 
 export const DEFAULT_SETTINGS: PatchableSettings = {
@@ -40,6 +42,8 @@ export const DEFAULT_SETTINGS: PatchableSettings = {
     health_gate_enabled: '1',
     health_gate_window_seconds: '90',
     env_block_deploy_on_missing_required: '0',
+    drift_scan_enabled: '0',
+    drift_scan_interval_minutes: '60',
 };
 
 export type SectionId =
@@ -54,6 +58,7 @@ export type SectionId =
     | 'host-alerts'
     | 'docker-storage'
     | 'image-updates'
+    | 'drift-scan'
     | 'fleet-mesh'
     | 'notifications'
     | 'webhooks'

--- a/frontend/src/components/stack/DriftPanel.test.tsx
+++ b/frontend/src/components/stack/DriftPanel.test.tsx
@@ -23,6 +23,7 @@ interface DriftReport {
   parseError?: string;
   temporal?: { hasBaseline: boolean; sourceChanged: boolean; renderedChanged: boolean };
   ledger?: Array<{ service: string; kind: string; message: string; detectedAt: number; resolvedAt: number | null }>;
+  lastCheckedAt?: number | null;
 }
 
 function report(partial: Partial<DriftReport>): DriftReport {
@@ -195,10 +196,11 @@ describe('DriftPanel', () => {
     expect(temporal).toHaveAttribute('data-temporal', 'matches');
   });
 
-  it('renders the persisted drift history with open and resolved entries', async () => {
+  it('renders the persisted drift history with open and resolved entries, labelled with when it was checked', async () => {
     vi.mocked(apiFetch).mockResolvedValue(jsonRes(report({
       status: 'drifted',
       findings: [{ kind: 'image-mismatch', service: 'web', detail: 'image differs' }],
+      lastCheckedAt: Date.now(),
       ledger: [
         { service: 'web', kind: 'image-mismatch', message: 'image differs', detectedAt: Date.now(), resolvedAt: null },
         { service: 'db', kind: 'service-missing', message: 'db not running', detectedAt: Date.now() - 1000, resolvedAt: Date.now() },
@@ -209,5 +211,21 @@ describe('DriftPanel', () => {
     expect(screen.getByText(/drift history/i)).toBeInTheDocument();
     expect(screen.getByText('open')).toBeInTheDocument();
     expect(screen.getByText('resolved')).toBeInTheDocument();
+    // The history is timestamped so a stale row reads as history, not the live status.
+    expect(screen.getByText(/checked/i)).toBeInTheDocument();
+  });
+
+  it('omits the last-checked label when the stack has never been reconciled', async () => {
+    vi.mocked(apiFetch).mockResolvedValue(jsonRes(report({
+      status: 'drifted',
+      findings: [{ kind: 'image-mismatch', service: 'web', detail: 'image differs' }],
+      lastCheckedAt: null,
+      ledger: [
+        { service: 'web', kind: 'image-mismatch', message: 'image differs', detectedAt: Date.now(), resolvedAt: null },
+      ],
+    })));
+    render(<DriftPanel stackName="web" />);
+    await screen.findByTestId('drift-status');
+    expect(screen.queryByText(/checked/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/stack/DriftPanel.tsx
+++ b/frontend/src/components/stack/DriftPanel.tsx
@@ -47,6 +47,9 @@ interface StackDriftReport {
   // Optional so a report from an older remote node (no ledger layer) still renders.
   temporal?: DriftTemporal;
   ledger?: DriftLedgerEntry[];
+  // When the ledger was last reconciled (re-check, deploy, or background scan); null
+  // if never. The history is "as of" this time, not the live status above it.
+  lastCheckedAt?: number | null;
 }
 
 const LABEL_CLASS = 'font-mono text-[10px] uppercase tracking-[0.18em] text-stat-subtitle';
@@ -229,6 +232,10 @@ export default function DriftPanel({ stackName }: { stackName: string }) {
   const temporal = report?.temporal ? temporalMeta(report.temporal) : null;
   const TemporalIcon = temporal?.icon;
   const ledger = report?.ledger ?? [];
+  // The ledger only moves on a reconcile (re-check, deploy, or background scan), so
+  // label the history with when that last happened: a "resolved"/"open" row then
+  // reads as the state at that check, not a claim about the live status above it.
+  const lastChecked = report?.lastCheckedAt != null ? formatTimeAgo(report.lastCheckedAt) : null;
   const busy = loading || rechecking;
 
   return (
@@ -306,7 +313,12 @@ export default function DriftPanel({ stackName }: { stackName: string }) {
 
           {ledger.length > 0 && (
             <section>
-              <div className={cn(LABEL_CLASS, 'mb-1.5')}>drift history</div>
+              <div className={cn(LABEL_CLASS, 'mb-1.5 flex items-center gap-1.5')}>
+                <span>drift history</span>
+                {lastChecked && (
+                  <span className="tracking-normal normal-case text-stat-subtitle/70">· checked {lastChecked}</span>
+                )}
+              </div>
               <div className="rounded-lg border border-muted bg-card/40 px-3 py-1">
                 {ledger.map((e, i) => (
                   <LedgerRow key={`${e.service}-${e.kind}-${e.detectedAt}-${i}`} entry={e} />


### PR DESCRIPTION
## Summary

Builds on #1405 (reconcile on deploy + last-checked timestamp). Deploys keep the ledger current, but drift introduced **out of band** (an SSH change between deploys) still goes unrecorded until someone opens the Drift tab and re-checks. This adds an opt-in background scanner that closes that gap.

> Stacked on **#1405** (`fix/drift-ledger-staleness`). Review/merge that first; this PR's base is the fix branch, so its diff is the scanner only.

### What changed

A new `DriftScanService` (singleton, base-tick timer, `isScanning` guard) periodically reconciles every stack on each **local** node when **Drift detection** is enabled, recording drift and surfacing it in the activity feed without an operator opening each Drift tab.

- **Off by default**; interval configurable (15-1440 min). Re-read each tick, so enabling/disabling/retuning takes effect on the next tick with no restart.
- **Local nodes only** (a remote node runs its own instance and scans itself).
- **Detection only**: it never changes a running stack to match its compose. One shared Docker snapshot per node keeps a full scan cheap; a Docker-unreachable node is skipped wholesale rather than falsely resolving open findings.
- Settings live under **Settings → Automation → Drift detection** (`drift_scan_enabled`, `drift_scan_interval_minutes`), wired through the generic `/settings` API with matching Zod validation and a toggle + interval control.

## Test plan

- Backend: scanner gating (off/on/due/within-interval), the local-nodes-only filter against a real remote node, `reconcileNode` (single shared snapshot, Docker-unreachable skips resolution, per-stack failure isolation), and the settings seed/projection/validation/admin-gate.
- Frontend: the Drift detection section patches only its two keys.
- `tsc`, lint, and targeted suites green on both packages. Each touched integration file passes in isolation; the only full-suite failures are pre-existing concurrency flakiness on the dev box (every failing file passes when run alone).

## Notes

The scanner records drift to the in-app activity feed only (history), consistent with the existing drift signal; it does not dispatch to external channels. Enforce-style auto-reconcile (changing a running stack to match compose) is deliberately out of scope.
