### PR TITLE
chore(gitignore): drop the obsolete frontend/DESIGN.md ignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,6 @@ plans/
 CLAUDE.md
 
 # Design system (local-only authoritative reference)
-frontend/DESIGN.md
 .design-bundle/
 docs/design/
 


### PR DESCRIPTION
The design system reference now lives under `docs/design/`, which `.gitignore` already covers.