### PR TITLE
fix(editor): suppress global hotkeys while the code editor is focused

### DIFF
--- a/frontend/src/lib/__tests__/keyboard-guards.test.ts
+++ b/frontend/src/lib/__tests__/keyboard-guards.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for isInputFocused, the shared guard both global hotkey systems
+ * use to bail when the user is typing in a field.
+ *
+ * Regression guard for #1410: Monaco's Chromium EditContext input surface is a
+ * plain focusable <div class="native-edit-context"> inside .monaco-editor, not a
+ * <textarea> or contentEditable element, so the tag/contentEditable checks miss
+ * it and single-key hotkeys (a/h/u/p/b) fired while editing a compose file in
+ * Chrome (Safari falls back to a hidden <textarea> and was unaffected).
+ *
+ * activeElement is stubbed with real DOM nodes so tagName, isContentEditable, and
+ * closest() all run their real logic, while staying free of jsdom's unreliable
+ * .focus() / isContentEditable handling on detached elements.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { isInputFocused } from '../keyboard-guards';
+
+function stubActiveElement(el: Element | null): void {
+  Object.defineProperty(document, 'activeElement', { configurable: true, get: () => el });
+}
+
+afterEach(() => {
+  // Drop the own-property shadow so jsdom's native activeElement getter returns.
+  Reflect.deleteProperty(document, 'activeElement');
+});
+
+describe('isInputFocused', () => {
+  it('returns false when nothing is focused', () => {
+    stubActiveElement(null);
+    expect(isInputFocused()).toBe(false);
+  });
+
+  it('returns true for a focused <input>', () => {
+    stubActiveElement(document.createElement('input'));
+    expect(isInputFocused()).toBe(true);
+  });
+
+  it('returns true for a focused <textarea>', () => {
+    stubActiveElement(document.createElement('textarea'));
+    expect(isInputFocused()).toBe(true);
+  });
+
+  it('returns true for a contentEditable element', () => {
+    const div = document.createElement('div');
+    Object.defineProperty(div, 'isContentEditable', { value: true });
+    stubActiveElement(div);
+    expect(isInputFocused()).toBe(true);
+  });
+
+  it('returns false for a focused non-editable element', () => {
+    stubActiveElement(document.createElement('button'));
+    expect(isInputFocused()).toBe(false);
+  });
+
+  it('returns true for focus inside the Monaco editor container (#1410)', () => {
+    const editor = document.createElement('div');
+    editor.className = 'monaco-editor';
+    const editContext = document.createElement('div');
+    editContext.className = 'native-edit-context';
+    editor.appendChild(editContext);
+    document.body.appendChild(editor);
+    stubActiveElement(editContext);
+    try {
+      expect(isInputFocused()).toBe(true);
+    } finally {
+      document.body.removeChild(editor);
+    }
+  });
+
+  it('returns true for any descendant of the Monaco editor, not just the edit-context node', () => {
+    // Pins the deliberate whole-container semantics: focus anywhere inside
+    // .monaco-editor counts, so narrowing the guard to a specific inner class
+    // would regress.
+    const editor = document.createElement('div');
+    editor.className = 'monaco-editor';
+    const viewLine = document.createElement('div');
+    viewLine.className = 'view-line';
+    editor.appendChild(viewLine);
+    document.body.appendChild(editor);
+    stubActiveElement(viewLine);
+    try {
+      expect(isInputFocused()).toBe(true);
+    } finally {
+      document.body.removeChild(editor);
+    }
+  });
+});

--- a/frontend/src/lib/keyboard-guards.ts
+++ b/frontend/src/lib/keyboard-guards.ts
@@ -2,7 +2,11 @@ export function isInputFocused(): boolean {
   const el = document.activeElement as HTMLElement | null;
   if (!el) return false;
   const tag = el.tagName;
-  return tag === 'INPUT' || tag === 'TEXTAREA' || el.isContentEditable;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || el.isContentEditable) return true;
+  // Monaco's EditContext surface (Chromium) is a plain focusable <div>, not a textarea or
+  // contentEditable element, so the checks above miss it. Treat any focus inside the editor
+  // container as input focus, matching the textarea fallback other browsers already get.
+  return !!el.closest('.monaco-editor');
 }
 
 export function isPaletteOpen(): boolean {


### PR DESCRIPTION
## Summary

Pressing a single-key shortcut (`a`/`h`/`u`/`p`/`b`) while typing in the stack compose editor opened that shortcut's action instead of inserting the character. It reproduced in Chrome (Mac and Windows) but not Safari.

## Root cause

Both global hotkey listeners bail when `isInputFocused()` (`frontend/src/lib/keyboard-guards.ts`) reports the user is typing. That guard recognized `<input>`, `<textarea>`, and `contentEditable` elements. The compose editor is Monaco, which in Chromium uses the EditContext API: its focused input surface is a plain focusable `<div>`, not a textarea or contentEditable element, so the guard missed it and the hotkeys fired. Safari lacks the EditContext API and falls back to a hidden `<textarea>`, which the guard already caught, which is why Safari was unaffected.

## Fix

Add one check to `isInputFocused()`: treat any focus inside the `.monaco-editor` container as input focus. `.monaco-editor` is Monaco's stable container in both EditContext and textarea modes, so this brings Chrome to parity with Safari for both global hotkey systems and every Monaco surface (compose editor, file viewer, blueprint editor, diff dialogs).

Read-only note: in view mode the editor still holds focus, so single-key hotkeys are suppressed while the cursor sits in a read-only file too. Click outside the editor to use them. This matches Safari's existing behavior.

## Test plan

- New unit test `frontend/src/lib/__tests__/keyboard-guards.test.ts` (7 cases), including the regression: focus on Monaco's `native-edit-context` div, and any other `.monaco-editor` descendant, returns `true`.
- Verified live in Chromium: the focused editor element is `<div class="native-edit-context">` (old guard missed it, new guard matches). Typed `a h u p b` in the focused editor: all characters inserted, no action UI opened. Blurred the editor: `a` opens the alert sheet (hotkeys still work). Focused a read-only editor: `a` opens nothing.
- `tsc -b --noEmit` and `eslint` clean; full frontend suite green.

Closes #1410
