### PR TITLE
fix(search): don't open the command palette via Cmd/Ctrl+K while typing

### DIFF
--- a/frontend/src/components/GlobalCommandPalette.tsx
+++ b/frontend/src/components/GlobalCommandPalette.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/components/ui/command';
 import { DialogDescription, DialogTitle } from '@/components/ui/dialog';
 import { useNodes, type Node } from '@/context/NodeContext';
+import { isInputFocused } from '@/lib/keyboard-guards';
 import { cn } from '@/lib/utils';
 import {
     useCrossNodeStackSearch,
@@ -51,6 +52,10 @@ export function GlobalCommandPaletteProvider({ children }: { children: ReactNode
                 // Let cmdk's own Ctrl+K handling take precedence when focus is already inside a palette
                 const target = e.target as HTMLElement | null;
                 if (target?.closest('[cmdk-root]')) return;
+                // Don't hijack Cmd/Ctrl+K while the user is typing in a field or the code
+                // editor: stealing focus mid-edit is surprising, and on macOS Ctrl+K is the
+                // native delete-to-end-of-line. Search still opens elsewhere, or via the icon.
+                if (isInputFocused()) return;
                 e.preventDefault();
                 setOpen(prev => !prev);
             }

--- a/frontend/src/components/__tests__/GlobalCommandPalette.test.tsx
+++ b/frontend/src/components/__tests__/GlobalCommandPalette.test.tsx
@@ -62,6 +62,18 @@ function type(value: string) {
   fireEvent.change(screen.getByPlaceholderText('Search the app...'), { target: { value } });
 }
 
+// Focus a real text input for the duration of `run`, then always detach it.
+function withFocusedInput(run: (input: HTMLInputElement) => void) {
+  const input = document.createElement('input');
+  document.body.appendChild(input);
+  input.focus();
+  try {
+    run(input);
+  } finally {
+    document.body.removeChild(input);
+  }
+}
+
 beforeEach(() => {
   hookReturn = { hits: [], failedNodes: [], loading: false };
   nodesValue = {
@@ -207,5 +219,37 @@ describe('GlobalCommandPalette', () => {
     open();
     type('zzzz');
     expect(screen.getByText('Searching...')).toBeInTheDocument();
+  });
+
+  it('opens on Ctrl+K when no field is focused', () => {
+    renderPalette();
+    fireEvent.keyDown(document.body, { key: 'k', ctrlKey: true });
+    expect(screen.getByPlaceholderText('Search the app...')).toBeInTheDocument();
+  });
+
+  it('ignores Ctrl+K while a text field is focused (no focus hijack)', () => {
+    renderPalette();
+    withFocusedInput(input => {
+      fireEvent.keyDown(input, { key: 'k', ctrlKey: true });
+      expect(screen.queryByPlaceholderText('Search the app...')).not.toBeInTheDocument();
+    });
+  });
+
+  it('ignores Cmd+K (metaKey) while a text field is focused', () => {
+    renderPalette();
+    withFocusedInput(input => {
+      fireEvent.keyDown(input, { key: 'k', metaKey: true });
+      expect(screen.queryByPlaceholderText('Search the app...')).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not close the open palette when Ctrl+K is pressed inside it', () => {
+    // The [cmdk-root] early-return must run before the input-focus guard, so the
+    // app handler never toggles the palette closed while focus is in its own input.
+    renderPalette();
+    open();
+    const paletteInput = screen.getByPlaceholderText('Search the app...');
+    fireEvent.keyDown(paletteInput, { key: 'k', ctrlKey: true });
+    expect(screen.getByPlaceholderText('Search the app...')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

The global command palette's `Cmd/Ctrl+K` shortcut opened the palette even while the user was typing in a text field or the code editor. That stole focus mid-edit and, on macOS, clobbered the native `Ctrl+K` ("delete to end of line"). This is the adjacent issue surfaced while fixing #1410 and is shipped separately (one concern per PR).

## Fix

The `Cmd/Ctrl+K` handler in `GlobalCommandPalette.tsx` now bails via the shared `isInputFocused()` guard, placed after the existing `[cmdk-root]` early-return:

```ts
if (target?.closest('[cmdk-root]')) return;  // existing: let cmdk handle keys inside an open palette
if (isInputFocused()) return;                // new: don't hijack Cmd/Ctrl+K while typing
```

The ordering is load-bearing: the `[cmdk-root]` check stays first so an open palette's own input keeps working. Search still opens with `Cmd/Ctrl+K` whenever no field is focused, and the toolbar search icon opens it from anywhere.

Behavior change (intentional): the palette no longer opens via keyboard while a text field or the editor has focus. Blur the field or click the search icon to open it while editing. This matches how app-level command palettes generally behave and preserves native text-field key bindings.

## Test plan

- 4 new unit tests in `GlobalCommandPalette.test.tsx`: opens on `Ctrl+K` when nothing is focused; ignores `Ctrl+K` and `Cmd+K` while an input is focused; does not close the open palette when `Ctrl+K` is pressed inside it (pins the early-return ordering). The negative cases fail without the guard.
- Verified live in Chromium: with the sidebar search input focused, `Ctrl+K` does not open the palette; with nothing focused, `Ctrl+K` opens it.
- `tsc -b --noEmit` and `eslint` clean; full frontend suite green (1261 tests).

## Notes

Independent of and non-conflicting with #1413 (different file). Once #1413 lands, this guard also covers the Monaco editor, since `isInputFocused()` then recognizes Monaco's Chromium EditContext surface.
