### PR TITLE
test(audit-log): assert PAID_REQUIRED code on Community-blocked stats and export

### DIFF
--- a/backend/src/__tests__/audit-log.test.ts
+++ b/backend/src/__tests__/audit-log.test.ts
@@ -655,6 +655,7 @@ describe('GET /api/audit-log/stats', () => {
       .get('/api/audit-log/stats')
       .set('Authorization', `Bearer ${adminToken()}`);
     expect(res.status).toBe(403);
+    expect(res.body.code).toBe('PAID_REQUIRED');
   });
 
   it('returns the four-tile stat structure for admin', async () => {
@@ -682,6 +683,7 @@ describe('GET /api/audit-log/export', () => {
       .get('/api/audit-log/export?format=json')
       .set('Authorization', `Bearer ${adminToken()}`);
     expect(res.status).toBe(403);
+    expect(res.body.code).toBe('PAID_REQUIRED');
   });
 
   it('exports JSON with correct Content-Type', async () => {


### PR DESCRIPTION
## Summary

The audit-log `/stats` and `/export` routes run the paid-license guard before the permission guard, so a Community admin's rejection comes from the paid gate. The two "returns 403 without a paid license" tests previously asserted only the `403` status, which a permission gate (or any other 403) would also satisfy, so they did not prove which gate fired.

This adds `expect(res.body.code).toBe('PAID_REQUIRED')` to both tests so each one pins the rejection to the paid gate specifically. It mirrors the assertion already used for the secrets route and the other paid-gated suites. No production code changes.

## Test plan

- `npx vitest run src/__tests__/audit-log.test.ts src/__tests__/secrets.test.ts`: 105 passed
- `npx tsc --noEmit` (backend): clean
- `npm run lint` (backend): 0 errors

## Notes

- The secrets route test already asserted the `PAID_REQUIRED` code, so no change was needed there.
- `GET /api/audit-log` (the list endpoint) is intentionally available to Community with a clamped recent-activity window, so it is correctly not paid-gated.
