### PR TITLE
fix(containers): require stack:read on container read routes

### DIFF
--- a/backend/src/__tests__/containers-routes-authz.test.ts
+++ b/backend/src/__tests__/containers-routes-authz.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Authorization tests for the container *read* routes
+ * (GET /api/containers and GET /api/containers/:id/logs).
+ *
+ * Both stream container data and, until now, carried only the global auth gate.
+ * These tests pin that they enforce the stack:read read model the canonical
+ * GET /api/stacks already uses, bringing them under the same authorization
+ * discipline as their write siblings (/start, /stop, /restart), which gate on
+ * requireAdmin. Every role currently holds stack:read, so the guard denies
+ * nobody today; the tests pin that (no role loses access) and prove the guard
+ * is actually wired (a denied principal gets 403, not the data).
+ *
+ * Docker is stubbed at the prototype so the granted path is deterministic
+ * without a daemon. For GET /:id/logs the guard runs before streamContainerLogs
+ * flushes SSE headers, so a denied caller gets a clean JSON 403 rather than a
+ * half-open event-stream.
+ */
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
+import request from 'supertest';
+import bcrypt from 'bcrypt';
+import type { UserRole } from '../services/DatabaseService';
+import { setupTestDb, cleanupTestDb, loginAsTestAdmin } from './helpers/setupTestDb';
+import DockerController from '../services/DockerController';
+import * as permissionsMod from '../middleware/permissions';
+
+let tmpDir: string;
+let app: import('express').Express;
+let DatabaseService: typeof import('../services/DatabaseService').DatabaseService;
+const roleCookie: Record<string, string> = {};
+let permSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+// Every role holds stack:read, so all of them must pass the read guard today.
+const READ_ROLES: UserRole[] = ['admin', 'node-admin', 'deployer', 'viewer', 'auditor'];
+
+async function seedAndLogin(role: UserRole): Promise<string> {
+  const username = `containers-${role}`;
+  const password = `containers-${role}-pass`;
+  const passwordHash = await bcrypt.hash(password, 1);
+  DatabaseService.getInstance().addUser({ username, password_hash: passwordHash, role });
+  const res = await request(app).post('/api/auth/login').send({ username, password });
+  const cookies = res.headers['set-cookie'] as string | string[];
+  return Array.isArray(cookies) ? cookies[0] : cookies;
+}
+
+/**
+ * Spy the imported requirePermission symbol (the routes call it cross-module, so
+ * the namespace spy intercepts reliably) and reproduce its real deny. Spying
+ * checkPermission would not work: requirePermission calls it as an intra-module
+ * reference a namespace spy cannot reach.
+ */
+function denyPermission(): void {
+  permSpy = vi.spyOn(permissionsMod, 'requirePermission').mockImplementation((_req, res) => {
+    res.status(403).json({ error: 'Permission denied.', code: 'PERMISSION_DENIED' });
+    return false;
+  });
+}
+
+beforeAll(async () => {
+  tmpDir = await setupTestDb();
+  ({ DatabaseService } = await import('../services/DatabaseService'));
+
+  // Deterministic Docker: the granted path must not depend on a live daemon.
+  vi.spyOn(DockerController.prototype, 'getRunningContainers').mockResolvedValue([]);
+  vi.spyOn(DockerController.prototype, 'streamContainerLogs').mockImplementation(
+    async (_id, _req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+      res.end();
+    },
+  );
+
+  ({ app } = await import('../index'));
+  roleCookie['admin'] = await loginAsTestAdmin(app);
+  for (const role of ['node-admin', 'deployer', 'viewer', 'auditor'] as const) {
+    roleCookie[role] = await seedAndLogin(role);
+  }
+});
+
+// Restore only the per-test permission spy; the Docker prototype stubs live for
+// the whole file (both read routes need them) and vitest isolates per file.
+afterEach(() => {
+  permSpy?.mockRestore();
+  permSpy = undefined;
+});
+
+afterAll(() => cleanupTestDb(tmpDir));
+
+describe('GET /api/containers (list) authorization', () => {
+  it('rejects unauthenticated requests with the auth-gate 401, not a permission error', async () => {
+    const res = await request(app).get('/api/containers');
+    expect(res.status).toBe(401);
+    // Distinct from the 403 permission shape: bare auth error, no `code`.
+    expect(res.body).toEqual({ error: 'Authentication required' });
+  });
+
+  it.each(READ_ROLES)('lets a %s through the read guard with 200', async (role) => {
+    const res = await request(app).get('/api/containers').set('Cookie', roleCookie[role]);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it('returns 403 PERMISSION_DENIED when stack:read is denied', async () => {
+    denyPermission();
+    const res = await request(app).get('/api/containers').set('Cookie', roleCookie['viewer']);
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('PERMISSION_DENIED');
+    expect(permSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), 'stack:read');
+  });
+});
+
+describe('GET /api/containers/:id/logs authorization', () => {
+  it('rejects unauthenticated requests with the auth-gate 401, not a permission error', async () => {
+    const res = await request(app).get('/api/containers/abc123/logs');
+    expect(res.status).toBe(401);
+    // Distinct from the 403 permission shape: bare auth error, no `code`.
+    expect(res.body).toEqual({ error: 'Authentication required' });
+  });
+
+  it.each(READ_ROLES)('lets a %s through the read guard with 200', async (role) => {
+    const res = await request(app).get('/api/containers/abc123/logs').set('Cookie', roleCookie[role]);
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 403 PERMISSION_DENIED before opening the stream when stack:read is denied', async () => {
+    denyPermission();
+    const res = await request(app).get('/api/containers/abc123/logs').set('Cookie', roleCookie['viewer']);
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('PERMISSION_DENIED');
+    expect(permSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), 'stack:read');
+  });
+});

--- a/backend/src/routes/containers.ts
+++ b/backend/src/routes/containers.ts
@@ -2,11 +2,14 @@ import { Router, type Request, type Response } from 'express';
 import DockerController from '../services/DockerController';
 import { FileSystemService } from '../services/FileSystemService';
 import { requireAdmin } from '../middleware/tierGates';
+import { requirePermission } from '../middleware/permissions';
 import { invalidateNodeCaches } from '../helpers/cacheInvalidation';
 
 export const containersRouter = Router();
 
 containersRouter.get('/', async (req: Request, res: Response) => {
+  // Baseline node-level read gate: the listing is node-wide, not per-stack scoped.
+  if (!requirePermission(req, res, 'stack:read')) return;
   try {
     const dockerController = DockerController.getInstance(req.nodeId);
     const containers = await dockerController.getRunningContainers();
@@ -17,6 +20,7 @@ containersRouter.get('/', async (req: Request, res: Response) => {
 });
 
 containersRouter.get('/:id/logs', async (req: Request, res: Response) => {
+  if (!requirePermission(req, res, 'stack:read')) return;
   try {
     const id = req.params.id as string;
     const dockerController = DockerController.getInstance(req.nodeId);


### PR DESCRIPTION
## Summary

The container list (`GET /api/containers`) and per-container log stream (`GET /api/containers/:id/logs`) routes were guarded only by the global authentication gate, while their write siblings (`/start`, `/stop`, `/restart`) require admin and the canonical `GET /api/stacks` enforces the `stack:read` read permission. This aligns the two container read routes with that read model by adding the same baseline `stack:read` guard.

Every role currently holds `stack:read`, so no role loses access today: this is a consistency and forward-proofing change, not a behavior change. The guard ensures the routes are protected before any future, more restricted role is introduced.

## Changes

- `backend/src/routes/containers.ts`: add `requirePermission(req, res, 'stack:read')` to `GET /` and `GET /:id/logs`. For the log stream the guard runs before SSE headers are flushed, so a denied caller receives a clean JSON 403 rather than a half-open stream. The three write routes keep their existing admin guard unchanged.

## Test plan

- New `containers-routes-authz.test.ts`:
  - Unauthenticated requests get the auth-gate 401 (distinct from the permission 403 shape).
  - All five roles pass the read guard (200), pinning that no role loses access.
  - A denied principal gets a 403 `PERMISSION_DENIED` before any container data or log stream is reached.
- Verified by toggling the guard: the two 403 tests fail without it and all 14 pass with it.
- `tsc --noEmit` clean; backend and frontend lint clean.

## Notes

- Frontend parity: no change. The logs affordance is shown to all roles and every current role passes `stack:read`, so the backend and frontend already agree; no role loses an affordance.
- Out of scope (tracked separately): a broader restrictive-scoping pass that would resource-scope container logs to their owning stack and give `GET /api/stacks` the same treatment. The `ports/in-use` lookup is a separate router and is unchanged.
