### PR TITLE
chore(deps): bump bundled Docker CLI golang.org/x/net to v0.55.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,8 +101,14 @@ RUN if [ "$TARGETARCH" = "$BUILDARCH" ]; then \
 # Runs on the BUILD platform; GOARCH cross-compiles the static binary for TARGET.
 # The fetch pulls only the v29.4.1 commit, minimising transfer size.
 # docker/cli uses CalVer and ships vendor.mod instead of go.mod to avoid SemVer
-# compliance requirements. We copy vendor.mod -> go.mod and build with -mod=vendor
-# so all deps come from the vendored tree (no network access needed).
+# compliance requirements. We copy vendor.mod -> go.mod, drop the committed vendor
+# tree, bump golang.org/x/net to v0.55.0, and build with -mod=mod so the patched
+# module is resolved from the module proxy instead of the pinned v0.53.0 that the
+# image scan flags for six HIGH advisories (CVE-2026-25680, -25681, -27136, -39821,
+# -42502, -42506; x/net/html parsing and x/net/idna). Removing vendor/ keeps -mod=mod
+# from reading the stale copy, and avoids `go mod tidy` (which does not run cleanly
+# against docker/cli's vendor.mod manifest). This stage now fetches modules at build
+# time rather than building fully offline.
 # Base image pinned by digest so the Go toolchain that compiles the static
 # Docker CLI binary cannot change without an explicit Dependabot bump.
 FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine@sha256:f1ddd9fe14fffc091dd98cb4bfa999f32c5fc77d2f2305ea9f0e2595c5437c14 AS cli-builder
@@ -125,8 +131,10 @@ WORKDIR /src/docker-cli
 RUN mkdir -p /build
 
 RUN cp vendor.mod go.mod && cp vendor.sum go.sum && \
+    rm -rf vendor && \
+    go get golang.org/x/net@v0.55.0 && \
     CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
-      -mod=vendor \
+      -mod=mod \
       -ldflags "-extldflags=-static \
         -X github.com/docker/cli/cli/version.Version=29.4.1 \
         -X github.com/docker/cli/cli/version.GitCommit=source-go1.26.3" \


### PR DESCRIPTION
## Summary

The bundled Docker CLI binary (`usr/local/bin/docker`, built by the `cli-builder` stage from docker/cli v29.4.1's vendored tree) shipped `golang.org/x/net` v0.53.0, which the image vulnerability scan (Trivy, severity CRITICAL/HIGH, fail-on-finding) flags for six HIGH advisories: CVE-2026-25680, -25681, -27136, -39821, -42502, -42506 (x/net/html parsing denial of service and an x/net/idna Punycode issue). All are fixed in x/net v0.55.0. These CVEs are present on `main`'s image, so the Docker Build & Scan check is currently failing on every open PR, not just this one.

The `cli-builder` stage previously built offline from docker/cli's committed `vendor/` tree (`-mod=vendor`), which pins x/net v0.53.0. This change drops the vendored tree, bumps `golang.org/x/net` to v0.55.0 with `go get`, and builds in module mode (`-mod=mod`) so the patched module is resolved from the module proxy. `go mod tidy` is intentionally not used: docker/cli ships a `vendor.mod` manifest rather than a standard `go.mod`, so a full tidy does not run cleanly against it; `-mod=mod` lets `go build` resolve and checksum the remaining graph itself.

The docker/cli release identity is unchanged (still v29.4.1, a transitive-dependency bump only), so the `version.Version=29.4.1` ldflag is left as-is.

## Test plan

- Confirmed `golang.org/x/net@v0.55.0` exists on the Go module proxy (published 2026-05-22) and is the version the scanner reports as the fix.
- The image cannot be built on the dev workstation, so the build plus Trivy re-scan in CI (Docker Build & Scan) is the validation gate. Expected result: the six HIGH x/net advisories clear and the scan passes.

## Notes

- This bumps a transitive dependency of the bundled docker/cli binary; it does not change Sencho's own dependencies.
- The `cli-builder` stage now fetches modules from the Go proxy at build time rather than building fully offline. The sibling `compose-builder` stage already fetches at build time, so the CI build environment allows Go module egress.
- Once this lands on `main`, it unblocks the Docker Build & Scan check for the other open PRs.
