### PR TITLE
feat(scheduler): flag one-shot tasks in the Scheduled Operations table

### DIFF
--- a/frontend/src/components/ScheduledOperationsView.tsx
+++ b/frontend/src/components/ScheduledOperationsView.tsx
@@ -619,13 +619,28 @@ export default function ScheduledOperationsView({ filterNodeId, onClearFilter, p
                       <div className="text-xs text-muted-foreground font-mono">{task.cron_expression}</div>
                     </TableCell>
                     <TableCell>
-                      {task.last_status === 'success' ? (
-                        <Badge className="bg-success-muted text-success border-success/20">Success</Badge>
-                      ) : task.last_status === 'failure' ? (
-                        <Badge variant="destructive">Failed</Badge>
-                      ) : (
-                        <span className="text-xs text-muted-foreground">Never run</span>
-                      )}
+                      <div className="flex items-center gap-1.5">
+                        {task.last_status === 'success' ? (
+                          <Badge className="bg-success-muted text-success border-success/20">Success</Badge>
+                        ) : task.last_status === 'failure' ? (
+                          <Badge variant="destructive">Failed</Badge>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">Never run</span>
+                        )}
+                        {task.delete_after_run === 1 && (
+                          <Badge
+                            variant="outline"
+                            className="text-[10px] text-muted-foreground"
+                            title={
+                              task.last_status === 'failure'
+                                ? 'One-shot task kept after a failed run so you can retry or debug. Deletes itself after a successful run.'
+                                : 'One-shot task. Deletes itself after a successful run.'
+                            }
+                          >
+                            One-shot
+                          </Badge>
+                        )}
+                      </div>
                     </TableCell>
                     <TableCell className="text-xs text-muted-foreground">
                       {formatTimestamp(task.next_run_at)}

--- a/frontend/src/components/__tests__/ScheduledOperationsView.test.tsx
+++ b/frontend/src/components/__tests__/ScheduledOperationsView.test.tsx
@@ -79,6 +79,37 @@ describe('ScheduledOperationsView', () => {
     expect(await screen.findByText('nightly-prune')).toBeInTheDocument();
   });
 
+  it('marks a one-shot task with a chip and leaves recurring tasks unmarked', async () => {
+    tasksFixture = [
+      makeTask({ id: 1, name: 'recurring-task' }),
+      makeTask({ id: 2, name: 'one-shot-task', delete_after_run: 1 }),
+    ];
+    render(<ScheduledOperationsView />);
+
+    await userEvent.click(await screen.findByRole('button', { name: /All tasks/ }));
+    await screen.findByText('recurring-task');
+
+    // A single One-shot chip, scoped to the one-shot row.
+    const chips = screen.getAllByText('One-shot');
+    expect(chips).toHaveLength(1);
+    // A pending one-shot carries the plain lifecycle tooltip, not the failure copy.
+    expect(chips[0]).toHaveAttribute('title', expect.stringContaining('Deletes itself after a successful run'));
+    expect(chips[0]).toHaveAttribute('title', expect.not.stringContaining('kept after a failed run'));
+    const oneShotRow = screen.getByText('one-shot-task').closest('tr');
+    expect(oneShotRow).toContainElement(chips[0]);
+    const recurringRow = screen.getByText('recurring-task').closest('tr');
+    expect(recurringRow?.textContent).not.toContain('One-shot');
+  });
+
+  it('explains a failed one-shot was kept to debug', async () => {
+    tasksFixture = [makeTask({ id: 1, name: 'failed-one-shot', delete_after_run: 1, last_status: 'failure' })];
+    render(<ScheduledOperationsView />);
+
+    await userEvent.click(await screen.findByRole('button', { name: /All tasks/ }));
+    const chip = await screen.findByText('One-shot');
+    expect(chip).toHaveAttribute('title', expect.stringContaining('kept after a failed run'));
+  });
+
   it('opens the create modal from a prefill and consumes it once', async () => {
     const onPrefillConsumed = vi.fn();
     render(


### PR DESCRIPTION
## Summary

A one-shot scheduled task (the "Delete after successful run" option) self-deletes only after a **successful** run. A failed one-shot is intentionally kept so the operator can retry or debug it. Until now the Scheduled Operations table gave no signal that a lingering task was a one-shot, so a failed one-shot was indistinguishable from a stuck recurring task (it even keeps a recalculated next-run time).

This adds a subtle **One-shot** chip to the Status cell for every task with delete-after-run enabled. The chip carries a tooltip that explains the lifecycle, and when the task has failed it explains the task was kept so it can be retried or debugged.

- Recurring task: no chip.
- Pending / not-yet-run one-shot: chip + "One-shot task. Deletes itself after a successful run."
- Failed one-shot: Failed badge + chip + "One-shot task kept after a failed run so you can retry or debug. Deletes itself after a successful run."

Frontend-only and presentational. Both data points (`delete_after_run`, `last_status`) already exist on the task payload, so there is no backend, schema, or API change. No tier/role/gate change.

## Test plan

- `npx tsc -b --noEmit` (frontend): clean.
- `npm run lint` (frontend): 0 errors.
- Vitest: two new tests in `ScheduledOperationsView.test.tsx` assert the chip renders only for one-shot tasks, is scoped to the correct row, and that both tooltip branches (pending vs failed) carry the right copy. Full file: 6/6 passing.
- Live browser check against a dev instance with three seeded tasks (recurring, pending one-shot, failed one-shot): confirmed the chip and tooltips render exactly as intended and recurring rows are unchanged.

## Notes

The Status cell content is now wrapped in a single flex container so the chip sits inline with the existing status badge across all three states (Success / Failed / Never run) without row drift. The bespoke mobile schedules view is unchanged: it lists upcoming runs by time and has no status column.
