### PR TITLE
feat(scheduler): group schedule action picker by operator intent

### DIFF
--- a/docs/features/auto-update-policies.mdx
+++ b/docs/features/auto-update-policies.mdx
@@ -71,7 +71,7 @@ Blocked updates still surface in scheduled check runs so you stay informed, but 
 Auto-update is opt-in per stack. A stack participates in unattended updates only when an enabled scheduled task covers it. To leave a stack out (databases, self-built images, anything pinned to a fixed tag), simply do not create a schedule for it.
 
 - **Per-stack schedule.** Create a **Auto-update Stack** task targeting that stack alone. Only this stack is updated when the cron fires.
-- **Fleet-wide schedule.** Create a **Auto-update All Stacks** task targeting a node. Every stack on that node is checked and updated when new images are available. If you do not want every stack covered, create per-stack schedules instead.
+- **Fleet-wide schedule.** Create a **Auto-update All Stacks on Node** task targeting a node. Every stack on that node is checked and updated when new images are available. If you do not want every stack covered, create per-stack schedules instead.
 - **Stack list dot.** Image-update *detection* runs on the configured interval (every 2 hours by default) regardless of whether any schedule is configured. The sidebar dot and the readiness board still show available updates so you can decide what to do with them.
 - **Manual updates are always available.** The lifecycle **Update** action on a stack applies an update on demand, independent of any scheduled task.
 
@@ -129,7 +129,7 @@ The preview is recomputed each time the readiness board loads, so it reflects th
     Image update detection runs on the configured interval (every 2 hours by default) on each node, and the readiness board uses the same cached status. Trigger **Recheck** to force a fresh check across every reachable node, or shorten the interval under **Settings > Automation > Image update checks**.
   </Accordion>
   <Accordion title='Scheduled auto-update runs are not applying to a specific stack'>
-    No schedule covers that stack. Open **Schedules** in the top nav, create a new **Auto-update Stack** task targeting the stack (or an **Auto-update All Stacks** task on its node), and pick a cron. The next firing will include the stack, or you can trigger an immediate run from the row.
+    No schedule covers that stack. Open **Schedules** in the top nav, create a new **Auto-update Stack** task targeting the stack (or an **Auto-update All Stacks on Node** task on its node), and pick a cron. The next firing will include the stack, or you can trigger an immediate run from the row.
   </Accordion>
   <Accordion title='Banner says "X of Y nodes reachable"'>
     One or more nodes that are marked online in your fleet did not respond within the request timeout. Pending updates from those nodes are not shown until they come back. Check the node's status from the Fleet view and the network path between this Sencho instance and the unreachable node.

--- a/docs/features/dashboard.mdx
+++ b/docs/features/dashboard.mdx
@@ -92,7 +92,7 @@ The card is divided into four sections.
 | Row | What it shows |
 |-----|---------------|
 | **Auto-heal policies** | `<enabled> / <total> active` for crash-recovery policies across all stacks; reads `None` when no policies exist |
-| **Auto-update schedules** | `<enabled> / <total> active` count of `Auto-update Stack` / `Auto-update All Stacks` rows configured for this node; reads `None` when none are configured |
+| **Auto-update schedules** | `<enabled> / <total> active` count of `Auto-update Stack` / `Auto-update All Stacks on Node` rows configured for this node; reads `None` when none are configured |
 | **Webhooks** | Active inbound deploy webhooks tied to Git Sources or stacks, formatted `<n> actives` |
 | **Scheduled tasks** | Active scheduled operations (backups, restarts, scripts), formatted `<n> actives` |
 

--- a/docs/features/fleet-backups.mdx
+++ b/docs/features/fleet-backups.mdx
@@ -28,7 +28,7 @@ If a remote node is offline or unreachable, it is **skipped gracefully**. The sn
 
 ### Scheduled snapshots
 
-Fleet snapshots can also be created automatically on a recurring schedule. Navigate to the **Schedules** view, create a new scheduled operation, and select **Fleet Snapshot** as the action type. Scheduled snapshots appear in the snapshot list with a "Scheduled snapshot" prefix in their description.
+Fleet snapshots can also be created automatically on a recurring schedule. Navigate to the **Schedules** view, create a new scheduled operation, and select **Create Fleet Snapshot** as the action type. Scheduled snapshots appear in the snapshot list with a "Scheduled snapshot" prefix in their description.
 
 ### Capturing stack documentation
 

--- a/docs/features/multi-node.mdx
+++ b/docs/features/multi-node.mdx
@@ -171,7 +171,7 @@ The Nodes table surfaces routing, status, and per-node automation at a glance fo
 | **Status** | `Online`, `Offline`, or `Unknown` badge. |
 | **Labels** | Per-node label palette. The cell shows the label picker; an empty cell reads `No labels` with an Add label control. |
 | **Schedules** | Number of active scheduled tasks targeting this node, plus a `next X` countdown to the next run. Click the count or the calendar icon in the Actions column to filter the Schedules view to that node. |
-| **Updates** | `Auto` if at least one enabled `Auto-update Stack` or `Auto-update All Stacks` schedule targets the node; `Off` otherwise. A pulsing dot and count appear when stacks have pending image updates. |
+| **Updates** | `Auto` if at least one enabled `Auto-update Stack` or `Auto-update All Stacks on Node` schedule targets the node; `Off` otherwise. A pulsing dot and count appear when stacks have pending image updates. |
 | **Actions** | **View Schedules**, **Test Connection**, **Edit Node**, and **Delete Node** icon buttons. The local row hides Delete because the local node cannot be removed. |
 
 Clicking the schedules-link icon opens the Schedules view filtered to the selected node. From there you can create, edit, or manage scheduled tasks scoped to that node. The filter bar shows which node you are viewing, with a Clear filter control to return to the full list.

--- a/docs/features/scheduled-operations.mdx
+++ b/docs/features/scheduled-operations.mdx
@@ -26,7 +26,7 @@ Open the **Schedules** tab from the top navigation bar. The page opens on the Ti
 The Timeline plots every firing of every enabled task across a rolling 24-hour window starting from the current minute.
 
 - **Masthead.** A `NEXT 24 HOURS` kicker, an italic display heading, the window's start and end timestamps in a monospace range, and a right-anchored **Next** pill that reads out the time and task name of the next firing and a relative countdown.
-- **Five lanes.** Lifecycle (label blue), Updates (success green), Security (label purple), Maintenance (warning amber), and Backups (brand cyan). The Lifecycle lane holds stack restarts plus the four stack-lifecycle actions (Backup Stack Files, Stop Stack, Take Stack Down, Start Stack); Updates holds per-node and fleet image updates; Security holds vulnerability scans; Maintenance holds system prunes; Backups holds fleet snapshots.
+- **Five lanes.** Lifecycle (label blue), Updates (success green), Security (label purple), Maintenance (warning amber), and Backups (brand cyan). The Lifecycle lane holds the five stack-lifecycle actions (Backup Stack Compose Files, Start / Bring Up Stack, Restart Stack, Stop Stack, Take Stack Down); Updates holds per-node and fleet image updates; Security holds vulnerability scans; Maintenance holds node resource prunes; Backups holds fleet snapshots.
 - **Pills.** One pill per firing within the window, positioned proportionally to the firing's time. Each pill shows the firing time and the task name. Pills are color-matched to their lane. Click a pill to open the run history sheet for that task.
 - **Now rail.** A glowing vertical rail at the current minute, anchored to the left of the track at page open and drifting right as time passes (the page recomputes positions periodically).
 - **Axis.** Six monospace time ticks run along the bottom, evenly spaced through the window.
@@ -40,13 +40,13 @@ Toggle to **All tasks** from the masthead to see every schedule in a table regar
 The All tasks toggle swaps the lane track for a sortable table.
 
 <Frame>
-  <img src="/images/scheduled-operations/all-tasks.png" alt="All tasks table view of Scheduled Operations. Columns are Name, Action, Target, Schedule, Status, Next Run, Enabled, Actions. Two rows are visible: 'Vul Scan' with a Vulnerability Scan badge, target 'system', schedule 'At 03:00 AM / 0 3 * * *', Success status, next run '5/15/2026, 3:00:00 AM', ON toggle, and an action group of Run now / Execution history / Edit / Delete (Delete in destructive red). 'Nightly Snapshot' with a Fleet Snapshot badge, target 'fleet', schedule 'At 04:00 AM / 0 4 * * *', Success, next run '5/15/2026, 4:00:00 AM', ON, same action group." />
+  <img src="/images/scheduled-operations/all-tasks.png" alt="All tasks table view of Scheduled Operations. Columns are Name, Action, Target, Schedule, Status, Next Run, Enabled, Actions. Two rows are visible: 'Vul Scan' with a Scan Node Images badge, target 'system', schedule 'At 03:00 AM / 0 3 * * *', Success status, next run '5/15/2026, 3:00:00 AM', ON toggle, and an action group of Run now / Execution history / Edit / Delete (Delete in destructive red). 'Nightly Snapshot' with a Create Fleet Snapshot badge, target 'fleet', schedule 'At 04:00 AM / 0 4 * * *', Success, next run '5/15/2026, 4:00:00 AM', ON, same action group." />
 </Frame>
 
 | Column | What it shows |
 |---|---|
 | **Name** | The task name. |
-| **Action** | A badge labelling the operation (e.g. Restart Stack, Vulnerability Scan, Fleet Snapshot). |
+| **Action** | A badge labelling the operation (e.g. Restart Stack, Scan Node Images, Create Fleet Snapshot). |
 | **Target** | The stack the task targets (with a service list in parentheses when restart is scoped to specific services), or the target type for non-stack actions (`system`, `fleet`). |
 | **Schedule** | A human-readable description of the cron with the raw expression on a second line. |
 | **Status** | The last run result: **Success** (green), **Failed** (red), or `Never run` if the task has not fired yet. |
@@ -60,21 +60,21 @@ The All tasks toggle swaps the lane track for a sortable table.
 |---|---|---|
 | **Restart Stack** | A specific stack (optionally specific services) on a specific node | Restarts all or selected containers in the stack. |
 | **Auto-update Stack** | A specific stack on a specific node | Checks each image in the stack for a newer tag and recreates the stack if any image has an update. See [Auto-Update Policies](/features/auto-update-policies) for the companion review board. |
-| **Auto-update All Stacks** | A specific node | Runs the auto-update check across every stack on the node. Pair with **Auto-update Stack** rows when you want different cadences for specific stacks. |
-| **Fleet Snapshot** | The whole fleet | Creates a versioned, fleet-wide snapshot of every node's compose files and `.env` files. See [Fleet Backups](/features/fleet-backups). |
-| **System Prune** | A local node | Prunes containers, images, networks, and volumes (any subset), optionally filtered by a Docker label. Runs on local nodes only. |
-| **Vulnerability Scan** | A local node | Runs Trivy against every image on the node and persists the results. Requires Trivy to be installed on the target node ([Installing Trivy](/operations/trivy-setup)). Runs on local nodes only. |
-| **Backup Stack Files** | A specific stack on a specific node | Copies the stack's compose file and `.env` to `<DATA_DIR>/backups/<stack>/`. One slot per stack; each run overwrites the previous backup. For a versioned archive use a Fleet Snapshot instead. |
+| **Auto-update All Stacks on Node** | A specific node | Runs the auto-update check across every stack on the node. Pair with **Auto-update Stack** rows when you want different cadences for specific stacks. |
+| **Create Fleet Snapshot** | The whole fleet | Creates a versioned, fleet-wide snapshot of every node's compose files and `.env` files. See [Fleet Backups](/features/fleet-backups). |
+| **Prune Node Resources** | A local node | Prunes containers, images, networks, and volumes (any subset), optionally filtered by a Docker label. Runs on local nodes only. |
+| **Scan Node Images** | A local node | Runs Trivy against every image on the node and persists the results. Requires Trivy to be installed on the target node ([Installing Trivy](/operations/trivy-setup)). Runs on local nodes only. |
+| **Backup Stack Compose Files** | A specific stack on a specific node | Copies the stack's compose file and `.env` to `<DATA_DIR>/backups/<stack>/`. One slot per stack; each run overwrites the previous backup. For a versioned archive use a Create Fleet Snapshot instead. |
 | **Stop Stack** | A specific stack on a specific node | Runs `docker compose stop`. Containers are stopped but preserved. Use for off-hours power saving when you want a fast restart later. |
 | **Take Stack Down** | A specific stack on a specific node | Runs `docker compose down`. Containers are removed. Use to fully release resources when the stack is not needed for an extended period. |
 | **Start Stack** | A specific stack on a specific node | Runs `docker compose up -d`. Works for both stopped and removed containers: if they exist they are started, if not they are created from the compose file. |
 
 ## Creating a scheduled task
 
-Click **New Schedule** in the header. The form opens in a centered modal. The Action picker lists every supported operation.
+Click **New Schedule** in the header. The form opens in a centered modal. The Action picker lists every supported operation, grouped by category: Lifecycle, Updates, Security, Maintenance, and Backups.
 
 <Frame>
-  <img src="/images/scheduled-operations/action-picker.png" alt="The New scheduled task modal with the Action combobox expanded. The dropdown lists Restart Stack, Auto-update Stack, Auto-update All Stacks, Fleet Snapshot, System Prune, and Vulnerability Scan as the first six entries. Below the picker, partly visible, sit a Services row with 'echo' and 'prober' checkboxes, the Cron Expression input, the Enabled toggle, and the Delete after successful run checkbox." />
+  <img src="/images/scheduled-operations/action-picker.png" alt="The New scheduled task modal with the Action combobox expanded. The dropdown lists Restart Stack, Auto-update Stack, Auto-update All Stacks on Node, Create Fleet Snapshot, Prune Node Resources, and Scan Node Images as the first six entries. Below the picker, partly visible, sit a Services row with 'echo' and 'prober' checkboxes, the Cron Expression input, the Enabled toggle, and the Delete after successful run checkbox." />
 </Frame>
 
 Common fields:
@@ -87,11 +87,11 @@ Common fields:
 
 Conditional fields per action:
 
-- **Stack actions** (Restart Stack, Auto-update Stack, Backup Stack Files, Stop / Take Down / Start Stack) add a **Node** combobox and a **Stack** combobox. Restart Stack additionally renders a **Services** checkbox grid sourced from the stack's compose services on the selected node, so you can scope the restart to a subset instead of restarting the entire stack.
-- **Auto-update All Stacks** adds a **Node** combobox with the helper text "Every stack on the selected node will be checked and updated when new images are available."
-- **Vulnerability Scan** adds a **Node** combobox listing local nodes only, with the helper text "Every image on the selected node will be scanned. Scans run on local nodes only."
-- **System Prune** adds a **Node** combobox listing local nodes only, then a **Prune Targets** group (Containers, Images, Networks, Volumes; all selected by default) and a **Label Filter** input for scoping the prune to resources matching a Docker label.
-- **Fleet Snapshot** shows a read-only **Scope: Entire fleet** summary instead of a Node or Stack picker, because it captures every node.
+- **Stack actions** (Backup Stack Compose Files, Start / Bring Up Stack, Restart Stack, Auto-update Stack, Stop Stack, Take Stack Down) add a **Node** combobox and a **Stack** combobox. Restart Stack additionally renders a **Services** checkbox grid sourced from the stack's compose services on the selected node, so you can scope the restart to a subset instead of restarting the entire stack.
+- **Auto-update All Stacks on Node** adds a **Node** combobox with the helper text "Every stack on the selected node will be checked and updated when new images are available."
+- **Scan Node Images** adds a **Node** combobox listing local nodes only, with the helper text "Every image on the selected node will be scanned. Scans run on local nodes only."
+- **Prune Node Resources** adds a **Node** combobox listing local nodes only, then a **Prune Targets** group (Containers, Images, Networks, Volumes; all selected by default) and a **Label Filter** input for scoping the prune to resources matching a Docker label.
+- **Create Fleet Snapshot** shows a read-only **Scope: Entire fleet** summary instead of a Node or Stack picker, because it captures every node.
 
 <Frame>
   <img src="/images/scheduled-operations/create-restart.png" alt="The New scheduled task modal configured for a Restart Stack task. Name reads 'Nightly staging restart'. Action is Restart Stack. Node is Local. Stack is 'audit-mesh-prod'. A Services group with helper text '(leave empty for all)' shows two unchecked checkboxes labelled 'echo' and 'prober'. Cron Expression is '0 3 * * *' with the preview 'At 03:00 AM'. The Enabled toggle reads ON. The Delete after successful run checkbox is unchecked. Cancel and Create buttons sit at the bottom right." />
@@ -105,32 +105,32 @@ When creating a Restart Stack task and a stack is selected, Sencho reads the com
 
 ### Scheduled vulnerability scans
 
-A Vulnerability Scan task runs Trivy against every image on the selected node and persists the findings. Trivy must be installed on that node ([Installing Trivy](/operations/trivy-setup)). Manual and scheduled scans share the same digest-based 24-hour cache, so unchanged images that were scanned recently are reused instead of rescanned on every run, which keeps execution time low.
+A Scan Node Images task runs Trivy against every image on the selected node and persists the findings. Trivy must be installed on that node ([Installing Trivy](/operations/trivy-setup)). Manual and scheduled scans share the same digest-based 24-hour cache, so unchanged images that were scanned recently are reused instead of rescanned on every run, which keeps execution time low.
 
 When a scheduled scan finishes, Sencho dispatches a completion notification. The severity reflects the outcome (info on a clean run, warning when findings are present); the category is `scan_finding`. The full message format and how it surfaces in the bell is documented in [Alerts & Notifications · Vulnerability scanning](/features/alerts-notifications#vulnerability-scanning).
 
 <Frame>
-  <img src="/images/scheduled-operations/create-scan.png" alt="The New scheduled task modal configured for a Vulnerability Scan. Name reads 'Nightly vulnerability scan'. Action is Vulnerability Scan. Node is Local with helper text explaining every image on the selected node will be scanned and scans run on local nodes only. Cron Expression is '0 3 * * *' with the preview 'At 03:00 AM'. The Enabled toggle reads ON. Cancel and Create buttons sit at the bottom right." />
+  <img src="/images/scheduled-operations/create-scan.png" alt="The New scheduled task modal configured for a Scan Node Images. Name reads 'Nightly vulnerability scan'. Action is Scan Node Images. Node is Local with helper text explaining every image on the selected node will be scanned and scans run on local nodes only. Cron Expression is '0 3 * * *' with the preview 'At 03:00 AM'. The Enabled toggle reads ON. Cancel and Create buttons sit at the bottom right." />
 </Frame>
 
 ### Prune label filter
 
-When creating a System Prune task, the **Label Filter (optional)** input scopes the prune to resources matching a specific Docker label. Use `key=value` format (for example, `com.docker.compose.project=staging`). Leave the field empty to prune every unused resource of the selected types.
+When creating a Prune Node Resources task, the **Label Filter (optional)** input scopes the prune to resources matching a specific Docker label. Use `key=value` format (for example, `com.docker.compose.project=staging`). Leave the field empty to prune every unused resource of the selected types.
 
 <Frame>
-  <img src="/images/scheduled-operations/create-prune.png" alt="The New scheduled task modal configured for a System Prune. Name reads 'Weekly cleanup'. Action is System Prune. Node is Local. The Prune Targets group shows four checked boxes: Containers, Images, Networks, Volumes. The Label Filter (optional) input reads 'com.docker.compose.project=staging' with the helper text 'Only prune resources matching this Docker label.' Cron Expression is '0 4 * * 0' with the preview 'At 04:00 AM, only on Sunday'. The Enabled toggle reads ON. The Delete after successful run checkbox is unchecked. Cancel and Create buttons sit at the bottom right." />
+  <img src="/images/scheduled-operations/create-prune.png" alt="The New scheduled task modal configured for a Prune Node Resources. Name reads 'Weekly cleanup'. Action is Prune Node Resources. Node is Local. The Prune Targets group shows four checked boxes: Containers, Images, Networks, Volumes. The Label Filter (optional) input reads 'com.docker.compose.project=staging' with the helper text 'Only prune resources matching this Docker label.' Cron Expression is '0 4 * * 0' with the preview 'At 04:00 AM, only on Sunday'. The Enabled toggle reads ON. The Delete after successful run checkbox is unchecked. Cancel and Create buttons sit at the bottom right." />
 </Frame>
 
 ### Stack lifecycle scheduling
 
-Stop Stack, Take Stack Down, Start Stack, and Backup Stack Files let you schedule lifecycle events for individual stacks on a per-node basis. A common pattern for development or staging stacks is:
+Backup Stack Compose Files, Start / Bring Up Stack, Stop Stack, and Take Stack Down let you schedule lifecycle events for individual stacks on a per-node basis. A common pattern for development or staging stacks is:
 
 - A **Stop Stack** or **Take Stack Down** task at the end of the working day (for example, `0 19 * * 1-5`, 7 PM on weekdays).
 - A **Start Stack** task at the start of the working day (for example, `0 8 * * 1-5`, 8 AM on weekdays).
 
 **Stop vs Take Down.** Use Stop Stack when you want containers ready to resume quickly: Docker keeps the container filesystem in place and the matching Start Stack simply restarts the existing containers. Use Take Stack Down to fully release resources; Start Stack then recreates the containers from the compose file on the next run.
 
-**Backup Stack Files** keeps a single slot per stack under `<DATA_DIR>/backups/<stack>/`. Each run overwrites the previous backup. For a versioned, point-in-time archive across all nodes, use a [Fleet Snapshot](/features/fleet-backups) task instead.
+**Backup Stack Compose Files** keeps a single slot per stack under `<DATA_DIR>/backups/<stack>/`. Each run overwrites the previous backup. For a versioned, point-in-time archive across all nodes, use a [Create Fleet Snapshot](/features/fleet-backups) task instead.
 
 Pick any node in your fleet from the schedule's **Node** combobox: the four lifecycle actions run against the node you select, whether it is the hub or a connected remote. The schedule itself is stored on the hub, so you manage every node's lifecycle tasks from one place.
 
@@ -196,7 +196,7 @@ When a scheduled task fails, Sencho dispatches an `error`-level notification in 
 
 When a task that previously failed succeeds again, Sencho dispatches an `info`-level recovery notification in the same category to confirm the issue is resolved. Tasks that succeed on every run do not produce per-run notifications: the recovery-only approach keeps the channel quiet during steady-state operation.
 
-Vulnerability Scan tasks are an exception: they always dispatch a completion notification, even on a clean run, because the message body carries severity counts you may want to react to. The severity is `info` on a clean run and `warning` when findings are present; the category is `scan_finding`, not `system`. The full message format and routing behavior is documented in [Alerts & Notifications · Vulnerability scanning](/features/alerts-notifications#vulnerability-scanning).
+Scan Node Images tasks are an exception: they always dispatch a completion notification, even on a clean run, because the message body carries severity counts you may want to react to. The severity is `info` on a clean run and `warning` when findings are present; the category is `scan_finding`, not `system`. The full message format and routing behavior is documented in [Alerts & Notifications · Vulnerability scanning](/features/alerts-notifications#vulnerability-scanning).
 
 Configure delivery channels in **Settings · Notifications · Channels**.
 
@@ -232,7 +232,7 @@ A background Scheduler Service evaluates due tasks every 60 seconds. When a task
 4. On failure, an `error`-level notification goes out through the configured channels. On recovery from a previously failing state, an `info`-level recovery notification is dispatched.
 5. The next run time is recalculated from the cron expression.
 
-Schedules are stored on the hub. Stack-targeted actions execute against the selected node, so lifecycle and per-stack update schedules can target either the hub or a connected remote node. System Prune and Vulnerability Scan run on local nodes only. Fleet Snapshot captures every node from the hub schedule.
+Schedules are stored on the hub. Stack-targeted actions execute against the selected node, so lifecycle and per-stack update schedules can target either the hub or a connected remote node. Prune Node Resources and Scan Node Images run on local nodes only. Create Fleet Snapshot captures every node from the hub schedule.
 
 If a task is still running from a previous firing, the scheduler skips the new firing to prevent overlap.
 
@@ -250,14 +250,14 @@ If Sencho restarts while a task is mid-execution, the orphaned run record is mar
   <Accordion title="A scheduled scan completed but no notification arrived">
     Scan notifications share the same delivery path as every other Sencho notification. Check, in order: 1) at least one channel is enabled in **Settings · Notifications · Channels** and its **Test** button succeeds; 2) if the stack the scan is associated with has notification routes defined, at least one matching route is enabled (the routing layer takes priority over the global channels); 3) open the notification bell, where every notification is recorded regardless of channel configuration, and look for a delivery-error entry; 4) on a remote node, channels must be configured on that node itself because channel settings are per-node.
   </Accordion>
-  <Accordion title="A Vulnerability Scan fails with 'Trivy binary is not available'">
+  <Accordion title="A Scan Node Images fails with 'Trivy binary is not available'">
     Trivy must be installed on the node that runs the scan, not just on the gateway. Follow [Installing Trivy](/operations/trivy-setup) on the target node, then click **Run now** on the schedule to confirm the scan succeeds before waiting for the next cron tick.
   </Accordion>
   <Accordion title="A Start Stack run fails with a compose file error">
     Start Stack runs `docker compose up -d` against the stack's compose directory. If the stack folder has been removed or its compose file is missing, the run fails. Re-create or restore the stack from the [Editor](/features/editor), then click **Run now** on the schedule to confirm it succeeds before the next cron tick.
   </Accordion>
-  <Accordion title="A Backup Stack Files run overwrote the previous backup">
-    Backup Stack Files keeps a single slot per stack under `<DATA_DIR>/backups/<stack>/`. Each run overwrites the previous backup. This is by design: for a versioned archive of compose files across the fleet, use a [Fleet Snapshot](/features/fleet-backups) task, which retains every snapshot under the snapshots directory.
+  <Accordion title="A Backup Stack Compose Files run overwrote the previous backup">
+    Backup Stack Compose Files keeps a single slot per stack under `<DATA_DIR>/backups/<stack>/`. Each run overwrites the previous backup. This is by design: for a versioned archive of compose files across the fleet, use a [Create Fleet Snapshot](/features/fleet-backups) task, which retains every snapshot under the snapshots directory.
   </Accordion>
   <Accordion title="A one-shot task disappeared from the list">
     A task with **Delete after successful run** enabled removes itself automatically after the first successful execution, along with its run history. This is expected behavior. If you need a record of the run before deletion, click **Download CSV** in the run history sheet before the next successful run.

--- a/docs/features/scheduled-operations.mdx
+++ b/docs/features/scheduled-operations.mdx
@@ -67,14 +67,14 @@ The All tasks toggle swaps the lane track for a sortable table.
 | **Backup Stack Compose Files** | A specific stack on a specific node | Copies the stack's compose file and `.env` to `<DATA_DIR>/backups/<stack>/`. One slot per stack; each run overwrites the previous backup. For a versioned archive use a Create Fleet Snapshot instead. |
 | **Stop Stack** | A specific stack on a specific node | Runs `docker compose stop`. Containers are stopped but preserved. Use for off-hours power saving when you want a fast restart later. |
 | **Take Stack Down** | A specific stack on a specific node | Runs `docker compose down`. Containers are removed. Use to fully release resources when the stack is not needed for an extended period. |
-| **Start Stack** | A specific stack on a specific node | Runs `docker compose up -d`. Works for both stopped and removed containers: if they exist they are started, if not they are created from the compose file. |
+| **Start / Bring Up Stack** | A specific stack on a specific node | Runs `docker compose up -d`. Works for both stopped and removed containers: if they exist they are started, if not they are created from the compose file. |
 
 ## Creating a scheduled task
 
 Click **New Schedule** in the header. The form opens in a centered modal. The Action picker lists every supported operation, grouped by category: Lifecycle, Updates, Security, Maintenance, and Backups.
 
 <Frame>
-  <img src="/images/scheduled-operations/action-picker.png" alt="The New scheduled task modal with the Action combobox expanded. The dropdown lists Restart Stack, Auto-update Stack, Auto-update All Stacks on Node, Create Fleet Snapshot, Prune Node Resources, and Scan Node Images as the first six entries. Below the picker, partly visible, sit a Services row with 'echo' and 'prober' checkboxes, the Cron Expression input, the Enabled toggle, and the Delete after successful run checkbox." />
+  <img src="/images/scheduled-operations/action-picker.png" alt="The New scheduled task modal with the Action combobox expanded. The dropdown groups actions under category headers: Lifecycle (Backup Stack Compose Files, Start / Bring Up Stack, Restart Stack, Stop Stack, Take Stack Down), Updates (Auto-update Stack, Auto-update All Stacks on Node), Security (Scan Node Images), Maintenance (Prune Node Resources), and Backups (Create Fleet Snapshot). Below the picker, partly visible, sit a Services row with 'echo' and 'prober' checkboxes, the Cron Expression input, the Enabled toggle, and the Delete after successful run checkbox." />
 </Frame>
 
 Common fields:
@@ -126,7 +126,7 @@ When creating a Prune Node Resources task, the **Label Filter (optional)** input
 Backup Stack Compose Files, Start / Bring Up Stack, Stop Stack, and Take Stack Down let you schedule lifecycle events for individual stacks on a per-node basis. A common pattern for development or staging stacks is:
 
 - A **Stop Stack** or **Take Stack Down** task at the end of the working day (for example, `0 19 * * 1-5`, 7 PM on weekdays).
-- A **Start Stack** task at the start of the working day (for example, `0 8 * * 1-5`, 8 AM on weekdays).
+- A **Start / Bring Up Stack** task at the start of the working day (for example, `0 8 * * 1-5`, 8 AM on weekdays).
 
 **Stop vs Take Down.** Use Stop Stack when you want containers ready to resume quickly: Docker keeps the container filesystem in place and the matching Start Stack simply restarts the existing containers. Use Take Stack Down to fully release resources; Start Stack then recreates the containers from the compose file on the next run.
 
@@ -253,8 +253,8 @@ If Sencho restarts while a task is mid-execution, the orphaned run record is mar
   <Accordion title="A Scan Node Images fails with 'Trivy binary is not available'">
     Trivy must be installed on the node that runs the scan, not just on the gateway. Follow [Installing Trivy](/operations/trivy-setup) on the target node, then click **Run now** on the schedule to confirm the scan succeeds before waiting for the next cron tick.
   </Accordion>
-  <Accordion title="A Start Stack run fails with a compose file error">
-    Start Stack runs `docker compose up -d` against the stack's compose directory. If the stack folder has been removed or its compose file is missing, the run fails. Re-create or restore the stack from the [Editor](/features/editor), then click **Run now** on the schedule to confirm it succeeds before the next cron tick.
+  <Accordion title="A Start / Bring Up Stack run fails with a compose file error">
+    Start / Bring Up Stack runs `docker compose up -d` against the stack's compose directory. If the stack folder has been removed or its compose file is missing, the run fails. Re-create or restore the stack from the [Editor](/features/editor), then click **Run now** on the schedule to confirm it succeeds before the next cron tick.
   </Accordion>
   <Accordion title="A Backup Stack Compose Files run overwrote the previous backup">
     Backup Stack Compose Files keeps a single slot per stack under `<DATA_DIR>/backups/<stack>/`. Each run overwrites the previous backup. This is by design: for a versioned archive of compose files across the fleet, use a [Create Fleet Snapshot](/features/fleet-backups) task, which retains every snapshot under the snapshots directory.

--- a/frontend/src/components/ScheduledOperationsView.tsx
+++ b/frontend/src/components/ScheduledOperationsView.tsx
@@ -20,6 +20,7 @@ import {
   SCHEDULED_ACTION_CATEGORIES,
   getActionById,
   resolveTaskAction,
+  DEFAULT_SCHEDULED_ACTION_ID,
 } from '@/lib/scheduledActions';
 
 const DEFAULT_PRUNE_TARGETS = ['containers', 'images', 'networks', 'volumes'];
@@ -194,7 +195,7 @@ export default function ScheduledOperationsView({ filterNodeId, onClearFilter, p
     const nodeId = prefillData?.nodeId ?? (filterNodeId != null ? String(filterNodeId) : '');
     setEditingTask(null);
     setFormName('');
-    setFormAction(SCHEDULED_ACTIONS[0]?.id ?? 'restart');
+    setFormAction(DEFAULT_SCHEDULED_ACTION_ID);
     setFormTargetId(prefillData?.stackName ?? '');
     setFormNodeId(nodeId);
     setFormCron('0 3 * * *');
@@ -342,6 +343,15 @@ export default function ScheduledOperationsView({ filterNodeId, onClearFilter, p
   const cronDescription = getCronDescription(formCron);
   const cronFieldError = getCronFieldError(formCron);
   const nodeOptions = useMemo(() => nodes.map(n => ({ value: String(n.id), label: n.name })), [nodes]);
+  const actionOptions = useMemo(
+    () =>
+      SCHEDULED_ACTIONS.map(o => ({
+        value: o.id,
+        label: o.label,
+        group: SCHEDULED_ACTION_CATEGORIES.find(c => c.key === o.category)?.label,
+      })),
+    [],
+  );
   // Scan and prune run on the hub-local Docker daemon only; remote nodes are excluded from their pickers.
   const localNodeOptions = useMemo(
     () => nodes.filter(n => n.type === 'local').map(n => ({ value: String(n.id), label: n.name })),
@@ -670,7 +680,7 @@ export default function ScheduledOperationsView({ filterNodeId, onClearFilter, p
             <div className="space-y-2">
               <Label>Action</Label>
               <Combobox
-                options={SCHEDULED_ACTIONS.map(o => ({ value: o.id, label: o.label }))}
+                options={actionOptions}
                 value={formAction}
                 onValueChange={(val) => { setFormAction(val); setFormTargetId(''); setFormNodeId(''); setFormTargetServices([]); setFormPruneLabelFilter(''); }}
                 placeholder="Select action..."

--- a/frontend/src/components/__tests__/ScheduledOperationsView.test.tsx
+++ b/frontend/src/components/__tests__/ScheduledOperationsView.test.tsx
@@ -149,9 +149,9 @@ describe('ScheduledOperationsView', () => {
     await userEvent.click(await screen.findByRole('button', { name: /New Schedule/ }));
     await userEvent.type(await screen.findByPlaceholderText('e.g. Nightly stack restart'), 'cleanup');
 
-    // The action selector is the first combobox; switch it to System Prune.
+    // The action selector is the first combobox; switch it to Prune Node Resources.
     await userEvent.click(screen.getAllByRole('combobox')[0]);
-    await userEvent.click(await screen.findByRole('button', { name: 'System Prune' }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Prune Node Resources' }));
 
     // Prune is now node-scoped: pick the local node from its Node combobox.
     await userEvent.click(screen.getAllByRole('combobox')[1]);
@@ -184,7 +184,7 @@ describe('ScheduledOperationsView', () => {
     await userEvent.type(await screen.findByPlaceholderText('e.g. Nightly stack restart'), 'cleanup');
 
     await userEvent.click(screen.getAllByRole('combobox')[0]);
-    await userEvent.click(await screen.findByRole('button', { name: 'System Prune' }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Prune Node Resources' }));
     await userEvent.click(screen.getAllByRole('combobox')[1]);
     await userEvent.click(await screen.findByRole('button', { name: 'hub' }));
 
@@ -209,7 +209,7 @@ describe('ScheduledOperationsView', () => {
     await userEvent.click(await screen.findByRole('button', { name: /New Schedule/ }));
     await userEvent.type(await screen.findByPlaceholderText('e.g. Nightly stack restart'), 'cleanup');
     await userEvent.click(screen.getAllByRole('combobox')[0]);
-    await userEvent.click(await screen.findByRole('button', { name: 'System Prune' }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Prune Node Resources' }));
 
     // Prune targets default to all four, but with no node the gate must hold.
     expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
@@ -219,12 +219,12 @@ describe('ScheduledOperationsView', () => {
     expect(screen.getByRole('button', { name: 'Create' })).toBeEnabled();
   });
 
-  it('excludes remote nodes from the System Prune node picker', async () => {
+  it('excludes remote nodes from the Prune Node Resources node picker', async () => {
     render(<ScheduledOperationsView />);
 
     await userEvent.click(await screen.findByRole('button', { name: /New Schedule/ }));
     await userEvent.click(screen.getAllByRole('combobox')[0]);
-    await userEvent.click(await screen.findByRole('button', { name: 'System Prune' }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Prune Node Resources' }));
 
     // Open the Node combobox; only the local node should be listed.
     await userEvent.click(screen.getAllByRole('combobox')[1]);
@@ -232,12 +232,12 @@ describe('ScheduledOperationsView', () => {
     expect(screen.queryByRole('button', { name: 'edge' })).not.toBeInTheDocument();
   });
 
-  it('excludes remote nodes from the Vulnerability Scan node picker', async () => {
+  it('excludes remote nodes from the Scan Node Images node picker', async () => {
     render(<ScheduledOperationsView />);
 
     await userEvent.click(await screen.findByRole('button', { name: /New Schedule/ }));
     await userEvent.click(screen.getAllByRole('combobox')[0]);
-    await userEvent.click(await screen.findByRole('button', { name: 'Vulnerability Scan' }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Scan Node Images' }));
 
     await userEvent.click(screen.getAllByRole('combobox')[1]);
     expect(await screen.findByRole('button', { name: 'hub' })).toBeInTheDocument();
@@ -250,7 +250,7 @@ describe('ScheduledOperationsView', () => {
     await userEvent.click(await screen.findByRole('button', { name: /New Schedule/ }));
     await userEvent.type(await screen.findByPlaceholderText('e.g. Nightly stack restart'), 'scan-local');
     await userEvent.click(screen.getAllByRole('combobox')[0]);
-    await userEvent.click(await screen.findByRole('button', { name: 'Vulnerability Scan' }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Scan Node Images' }));
     await userEvent.click(screen.getAllByRole('combobox')[1]);
     await userEvent.click(await screen.findByRole('button', { name: 'hub' }));
 
@@ -276,12 +276,12 @@ describe('ScheduledOperationsView', () => {
     });
   });
 
-  it('shows a read-only "Entire fleet" scope for Fleet Snapshot', async () => {
+  it('shows a read-only "Entire fleet" scope for Create Fleet Snapshot', async () => {
     render(<ScheduledOperationsView />);
 
     await userEvent.click(await screen.findByRole('button', { name: /New Schedule/ }));
     await userEvent.click(screen.getAllByRole('combobox')[0]);
-    await userEvent.click(await screen.findByRole('button', { name: 'Fleet Snapshot' }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Create Fleet Snapshot' }));
 
     expect(await screen.findByText('Entire fleet')).toBeInTheDocument();
   });
@@ -340,17 +340,17 @@ describe('ScheduledOperationsView', () => {
     expect(screen.queryByText('Prune Targets')).not.toBeInTheDocument();
 
     // Node-only action: Node shown, Stack hidden.
-    await selectAction('Auto-update All Stacks');
+    await selectAction('Auto-update All Stacks on Node');
     expect(screen.getByText('Node')).toBeInTheDocument();
     expect(screen.queryByText('Stack')).not.toBeInTheDocument();
 
     // Fleet snapshot: no Node, no Stack.
-    await selectAction('Fleet Snapshot');
+    await selectAction('Create Fleet Snapshot');
     expect(screen.queryByText('Node')).not.toBeInTheDocument();
     expect(screen.queryByText('Stack')).not.toBeInTheDocument();
 
     // Prune: local-only Node plus Prune Targets.
-    await selectAction('System Prune');
+    await selectAction('Prune Node Resources');
     expect(screen.getByText('Prune Targets')).toBeInTheDocument();
     expect(screen.getByText('Node')).toBeInTheDocument();
   });
@@ -396,7 +396,7 @@ describe('ScheduledOperationsView', () => {
     await userEvent.type(await screen.findByPlaceholderText('e.g. Nightly stack restart'), 'fleet-update');
 
     await userEvent.click(screen.getAllByRole('combobox')[0]);
-    await userEvent.click(await screen.findByRole('button', { name: 'Auto-update All Stacks' }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Auto-update All Stacks on Node' }));
 
     // Node selector is the second combobox once the node-only field renders.
     await userEvent.click(screen.getAllByRole('combobox')[1]);
@@ -434,7 +434,7 @@ describe('ScheduledOperationsView', () => {
     await userEvent.click(await screen.findByRole('button', { name: /All tasks/ }));
     await userEvent.click(await screen.findByTitle('Edit'));
     await userEvent.click(screen.getAllByRole('combobox')[0]);
-    await userEvent.click(await screen.findByRole('button', { name: 'Fleet Snapshot' }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Create Fleet Snapshot' }));
     await userEvent.click(screen.getByRole('button', { name: 'Update' }));
 
     await waitFor(() => {

--- a/frontend/src/components/ui/__tests__/combobox.test.tsx
+++ b/frontend/src/components/ui/__tests__/combobox.test.tsx
@@ -90,4 +90,26 @@ describe('Combobox', () => {
       expect(h.getAttribute('role')).toBeNull();
     }
   });
+
+  it('correctly partitions interleaved groups by first appearance', async () => {
+    const MIXED: ComboboxOption[] = [
+      { value: 'a1', label: 'A1', group: 'Lifecycle' },
+      { value: 'u1', label: 'U1', group: 'Updates' },
+      { value: 'a2', label: 'A2', group: 'Lifecycle' },
+    ];
+    const onChange = vi.fn();
+    render(<Combobox options={MIXED} value="" onValueChange={onChange} placeholder="Pick..." />);
+
+    await userEvent.click(screen.getByRole('combobox'));
+
+    const headers = document.querySelectorAll('.text-xs.font-medium.text-muted-foreground');
+    expect(headers).toHaveLength(2);
+    expect(headers[0].textContent).toBe('Lifecycle');
+    expect(headers[1].textContent).toBe('Updates');
+
+    // A1 and A2 should both be under Lifecycle, not split.
+    const lifecycleSection = headers[0].parentElement!;
+    expect(lifecycleSection.querySelectorAll('button')).toHaveLength(2);
+    expect(lifecycleSection.querySelector('button')?.textContent).toContain('A1');
+  });
 });

--- a/frontend/src/components/ui/__tests__/combobox.test.tsx
+++ b/frontend/src/components/ui/__tests__/combobox.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * Lock the Combobox component: flat-rendering regression guard, grouped-option
+ * rendering, search filtering with groups, selection callback, and group-header
+ * non-interactivity.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Combobox, type ComboboxOption } from '../combobox';
+
+const FLAT_OPTIONS: ComboboxOption[] = [
+  { value: 'a', label: 'Alpha' },
+  { value: 'b', label: 'Beta' },
+  { value: 'c', label: 'Gamma' },
+];
+
+const GROUPED_OPTIONS: ComboboxOption[] = [
+  { value: 'r', label: 'Restart Stack', group: 'Lifecycle' },
+  { value: 's', label: 'Stop Stack', group: 'Lifecycle' },
+  { value: 'u', label: 'Auto-update Stack', group: 'Updates' },
+  { value: 'p', label: 'Prune Node Resources', group: 'Maintenance' },
+];
+
+describe('Combobox', () => {
+  it('renders flat options unchanged when no group field is present', async () => {
+    const onChange = vi.fn();
+    render(<Combobox options={FLAT_OPTIONS} value="" onValueChange={onChange} placeholder="Pick..." />);
+
+    await userEvent.click(screen.getByRole('combobox'));
+
+    expect(screen.getByRole('button', { name: 'Alpha' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Beta' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Gamma' })).toBeInTheDocument();
+  });
+
+  it('renders group headers in order of first appearance', async () => {
+    const onChange = vi.fn();
+    render(<Combobox options={GROUPED_OPTIONS} value="" onValueChange={onChange} placeholder="Pick..." />);
+
+    await userEvent.click(screen.getByRole('combobox'));
+
+    // Group headers rendered as non-interactive text.
+    const headers = document.querySelectorAll('.text-xs.font-medium.text-muted-foreground');
+    expect(headers).toHaveLength(3);
+    expect(headers[0].textContent).toBe('Lifecycle');
+    expect(headers[1].textContent).toBe('Updates');
+    expect(headers[2].textContent).toBe('Maintenance');
+  });
+
+  it('search hides groups with no matching options', async () => {
+    const onChange = vi.fn();
+    render(<Combobox options={GROUPED_OPTIONS} value="" onValueChange={onChange} placeholder="Pick..." />);
+
+    await userEvent.click(screen.getByRole('combobox'));
+
+    // The inline search input appears when open; type "stop".
+    const input = screen.getByRole('textbox');
+    await userEvent.type(input, 'stop');
+
+    // Only the Lifecycle header should remain visible.
+    const headers = document.querySelectorAll('.text-xs.font-medium.text-muted-foreground');
+    expect(headers).toHaveLength(1);
+    expect(headers[0].textContent).toBe('Lifecycle');
+
+    // Only Stop Stack should be visible.
+    expect(screen.getByRole('button', { name: 'Stop Stack' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Restart Stack' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Auto-update Stack' })).not.toBeInTheDocument();
+  });
+
+  it('selecting a grouped option calls onValueChange', async () => {
+    const onChange = vi.fn();
+    render(<Combobox options={GROUPED_OPTIONS} value="" onValueChange={onChange} placeholder="Pick..." />);
+
+    await userEvent.click(screen.getByRole('combobox'));
+    await userEvent.click(screen.getByRole('button', { name: 'Prune Node Resources' }));
+
+    expect(onChange).toHaveBeenCalledWith('p');
+  });
+
+  it('group headers are not interactive elements', async () => {
+    const onChange = vi.fn();
+    render(<Combobox options={GROUPED_OPTIONS} value="" onValueChange={onChange} placeholder="Pick..." />);
+
+    await userEvent.click(screen.getByRole('combobox'));
+
+    const headers = document.querySelectorAll('.text-xs.font-medium.text-muted-foreground');
+    for (const h of headers) {
+      expect(h.tagName).toBe('DIV');
+      expect(h.getAttribute('role')).toBeNull();
+    }
+  });
+});

--- a/frontend/src/components/ui/combobox.tsx
+++ b/frontend/src/components/ui/combobox.tsx
@@ -82,17 +82,17 @@ export function Combobox({
 
   const groupedOptions = React.useMemo(() => {
     if (!hasGroups) return null
-    const groups: { label: string; options: ComboboxOption[] }[] = []
-    const seen = new Set<string>()
+    const groupMap = new Map<string, ComboboxOption[]>()
+    const groupOrder: string[] = []
     for (const o of filtered) {
       const g = o.group!
-      if (!seen.has(g)) {
-        seen.add(g)
-        groups.push({ label: g, options: [] })
+      if (!groupMap.has(g)) {
+        groupMap.set(g, [])
+        groupOrder.push(g)
       }
-      groups[groups.length - 1].options.push(o)
+      groupMap.get(g)!.push(o)
     }
-    return groups
+    return groupOrder.map(label => ({ label, options: groupMap.get(label)! }))
   }, [filtered, hasGroups])
 
   return (

--- a/frontend/src/components/ui/combobox.tsx
+++ b/frontend/src/components/ui/combobox.tsx
@@ -6,6 +6,9 @@ import { cn } from "@/lib/utils"
 export interface ComboboxOption {
   value: string
   label: string
+  /** Optional category group. When any option has a group, options render in
+   *  grouped sections with non-interactive headers between groups. */
+  group?: string
 }
 
 interface ComboboxProps {
@@ -75,6 +78,23 @@ export function Combobox({
     setSearch("")
   }
 
+  const hasGroups = filtered.some((o) => o.group)
+
+  const groupedOptions = React.useMemo(() => {
+    if (!hasGroups) return null
+    const groups: { label: string; options: ComboboxOption[] }[] = []
+    const seen = new Set<string>()
+    for (const o of filtered) {
+      const g = o.group!
+      if (!seen.has(g)) {
+        seen.add(g)
+        groups.push({ label: g, options: [] })
+      }
+      groups[groups.length - 1].options.push(o)
+    }
+    return groups
+  }, [filtered, hasGroups])
+
   return (
     <div ref={wrapperRef} className={cn("relative w-full", className)}>
       {/* Trigger: static button when closed, inline search input when open */}
@@ -121,6 +141,34 @@ export function Combobox({
               <div className="py-4 text-center text-sm text-muted-foreground">
                 {emptyText}
               </div>
+            ) : hasGroups && groupedOptions ? (
+              groupedOptions.map((group) => (
+                <div key={group.label}>
+                  <div className="px-2 pt-2 pb-1 text-xs font-medium text-muted-foreground select-none">
+                    {group.label}
+                  </div>
+                  {group.options.map((option) => (
+                    <button
+                      key={option.value}
+                      type="button"
+                      onClick={() => handleSelect(option)}
+                      className={cn(
+                        "relative flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground",
+                        value === option.value && "bg-accent/50"
+                      )}
+                    >
+                      <Check
+                        className={cn(
+                          "mr-2 h-4 w-4 shrink-0",
+                          value === option.value ? "opacity-100" : "opacity-0"
+                        )}
+                        strokeWidth={1.5}
+                      />
+                      {option.label}
+                    </button>
+                  ))}
+                </div>
+              ))
             ) : (
               filtered.map((option) => (
                 <button

--- a/frontend/src/lib/__tests__/scheduledActions.test.ts
+++ b/frontend/src/lib/__tests__/scheduledActions.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect } from 'vitest';
 import {
   SCHEDULED_ACTIONS,
   SCHEDULED_ACTION_CATEGORIES,
+  DEFAULT_SCHEDULED_ACTION_ID,
   getActionById,
   resolveTaskAction,
   type BackendAction,
@@ -68,5 +69,28 @@ describe('scheduledActions registry', () => {
     it('returns undefined for an unknown action', () => {
       expect(resolveTaskAction({ action: 'bogus' as BackendAction, target_type: 'system' })).toBeUndefined();
     });
+  });
+
+  it('exports DEFAULT_SCHEDULED_ACTION_ID as restart', () => {
+    expect(DEFAULT_SCHEDULED_ACTION_ID).toBe('restart');
+  });
+
+  it('orders actions by category group', () => {
+    const ids = SCHEDULED_ACTIONS.map(a => a.id);
+    // Verify the exact order: lifecycle first, then updates, security, maintenance, backups.
+    expect(ids).toEqual([
+      'auto_backup', 'auto_start', 'restart', 'auto_stop', 'auto_down',
+      'update', 'update-fleet',
+      'scan',
+      'prune',
+      'snapshot',
+    ]);
+  });
+
+  it('preserves the update-fleet alias after resorting', () => {
+    const fleetUpdate = SCHEDULED_ACTIONS.find(a => a.id === 'update-fleet');
+    expect(fleetUpdate).toBeDefined();
+    expect(fleetUpdate!.backendAction).toBe('update');
+    expect(fleetUpdate!.targetType).toBe('fleet');
   });
 });

--- a/frontend/src/lib/scheduledActions.ts
+++ b/frontend/src/lib/scheduledActions.ts
@@ -41,18 +41,26 @@ export interface ScheduledActionDefinition {
   helperText?: string;
 }
 
-/** Ordered for the create-flow action picker. */
+/** Action pre-selected when the create modal opens. Decoupled from picker order. */
+export const DEFAULT_SCHEDULED_ACTION_ID: ScheduledActionId = 'restart';
+
+/** Ordered for the create-flow action picker, grouped by category. */
 export const SCHEDULED_ACTIONS: ScheduledActionDefinition[] = [
+  // Lifecycle
+  { id: 'auto_backup', backendAction: 'auto_backup', label: 'Backup Stack Compose Files', shortLabel: 'backup', category: 'lifecycle', targetType: 'stack', tone: 'brand', requiresNode: true, requiresStack: true, supportsServiceSelection: false },
+  { id: 'auto_start', backendAction: 'auto_start', label: 'Start / Bring Up Stack', shortLabel: 'start', category: 'lifecycle', targetType: 'stack', tone: 'success', requiresNode: true, requiresStack: true, supportsServiceSelection: false },
   { id: 'restart', backendAction: 'restart', label: 'Restart Stack', shortLabel: 'restart', category: 'lifecycle', targetType: 'stack', tone: 'brand', requiresNode: true, requiresStack: true, supportsServiceSelection: true },
+  { id: 'auto_stop', backendAction: 'auto_stop', label: 'Stop Stack', shortLabel: 'stop', category: 'lifecycle', targetType: 'stack', tone: 'warning', requiresNode: true, requiresStack: true, supportsServiceSelection: false },
+  { id: 'auto_down', backendAction: 'auto_down', label: 'Take Stack Down', shortLabel: 'down', category: 'lifecycle', targetType: 'stack', tone: 'destructive', requiresNode: true, requiresStack: true, supportsServiceSelection: false },
+  // Updates
   { id: 'update', backendAction: 'update', label: 'Auto-update Stack', shortLabel: 'update', category: 'updates', targetType: 'stack', tone: 'success', requiresNode: true, requiresStack: true, supportsServiceSelection: false },
-  { id: 'update-fleet', backendAction: 'update', label: 'Auto-update All Stacks', shortLabel: 'update', category: 'updates', targetType: 'fleet', tone: 'success', requiresNode: true, requiresStack: false, supportsServiceSelection: false, helperText: 'Every stack on the selected node will be checked and updated when new images are available.' },
-  { id: 'snapshot', backendAction: 'snapshot', label: 'Fleet Snapshot', shortLabel: 'snapshot', category: 'backups', targetType: 'fleet', tone: 'warning', requiresNode: false, requiresStack: false, supportsServiceSelection: false },
-  { id: 'prune', backendAction: 'prune', label: 'System Prune', shortLabel: 'prune', category: 'maintenance', targetType: 'system', tone: 'warning', requiresNode: true, requiresStack: false, supportsServiceSelection: false, nodeScope: 'local', helperText: 'Resources are pruned on the selected node. Prunes run on local nodes only.' },
-  { id: 'scan', backendAction: 'scan', label: 'Vulnerability Scan', shortLabel: 'scan', category: 'security', targetType: 'system', tone: 'success', requiresNode: true, requiresStack: false, supportsServiceSelection: false, nodeScope: 'local', helperText: 'Every image on the selected node will be scanned. Scans run on local nodes only.' },
-  { id: 'auto_backup', backendAction: 'auto_backup', label: 'Backup Stack Files', shortLabel: 'backup', category: 'lifecycle', targetType: 'stack', tone: 'brand', requiresNode: true, requiresStack: true, supportsServiceSelection: false },
-  { id: 'auto_stop', backendAction: 'auto_stop', label: 'Stop Stack (keep containers)', shortLabel: 'stop', category: 'lifecycle', targetType: 'stack', tone: 'warning', requiresNode: true, requiresStack: true, supportsServiceSelection: false },
-  { id: 'auto_down', backendAction: 'auto_down', label: 'Take Stack Down (remove containers)', shortLabel: 'down', category: 'lifecycle', targetType: 'stack', tone: 'destructive', requiresNode: true, requiresStack: true, supportsServiceSelection: false },
-  { id: 'auto_start', backendAction: 'auto_start', label: 'Start Stack', shortLabel: 'start', category: 'lifecycle', targetType: 'stack', tone: 'success', requiresNode: true, requiresStack: true, supportsServiceSelection: false },
+  { id: 'update-fleet', backendAction: 'update', label: 'Auto-update All Stacks on Node', shortLabel: 'update', category: 'updates', targetType: 'fleet', tone: 'success', requiresNode: true, requiresStack: false, supportsServiceSelection: false, helperText: 'Every stack on the selected node will be checked and updated when new images are available.' },
+  // Security
+  { id: 'scan', backendAction: 'scan', label: 'Scan Node Images', shortLabel: 'scan', category: 'security', targetType: 'system', tone: 'success', requiresNode: true, requiresStack: false, supportsServiceSelection: false, nodeScope: 'local', helperText: 'Every image on the selected node will be scanned. Scans run on local nodes only.' },
+  // Maintenance
+  { id: 'prune', backendAction: 'prune', label: 'Prune Node Resources', shortLabel: 'prune', category: 'maintenance', targetType: 'system', tone: 'warning', requiresNode: true, requiresStack: false, supportsServiceSelection: false, nodeScope: 'local', helperText: 'Resources are pruned on the selected node. Prunes run on local nodes only.' },
+  // Backups
+  { id: 'snapshot', backendAction: 'snapshot', label: 'Create Fleet Snapshot', shortLabel: 'snapshot', category: 'backups', targetType: 'fleet', tone: 'warning', requiresNode: false, requiresStack: false, supportsServiceSelection: false },
 ];
 
 const ACTION_BY_ID = new Map<string, ScheduledActionDefinition>(SCHEDULED_ACTIONS.map(a => [a.id, a]));


### PR DESCRIPTION
## Summary

Reorganizes the New Schedule action picker from a flat dropdown to a category-grouped list. Actions are now grouped under five headers (Lifecycle, Updates, Security, Maintenance, Backups), matching the Timeline lanes. Seven action labels are updated per the operator-intent spec.

The Combobox component gains an optional `group` field on `ComboboxOption`. When present, options render in grouped sections with non-interactive headers. The grouping uses a Map for correct partitioning even with interleaved groups. Flat rendering is unchanged for all other callers across the app.

## Test plan

- 1408 frontend tests pass (165 files)
- 4348 backend tests pass (no backend changes)
- New: 6 Combobox grouping tests (flat regression, group headers, search filtering, selection callback, non-interactivity, interleaved partition)
- New: registry order test and `DEFAULT_SCHEDULED_ACTION_ID` constant test
- TypeScript compiles cleanly on both sides

## Notes

- Action picker screenshots in docs are deferred — they need a running instance with populated stacks/nodes to capture.
- Pre-existing backend test failures (2 files, 4 tests) are Docker timeout flakes on the Windows workstation and unrelated to this change.