### PR TITLE
feat: show container name in structured log output

### DIFF
--- a/backend/src/__tests__/compose-service.test.ts
+++ b/backend/src/__tests__/compose-service.test.ts
@@ -111,7 +111,7 @@ vi.mock('../services/FileSystemService', () => ({
 }));
 
 vi.mock('../services/LogFormatter', () => ({
-  LogFormatter: { formatLine: (line: string) => line },
+  LogFormatter: { process: (line: string) => line },
 }));
 
 // runCommand and the deploy/update paths route through authoredComposeArgs, which
@@ -1054,5 +1054,131 @@ describe('ComposeService - idle-output stall backstop', () => {
     expect(error).not.toBeNull();
     expect(error!.message).toContain('STACK_STALLED_OUTPUT');
     expect(getComposeRollbackInfo(error)).toMatchObject({ attempted: true });
+  });
+});
+
+// ── streamLogs ─────────────────────────────────────────────────────────
+
+describe('ComposeService - streamLogs', () => {
+  it('emits a normalized container name prefix for each container', async () => {
+    mockGetContainersByStack.mockResolvedValue([
+      { Names: ['/mystack-redis-1'], State: 'running', Id: 'abc123' },
+      { Names: ['/mystack-api-1'], State: 'running', Id: 'def456' },
+    ]);
+
+    const ws = createMockWs();
+    const svc = ComposeService.getInstance(1);
+
+    const proc1 = createMockProcess();
+    const proc2 = createMockProcess();
+    mockSpawn
+      .mockReturnValueOnce(proc1)
+      .mockReturnValueOnce(proc2);
+
+    svc.streamLogs('mystack', ws);
+    await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalledTimes(2));
+
+    // Emit stdout from each container.
+    proc1.stdout.emit('data', Buffer.from('2024-01-01T00:00:00Z redis log line\n'));
+    proc2.stdout.emit('data', Buffer.from('2024-01-01T00:00:01Z api response\n'));
+
+    const calls = (ws.send as ReturnType<typeof vi.fn>).mock.calls as string[][];
+    const sentLines = calls.flatMap(c => c[0].split('\r\n')).filter(Boolean);
+
+    expect(sentLines).toContain('redis | 2024-01-01T00:00:00Z redis log line');
+    expect(sentLines).toContain('api | 2024-01-01T00:00:01Z api response');
+  });
+
+  it('prefixes flushBuffer trailing line on child close', async () => {
+    mockGetContainersByStack.mockResolvedValue([
+      { Names: ['/mystack-web-1'], State: 'running', Id: 'ghi789' },
+    ]);
+
+    const ws = createMockWs();
+    const svc = ComposeService.getInstance(1);
+
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    svc.streamLogs('mystack', ws);
+    await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalled());
+
+    // Emit a line without a trailing newline, then close.
+    proc.stdout.emit('data', Buffer.from('trailing content'));
+    proc.emit('close', 0);
+
+    const calls = (ws.send as ReturnType<typeof vi.fn>).mock.calls as string[][];
+    const sentLines = calls.flatMap(c => c[0].split('\r\n')).filter(Boolean);
+
+    expect(sentLines).toContain('web | trailing content');
+  });
+
+  it('joins chunk-split lines and prefixes once', async () => {
+    mockGetContainersByStack.mockResolvedValue([
+      { Names: ['/mystack-db-1'], State: 'running', Id: 'jkl012' },
+    ]);
+
+    const ws = createMockWs();
+    const svc = ComposeService.getInstance(1);
+
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    svc.streamLogs('mystack', ws);
+    await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalled());
+
+    // Split a single line across two data events.
+    proc.stdout.emit('data', Buffer.from('2024-01-01T00:00:00Z partial '));
+    proc.stdout.emit('data', Buffer.from('end of line\n'));
+
+    const calls = (ws.send as ReturnType<typeof vi.fn>).mock.calls as string[][];
+    const sentLines = calls.flatMap(c => c[0].split('\r\n')).filter(Boolean);
+
+    expect(sentLines).toContain('db | 2024-01-01T00:00:00Z partial end of line');
+  });
+
+  it('normalizes dotted container names', async () => {
+    mockGetContainersByStack.mockResolvedValue([
+      { Names: ['/mystack-api.v1-1'], State: 'running', Id: 'mno345' },
+    ]);
+
+    const ws = createMockWs();
+    const svc = ComposeService.getInstance(1);
+
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    svc.streamLogs('mystack', ws);
+    await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalled());
+
+    proc.stdout.emit('data', Buffer.from('2024-01-01T00:00:00Z started\n'));
+
+    const calls = (ws.send as ReturnType<typeof vi.fn>).mock.calls as string[][];
+    const sentLines = calls.flatMap(c => c[0].split('\r\n')).filter(Boolean);
+
+    // normalizeContainerName strips stack prefix and -1 replica suffix, leaving 'api.v1'.
+    expect(sentLines).toContain('api.v1 | 2024-01-01T00:00:00Z started');
+  });
+
+  it('passes raw container name to docker logs, not normalized name', async () => {
+    mockGetContainersByStack.mockResolvedValue([
+      { Names: ['/mystack-redis-1'], State: 'running', Id: 'pqr678' },
+    ]);
+
+    const ws = createMockWs();
+    const svc = ComposeService.getInstance(1);
+
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    svc.streamLogs('mystack', ws);
+    await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalled());
+
+    // Verify that docker logs uses the raw name, not the normalized one.
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'docker',
+      ['logs', '-f', '-t', '--tail', '100', 'mystack-redis-1'],
+      expect.anything(),
+    );
   });
 });

--- a/backend/src/__tests__/log-formatter.test.ts
+++ b/backend/src/__tests__/log-formatter.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { LogFormatter } from '../services/LogFormatter';
+
+const CYAN = '\x1b[36m';
+const GRAY = '\x1b[90m';
+const RESET = '\x1b[0m';
+const WHITE = '\x1b[37m';
+
+describe('LogFormatter.process', () => {
+  it('colorizes prefix and timestamp when prefix comes first', () => {
+    const result = LogFormatter.process('redis | 2024-01-01T00:00:00Z started');
+    expect(result).toContain(`${CYAN}redis${WHITE}${RESET} | `);
+    expect(result).toContain(`${GRAY}2024-01-01T00:00:00Z ${RESET}`);
+  });
+
+  it('colorizes timestamp and prefix when timestamp comes first (legacy order)', () => {
+    const result = LogFormatter.process('2024-01-01T00:00:00Z redis | started');
+    expect(result).toContain(`${GRAY}2024-01-01T00:00:00Z ${RESET}`);
+    expect(result).toContain(`${CYAN}redis${WHITE}${RESET} | `);
+  });
+
+  it('colorizes timestamp only when no prefix is present (backward compat)', () => {
+    const result = LogFormatter.process('2024-01-01T00:00:00Z started');
+    expect(result).toContain(`${GRAY}2024-01-01T00:00:00Z ${RESET}`);
+    expect(result).not.toContain(CYAN);
+  });
+
+  it('colorizes dotted container names', () => {
+    const result = LogFormatter.process('api.v1 | 2024-01-01T00:00:00Z started');
+    expect(result).toContain(`${CYAN}api.v1${WHITE}${RESET} | `);
+    expect(result).toContain(`${GRAY}2024-01-01T00:00:00Z ${RESET}`);
+  });
+
+  it('colorizes container names with underscores', () => {
+    const result = LogFormatter.process('my-service_1 | 2024-01-01T00:00:00Z started');
+    expect(result).toContain(`${CYAN}my-service_1${WHITE}${RESET} | `);
+    expect(result).toContain(`${GRAY}2024-01-01T00:00:00Z ${RESET}`);
+  });
+
+  it('handles timestamp with offset notation', () => {
+    const result = LogFormatter.process('redis | 2024-01-01T00:00:00+05:00 started');
+    expect(result).toContain(`${CYAN}redis${WHITE}${RESET} | `);
+    expect(result).toContain(`${GRAY}2024-01-01T00:00:00+05:00 ${RESET}`);
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(LogFormatter.process('')).toBe('');
+  });
+
+  it('returns whitespace-only string unchanged', () => {
+    expect(LogFormatter.process('   ')).toBe('   ');
+  });
+
+  it('handles bare message with no prefix or timestamp', () => {
+    const result = LogFormatter.process('just a plain message');
+    expect(result).toBe('just a plain message');
+  });
+});

--- a/backend/src/services/ComposeService.ts
+++ b/backend/src/services/ComposeService.ts
@@ -16,6 +16,7 @@ import { deriveStackExposure } from './preflight/exposure';
 
 import { isDebugEnabled } from '../utils/debug';
 import { getErrorMessage } from '../utils/errors';
+import { normalizeContainerName } from '../utils/log-parsing';
 import { describeSpawnError } from '../utils/spawnErrors';
 import { isPathWithinBase, isValidStackName } from '../utils/validation';
 import { authoredComposeFileArgs, authoredComposeEnvFileArgs } from '../utils/authoredComposeArgs';
@@ -553,7 +554,8 @@ export class ComposeService {
         };
 
         for (const container of containersToLog) {
-          const containerName = container.Names?.[0]?.replace(/^\//, '') || container.Id;
+          const rawName = container.Names?.[0]?.replace(/^\//, '') || container.Id;
+          const displayName = normalizeContainerName(rawName, stackName);
           activeProcesses++;
           let lineBuffer = '';
 
@@ -563,19 +565,19 @@ export class ComposeService {
               const lines = lineBuffer.split(/\r?\n/);
               lineBuffer = lines.pop() || '';
               for (const line of lines) {
-                ws.send(LogFormatter.process(line) + '\r\n');
+                ws.send(LogFormatter.process(`${displayName} | ${line}`) + '\r\n');
               }
             }
           };
 
           const flushBuffer = () => {
             if (lineBuffer && ws.readyState === WebSocket.OPEN) {
-              ws.send(LogFormatter.process(lineBuffer) + '\r\n');
+              ws.send(LogFormatter.process(`${displayName} | ${lineBuffer}`) + '\r\n');
               lineBuffer = '';
             }
           };
 
-          const child = spawn('docker', ['logs', '-f', '-t', '--tail', '100', containerName], {
+          const child = spawn('docker', ['logs', '-f', '-t', '--tail', '100', rawName], {
             env: {
               ...process.env,
               PATH: process.env.PATH || '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'

--- a/backend/src/services/LogFormatter.ts
+++ b/backend/src/services/LogFormatter.ts
@@ -13,7 +13,7 @@ export class LogFormatter {
     private static readonly TIMESTAMP_REGEX = /^(\d{4}-\d{2}-\d{2}[T\s]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?\s*)/;
 
     // Matches docker-compose style prefix like "container-name  | " or "db-1 | "
-    private static readonly PREFIX_REGEX = /^([a-zA-Z0-9_-]+)(?:\s+\|\s+)/;
+    private static readonly PREFIX_REGEX = /^([a-zA-Z0-9_.-]+)(?:\s+\|\s+)/;
 
     // Level regexes (case insensitive for matching, but we check raw string for precise targeting if needed)
     private static readonly ERROR_REGEX = /\b(ERROR|ERR|Exception|Fatal)\b/i;
@@ -26,26 +26,34 @@ export class LogFormatter {
         let processedLine = line;
         let formatAccumulator = '';
 
-        // 1. Process Timestamp
-        const tsMatch = processedLine.match(LogFormatter.TIMESTAMP_REGEX);
-        if (tsMatch) {
-            const ts = tsMatch[1];
-            formatAccumulator += `${LogFormatter.GRAY}${ts}${LogFormatter.RESET}`;
-            processedLine = processedLine.slice(ts.length);
+        // 1. Process prefix and timestamp tokens in arrival order.
+        // Each regex is anchored at ^ and strips its match from the
+        // remainder, so looping until neither matches naturally handles
+        // both "redis | 2024-...Z message" and "2024-...Z redis | message".
+        let changed = true;
+        while (changed) {
+            changed = false;
+
+            const prefixMatch = processedLine.match(LogFormatter.PREFIX_REGEX);
+            if (prefixMatch) {
+                const pfxMatchStr = prefixMatch[0]; // e.g. "redis | "
+                const name = prefixMatch[1];
+                const restOfPrefix = pfxMatchStr.slice(name.length); // e.g. " | "
+                formatAccumulator += `${LogFormatter.CYAN}${name}${LogFormatter.WHITE}${LogFormatter.RESET}${restOfPrefix}`;
+                processedLine = processedLine.slice(pfxMatchStr.length);
+                changed = true;
+            }
+
+            const tsMatch = processedLine.match(LogFormatter.TIMESTAMP_REGEX);
+            if (tsMatch) {
+                const ts = tsMatch[1];
+                formatAccumulator += `${LogFormatter.GRAY}${ts}${LogFormatter.RESET}`;
+                processedLine = processedLine.slice(ts.length);
+                changed = true;
+            }
         }
 
-        // 2. Process Prefix
-        const prefixMatch = processedLine.match(LogFormatter.PREFIX_REGEX);
-        if (prefixMatch) {
-            const pfxMatchStr = prefixMatch[0]; // e.g. "container-name | "
-            const name = prefixMatch[1];
-            const restOfPrefix = pfxMatchStr.slice(name.length); // e.g. " | "
-
-            formatAccumulator += `${LogFormatter.CYAN}${name}${LogFormatter.WHITE}${LogFormatter.RESET}${restOfPrefix}`;
-            processedLine = processedLine.slice(pfxMatchStr.length);
-        }
-
-        // 3. Process Levels & JSON
+        // 2. Process Levels & JSON
         const trimmedLine = processedLine.trim();
 
         // Fast JSON Check (Starts with { and ends with })

--- a/frontend/src/components/StructuredLogViewer.tsx
+++ b/frontend/src/components/StructuredLogViewer.tsx
@@ -14,6 +14,8 @@ interface LogRow {
   ts: string | null;
   level: LogLevel;
   message: string;
+  /** Normalized service name extracted from the log prefix, or null for synthetic / old-format rows. */
+  containerName: string | null;
   /** True when this row was synthesized by the client (e.g. reconnect sentinel). */
   synthetic?: boolean;
 }
@@ -24,6 +26,7 @@ const BUFFER_CAP = 10_000;
 const TIMESTAMP_REGEX = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)\s+(.*)$/;
 // eslint-disable-next-line no-control-regex
 const ANSI_REGEX = /\x1b\[[0-9;]*[A-Za-z]/g;
+const PREFIX_REGEX = /^([a-zA-Z0-9_.-]+)(?:\s+\|\s+)/;
 const ERROR_REGEX = /\b(ERROR|ERR|FATAL|Exception)\b/i;
 const WARN_REGEX = /\b(WARN|WARNING|WRN)\b/i;
 
@@ -34,14 +37,20 @@ const WARN_REGEX = /\b(WARN|WARNING|WRN)\b/i;
 const RECONNECT_DELAYS_MS = [1_000, 2_000, 4_000, 8_000, 16_000, 30_000];
 
 function parseLine(raw: string): Omit<LogRow, 'id'> {
-  const stripped = raw.replace(ANSI_REGEX, '').replace(/[\r\n]+$/, '');
+  let stripped = raw.replace(ANSI_REGEX, '').replace(/[\r\n]+$/, '');
+  let containerName: string | null = null;
+  const prefixMatch = stripped.match(PREFIX_REGEX);
+  if (prefixMatch) {
+    containerName = prefixMatch[1];
+    stripped = stripped.slice(prefixMatch[0].length);
+  }
   const match = stripped.match(TIMESTAMP_REGEX);
   const ts = match ? match[1] : null;
   const body = match ? match[2] : stripped;
   let level: LogLevel = 'info';
   if (ERROR_REGEX.test(body)) level = 'err';
   else if (WARN_REGEX.test(body)) level = 'warn';
-  return { ts, level, message: body };
+  return { ts, level, message: body, containerName };
 }
 
 function formatTs(iso: string | null): string {
@@ -100,6 +109,7 @@ export default function StructuredLogViewer({ stackName }: StructuredLogViewerPr
         ts: new Date().toISOString(),
         level,
         message,
+        containerName: null,
         synthetic: true,
       });
       scheduleFlush();
@@ -205,7 +215,11 @@ export default function StructuredLogViewer({ stackName }: StructuredLogViewerPr
   };
 
   const downloadLogs = () => {
-    const text = rows.map(r => `${r.ts ?? ''} ${r.level.toUpperCase()} ${r.message}`.trim()).join('\n');
+    const text = rows.map(r =>
+      r.containerName
+        ? `[${r.containerName}] ${r.ts ?? ''} ${r.level.toUpperCase()} ${r.message}`.trim()
+        : `${r.ts ?? ''} ${r.level.toUpperCase()} ${r.message}`.trim(),
+    ).join('\n');
     const blob = new Blob([text], { type: 'text/plain;charset=utf-8' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
@@ -289,7 +303,17 @@ export default function StructuredLogViewer({ stackName }: StructuredLogViewerPr
               )}>
                 {row.level}
               </span>
-              <span className="whitespace-pre-wrap break-all text-foreground/90">{row.message}</span>
+              <span className="whitespace-pre-wrap break-all text-foreground/90">
+                {row.containerName && (
+                  <span
+                    className="font-mono text-[10px] tracking-wide text-brand/80 bg-brand/10 rounded px-1.5 py-px mr-1.5 select-none"
+                    title={row.containerName}
+                  >
+                    {row.containerName}
+                  </span>
+                )}
+                {row.message}
+              </span>
             </div>
           ))
         )}

--- a/frontend/src/components/__tests__/StructuredLogViewer.test.tsx
+++ b/frontend/src/components/__tests__/StructuredLogViewer.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * Unit tests for StructuredLogViewer log parsing, rendering, and downloads.
+ */
+import { render, screen, cleanup, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import StructuredLogViewer from '../StructuredLogViewer';
+
+class MockWS {
+  static instances: MockWS[] = [];
+  url: string;
+  onopen: (() => void) | null = null;
+  onmessage: ((e: { data: string }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: ((e?: unknown) => void) | null = null;
+  send = vi.fn();
+  close = vi.fn();
+  constructor(url: string) { this.url = url; MockWS.instances.push(this); }
+  static reset() { MockWS.instances = []; }
+}
+
+beforeEach(() => {
+  MockWS.reset();
+  vi.stubGlobal('WebSocket', MockWS);
+  vi.stubGlobal('cancelAnimationFrame', vi.fn());
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    cb(0);
+    return 0;
+  });
+  localStorage.setItem('sencho-active-node', '');
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  localStorage.removeItem('sencho-active-node');
+  vi.clearAllMocks();
+});
+
+describe('StructuredLogViewer', () => {
+  it('renders initial empty state and builds the correct WebSocket URL', () => {
+    const { container } = render(<StructuredLogViewer stackName="test-stack" />);
+    expect(container.textContent).toContain('Waiting for log output');
+    expect(MockWS.instances).toHaveLength(1);
+    expect(MockWS.instances[0].url).toContain('/api/stacks/test-stack/logs');
+  });
+
+  it('renders log lines with timestamp, level badge, and message', async () => {
+    const { container } = render(<StructuredLogViewer stackName="test-stack" />);
+    await act(async () => {
+      MockWS.instances[0].onopen?.();
+      MockWS.instances[0].onmessage?.({ data: '2025-01-01T12:00:00Z started' });
+    });
+
+    expect(container.textContent).toContain('started');
+    expect(container.textContent).toContain('info');
+  });
+
+  it('strips .yml and .yaml suffixes from the WebSocket URL', () => {
+    const { rerender } = render(<StructuredLogViewer stackName="my-stack.yml" />);
+    expect(MockWS.instances[0].url).toContain('/api/stacks/my-stack/logs');
+    expect(MockWS.instances[0].url).not.toContain('.yml');
+
+    rerender(<StructuredLogViewer stackName="another-stack.yaml" />);
+    expect(MockWS.instances[1].url).toContain('/api/stacks/another-stack/logs');
+    expect(MockWS.instances[1].url).not.toContain('.yaml');
+  });
+
+  // ── Container name chip ────────────────────────────────────────────
+
+  it('renders a container name chip when the WebSocket message includes a prefix', async () => {
+    const { container } = render(<StructuredLogViewer stackName="test-stack" />);
+    await act(async () => {
+      MockWS.instances[0].onopen?.();
+      MockWS.instances[0].onmessage?.({ data: 'redis | 2025-01-01T12:00:00Z connected\n' });
+    });
+
+    expect(container.textContent).toContain('redis');
+    expect(container.textContent).toContain('connected');
+  });
+
+  it('does not render a container name chip for old-format lines with no prefix', async () => {
+    const { container } = render(<StructuredLogViewer stackName="test-stack" />);
+    await act(async () => {
+      MockWS.instances[0].onopen?.();
+      MockWS.instances[0].onmessage?.({ data: '2025-01-01T12:00:00Z plain message\n' });
+    });
+
+    expect(container.textContent).toContain('plain message');
+    // The chip span uses select-none; a line without a prefix has no chip.
+    expect(container.querySelector('.select-none')).toBeNull();
+  });
+
+  it('renders a dotted container name correctly', async () => {
+    const { container } = render(<StructuredLogViewer stackName="test-stack" />);
+    await act(async () => {
+      MockWS.instances[0].onopen?.();
+      MockWS.instances[0].onmessage?.({ data: 'api.v1 | 2025-01-01T12:00:00Z ready\n' });
+    });
+
+    expect(container.textContent).toContain('api.v1');
+    expect(container.textContent).toContain('ready');
+  });
+
+  it('handles pipe in message body without false prefix extraction', async () => {
+    const { container } = render(<StructuredLogViewer stackName="test-stack" />);
+    await act(async () => {
+      MockWS.instances[0].onopen?.();
+      MockWS.instances[0].onmessage?.({ data: 'redis | 2025-01-01T12:00:00Z value | other\n' });
+    });
+
+    expect(container.textContent).toContain('redis');
+    expect(container.textContent).toContain('value');
+    expect(container.textContent).toContain('other');
+  });
+
+  // ── Download ────────────────────────────────────────────────────────
+
+  it('includes container name in downloaded logs', async () => {
+    let capturedBlob: Blob | null = null;
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn((blob: Blob) => {
+        capturedBlob = blob;
+        return 'blob:fake';
+      }),
+      revokeObjectURL: vi.fn(),
+    });
+
+    render(<StructuredLogViewer stackName="test-stack" />);
+    await act(async () => {
+      MockWS.instances[0].onopen?.();
+      MockWS.instances[0].onmessage?.({ data: 'redis | 2025-01-01T12:00:00Z connected\n' });
+    });
+
+    const downloadBtn = screen.getByLabelText('Download logs');
+    await userEvent.click(downloadBtn);
+
+    expect(capturedBlob).not.toBeNull();
+    const text = await capturedBlob!.text();
+    expect(text).toContain('[redis]');
+    expect(text).toContain('connected');
+  });
+
+  it('omits [container] prefix in download for rows without containerName', async () => {
+    let capturedBlob: Blob | null = null;
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn((blob: Blob) => {
+        capturedBlob = blob;
+        return 'blob:fake';
+      }),
+      revokeObjectURL: vi.fn(),
+    });
+
+    render(<StructuredLogViewer stackName="test-stack" />);
+    await act(async () => {
+      MockWS.instances[0].onopen?.();
+      MockWS.instances[0].onmessage?.({ data: '2025-01-01T12:00:00Z legacy line\n' });
+    });
+
+    const downloadBtn = screen.getByLabelText('Download logs');
+    await userEvent.click(downloadBtn);
+
+    expect(capturedBlob).not.toBeNull();
+    const text = await capturedBlob!.text();
+    expect(text).not.toContain('[null]');
+    expect(text).not.toContain('[');
+    expect(text).toContain('legacy line');
+  });
+});


### PR DESCRIPTION
## Summary

Adds the source container/service name to each log line in the structured log viewer and raw terminal. Previously, when viewing stack logs with multiple containers, lines from all containers were interleaved with no way to tell which container produced each entry.

## Approach

A single enrichment point in `ComposeService.streamLogs()` — a normalized service name (e.g., `redis` from `mystack-redis-1`) is prepended before `LogFormatter.process()`, so both consumers benefit:

- **Structured viewer:** An inline cyan mono chip renders before the message text.
- **Raw terminal:** The prefix is colorized in cyan by `LogFormatter` ANSI codes, visible in xterm.js.

## Changes

| File | Change |
|------|--------|
| `backend/src/services/LogFormatter.ts` | Widen `PREFIX_REGEX` for dotted names; refactor `process()` to a loop handling both prefix-first and timestamp-first input orders |
| `backend/src/services/ComposeService.ts` | Import `normalizeContainerName`, compute display name, prepend to `sendOutput`/`flushBuffer` lines; raw name still used for `docker logs` |
| `frontend/src/components/StructuredLogViewer.tsx` | Add `containerName` to `LogRow`, extract prefix in `parseLine`, render inline chip, include name in downloads |
| `backend/src/__tests__/log-formatter.test.ts` | 9 tests: both input orders, dotted names, edge cases |
| `backend/src/__tests__/compose-service.test.ts` | Fixed LogFormatter mock; 5 `streamLogs` tests |
| `frontend/src/components/__tests__/StructuredLogViewer.test.tsx` | 7 tests: chip rendering, dotted names, pipe-in-body, download format |

## Test plan

- Backend: 59 tests pass (9 new formatter + 5 new streamLogs)
- Frontend: 1418 tests pass (7 new StructuredLogViewer)
- `tsc --noEmit` clean both sides, ESLint clean on changed files