### PR TITLE
fix(dependency-map): stop flagging env-var bind mounts as missing volumes

### DIFF
--- a/backend/src/__tests__/compose-dependency-parse.test.ts
+++ b/backend/src/__tests__/compose-dependency-parse.test.ts
@@ -37,6 +37,42 @@ describe('parseComposeDependencies - volumes', () => {
     const r = parseComposeDependencies('services:\n  web:\n    volumes:\n      - type: volume\n        source: data\n        target: /d\n      - type: bind\n        source: /host\n        target: /b\n');
     expect(r.services[0].volumes).toEqual(['data']);
   });
+
+  it('drops env-var-interpolated bind sources and keeps real named volumes', () => {
+    const r = parseComposeDependencies(svc('web', 'volumes:\n  - ${BACKUPS_PATH}:/backups\n  - $LEGACY_PATH:/legacy\n  - db_data:/var/lib'));
+    expect(r.services[0].volumes).toEqual(['db_data']);
+  });
+
+  it('drops a bind source with an embedded (non-leading) env var', () => {
+    const r = parseComposeDependencies(svc('web', 'volumes:\n  - prefix-${SUB}:/data'));
+    expect(r.services[0].volumes).toEqual([]);
+  });
+
+  it('passes a long-form type: volume env-var source through unchanged', () => {
+    // The long-form path never calls isNamedVolumeSource, so its contract is
+    // unaffected by the short-form env-var fix; this guards that.
+    const r = parseComposeDependencies('services:\n  web:\n    volumes:\n      - type: volume\n        source: ${MY_VOLUME}\n        target: /d\n');
+    expect(r.services[0].volumes).toEqual(['${MY_VOLUME}']);
+  });
+
+  it('does not flag env-var bind mounts as named volumes (issue #1464 repro)', () => {
+    const r = parseComposeDependencies(
+      'services:\n' +
+      '  core:\n' +
+      '    volumes:\n' +
+      '      - ${COMPOSE_KOMODO_BACKUPS_PATH}:/backups\n' +
+      '      - keys:/config/keys\n' +
+      '  periphery:\n' +
+      '    volumes:\n' +
+      '      - /var/run/docker.sock:/var/run/docker.sock\n' +
+      '      - ${PERIPHERY_ROOT_DIRECTORY}:/root\n' +
+      '      - ${PERIPHERY_STACK_DIR}:/stack\n',
+    );
+    const core = r.services.find((s) => s.name === 'core');
+    const periphery = r.services.find((s) => s.name === 'periphery');
+    expect(core?.volumes).toEqual(['keys']);
+    expect(periphery?.volumes).toEqual([]);
+  });
 });
 
 describe('parseComposeDependencies - ports', () => {

--- a/backend/src/helpers/composeDependencyParse.ts
+++ b/backend/src/helpers/composeDependencyParse.ts
@@ -66,7 +66,9 @@ function collectKeys(value: unknown): string[] {
 /** True when a volume source is a named volume (not a bind mount or anonymous). */
 function isNamedVolumeSource(source: string): boolean {
   if (!source) return false;
-  if (source.includes('$')) return false; // env-var-interpolated bind path, unresolvable at parse time
+  // A named-volume key is [a-zA-Z0-9._-]+, so any '$' marks an env-var bind path
+  // (or the '$$' literal-dollar escape) whose value is unresolvable at parse time.
+  if (source.includes('$')) return false;
   if (source.includes('/')) return false; // bind mount path
   if (source.startsWith('.') || source.startsWith('~')) return false;
   if (/^[a-zA-Z]:[\\/]/.test(source)) return false; // Windows drive path

--- a/backend/src/helpers/composeDependencyParse.ts
+++ b/backend/src/helpers/composeDependencyParse.ts
@@ -66,6 +66,7 @@ function collectKeys(value: unknown): string[] {
 /** True when a volume source is a named volume (not a bind mount or anonymous). */
 function isNamedVolumeSource(source: string): boolean {
   if (!source) return false;
+  if (source.includes('$')) return false; // env-var-interpolated bind path, unresolvable at parse time
   if (source.includes('/')) return false; // bind mount path
   if (source.startsWith('.') || source.startsWith('~')) return false;
   if (/^[a-zA-Z]:[\\/]/.test(source)) return false; // Windows drive path


### PR DESCRIPTION
## Summary

The Fleet Map "Missing dependencies" anomaly was showing false positives for services whose volumes use environment-variable-interpolated bind sources, such as `${BACKUPS_PATH}:/backups`.

Root cause: the compose dependency parser's `isNamedVolumeSource()` classified the source half of a short-form volume entry as a **named volume** whenever it had no `/`, no leading `.`/`~`, and was not a Windows drive path. A `${VAR}` token meets all of those (the slash lives in the container target, after the `:` split), so it was treated as a named volume. The runtime presence check then found no matching volume and raised a `missing-dependency` flag, which renders as the single "Missing deps" badge.

In the reported Komodo stack this lit up `core` (one `${VAR}` bind alongside a real named volume) and `periphery` (only `${VAR}` binds, no `depends_on` at all). The `depends_on` resolution itself was always correct, which is why the dependency line was still drawn while the node was wrongly flagged.

Fix: a compose named-volume key can never contain `$`, so any source containing an env var is a bind path whose value is unresolvable at parse time. Exclude it from named-volume classification.

```ts
if (source.includes('$')) return false; // env-var-interpolated bind path, unresolvable at parse time
```

## Test plan

- Added unit tests to `compose-dependency-parse.test.ts`:
  - short-form `${VAR}` and `$VAR` bind sources dropped, real named volumes kept
  - embedded (non-leading) `$` such as `prefix-${SUB}` dropped (guards against a narrower `startsWith` regression)
  - long-form `type: volume` env-var source passthrough unchanged (regression guard; that path never calls the helper)
  - self-contained reproduction of the reported stack: `core.volumes` resolves to `['keys']`, `periphery.volumes` to `[]`
- `npm test` for `compose-dependency-parse` and `dependency-graph-builder` suites: green.
- `npx tsc --noEmit`: clean.
- Backend-only change; the map renderer and flag badge are untouched, so there is no visual regression and no Playwright run was needed.

## Notes

Behavior trade-off: an env var that genuinely resolves to a named-volume key (e.g. `${DB_VOLUME}`) will no longer be flagged when that volume is missing. The parser cannot resolve env vars, so flagging it would be guesswork; trading a rare, unprovable true positive for the elimination of common, reproducible false positives is the correct call.

Stacks with env-var bind mounts will report `renderedChanged: true` in the drift-temporal response until their next deploy, because the corrected parse changes the stable model hash. This is invisible to operators because the frontend only surfaces `renderedChanged` when `sourceChanged` is also true.

Closes #1464
