### PR TITLE
fix: copy the full finding set when reusing a cached scan for the deploy gate

### DIFF
--- a/backend/src/__tests__/trivy-preflight-cache-details.test.ts
+++ b/backend/src/__tests__/trivy-preflight-cache-details.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Regression coverage for the pre-deploy gate false-block on cached large scans.
+ *
+ * A cache-hit preflight scan must copy the cached scan's FULL finding set, not a
+ * truncated page. When the copy kept only the first 1000 detail rows but
+ * preserved the full aggregate total, the persisted scan was internally
+ * inconsistent (stored rows < total_vulnerabilities), and the deploy gate's
+ * integrity check (evaluateImageRisk) failed closed on every KEV/fixable input,
+ * blocking a deploy with no actual matching finding.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { setupTestDb, cleanupTestDb } from './helpers/setupTestDb';
+import { DatabaseService } from '../services/DatabaseService';
+
+let tmpDir: string;
+let TrivyService: typeof import('../services/TrivyService').default;
+
+const DIGEST = 'sha256:cachedbig';
+const TOTAL = 1100; // deliberately over the old 1000-row copy cap
+
+beforeAll(async () => {
+  tmpDir = await setupTestDb();
+  TrivyService = (await import('../services/TrivyService')).default;
+});
+
+afterAll(() => cleanupTestDb(tmpDir));
+
+function svc() {
+  return TrivyService.getInstance();
+}
+function db() {
+  return DatabaseService.getInstance();
+}
+
+/** Seed a consistent cached vuln scan: total_vulnerabilities matches its detail rows. */
+function seedCachedScan(): number {
+  const scanId = db().createVulnerabilityScan({
+    node_id: 1, image_ref: 'big:1', image_digest: DIGEST, scanned_at: Date.now(),
+    total_vulnerabilities: TOTAL, critical_count: TOTAL, high_count: 0, medium_count: 0, low_count: 0,
+    unknown_count: 0, fixable_count: 0, secret_count: 0, misconfig_count: 0, scanners_used: 'vuln',
+    highest_severity: 'CRITICAL', os_info: null, trivy_version: null, scan_duration_ms: null,
+    triggered_by: 'manual', status: 'completed', error: null, stack_context: null,
+  });
+  const details = Array.from({ length: TOTAL }, (_, i) => ({
+    vulnerability_id: `CVE-2024-${i}`, pkg_name: `pkg-${i}`, installed_version: '1', fixed_version: null,
+    severity: 'CRITICAL' as const, title: null, description: null, primary_url: null,
+  }));
+  db().insertVulnerabilityDetails(scanId, details);
+  return scanId;
+}
+
+beforeEach(() => {
+  const raw = (db() as unknown as { db: { prepare: (s: string) => { run: () => void } } }).db;
+  raw.prepare('DELETE FROM vulnerability_details').run();
+  raw.prepare('DELETE FROM vulnerability_scans').run();
+  (svc() as unknown as { scanningImages: Set<string> }).scanningImages.clear();
+  // The cache-hit path returns before invoking the binary; a non-null path is
+  // enough to pass the availability guard.
+  (svc() as unknown as { binaryPath: string }).binaryPath = '/fake/trivy';
+});
+
+describe('TrivyService cache-hit detail copy', () => {
+  it('copies every cached vulnerability detail, not a truncated page', async () => {
+    seedCachedScan();
+    const result = await svc().scanImage('big:1', 1, { useCache: true, digest: DIGEST, scanners: ['vuln'] });
+    expect(result.totalVulnerabilities).toBe(TOTAL);
+    expect(result.vulnerabilities).toHaveLength(TOTAL);
+  });
+
+  it('persists a preflight scan whose stored detail count matches its total (no false-block mismatch)', async () => {
+    seedCachedScan();
+    // scanImagePreflight resolves the digest itself; the cache hit then reuses it.
+    vi.spyOn(svc(), 'getImageDigest').mockResolvedValue(DIGEST);
+
+    const persisted = await svc().scanImagePreflight('big:1', 1, 'web');
+
+    const storedDetailCount = db().getAllVulnerabilityDetails(persisted.id).length;
+    expect(persisted.total_vulnerabilities).toBe(TOTAL);
+    expect(storedDetailCount).toBe(persisted.total_vulnerabilities);
+    // The severity aggregates must survive the cache round-trip too.
+    expect(persisted.critical_count).toBe(TOTAL);
+  });
+});

--- a/backend/src/services/TrivyService.ts
+++ b/backend/src/services/TrivyService.ts
@@ -651,7 +651,11 @@ class TrivyService {
                         `scanImage: cache hit for digest=${digest} scanId=${cached.id} ageMs=${startedAt - cached.scanned_at}`,
                     );
                     const db = DatabaseService.getInstance();
-                    const details = db.getVulnerabilityDetails(cached.id, { limit: 1000 }).items;
+                    // Copy the cached scan's full finding set, not a truncated page:
+                    // the persisted copy must keep stored details == total_vulnerabilities,
+                    // or the deploy gate's integrity check fails closed on a cached scan
+                    // that has more findings than a single detail page would hold.
+                    const details = db.getAllVulnerabilityDetails(cached.id);
                     const cachedSecrets = scanners.includes('secret')
                         ? db.getSecretFindings(cached.id, { limit: 1000 }).items
                         : [];


### PR DESCRIPTION
## Summary

A pre-deploy gate scan reuses a cached scan for the same image digest within 24h. The cache-hit path copied only the first 1000 vulnerability detail rows while preserving the cached scan's full aggregate `total_vulnerabilities`, so the persisted preflight scan stored fewer detail rows than its total. The deploy gate's integrity check in `evaluateImageRisk` (`findings.length !== scan.total_vulnerabilities`) treats that mismatch as untrustworthy and fails closed on every active KEV or fixable input. A default risk-first policy would therefore block a deploy of any image with more than 1000 findings, with no actual KEV or fixable match, and honored suppressions stopped applying on that path.

## What changed

The cache-hit copy now reads the complete detail set with `getAllVulnerabilityDetails` instead of a capped page, so the persisted preflight scan keeps stored details equal to `total_vulnerabilities`, matching a fresh (cache-miss) scan, which already inserts the full parsed set. The gate then evaluates the real findings: KEV/fixable absence is provable, and honored suppressions apply again.

## Test plan

- `cd backend && npx tsc --noEmit` clean.
- New regression test (`trivy-preflight-cache-details.test.ts`), seeding a consistent cached scan of 1100 findings (over the old 1000 cap):
  - a cache-hit `scanImage` copies all 1100 details, not a truncated page;
  - a cache-hit `scanImagePreflight` persists a scan whose stored detail count and `critical_count` equal its `total_vulnerabilities`, the invariant the gate checks.
- Existing `policy-enforcement.test.ts` already covers the other half (the gate fails closed when detail rows are genuinely incomplete); the two suites compose into full coverage.
- `policy-enforcement` and `database-scan-cache` suites green.

## Notes

- The gate's fail-closed-on-mismatch behavior is intentional and unchanged: genuinely incomplete details must not silently allow a deploy. This change only stops manufacturing the mismatch on the happy path.
- Fresh installs are fully fixed. On upgrade, a pre-existing inconsistent preflight row (an image with more than 1000 findings scanned before the upgrade) can still fail closed if it is reused within its 24h cache TTL; that is the safe direction (it blocks, never allows, and admins can bypass) and it self-heals on the next fresh scan. This is strictly an improvement over the prior persistent false-block.
- The cached secret-findings copy is intentionally left as is: secrets do not feed the deploy gate, and the preflight path requests only the vulnerability scanner.
