### PR TITLE
fix: contain file-explorer binds that reach symlinked Sencho-managed paths

### DIFF
--- a/backend/src/__tests__/stack-file-roots-service.test.ts
+++ b/backend/src/__tests__/stack-file-roots-service.test.ts
@@ -327,6 +327,56 @@ describe('StackFileRootsService.listRoots', () => {
     }
   });
 
+  it('suppresses a bind to the real target of a symlinked managed Trivy binary (canonical managed root)', async () => {
+    // TRIVY_BIN (and the other managed paths) may itself be a symlink, e.g.
+    // /opt/trivy -> /srv/tool-target/trivy. Bind sources are canonicalized before
+    // the overlap check, so the managed paths must be canonicalized too. Without
+    // it, a bind to the symlink target's real directory does not overlap the
+    // configured symlink path, and a stack editor could overwrite the real binary
+    // a later scan executes. realpath is the only canonicalization seam, so stub
+    // it to resolve the configured symlink to the real binary path inside the
+    // bound directory; identity for every other path leaves the real
+    // baseDir/app/tmp comparisons intact.
+    const targetDir = await fs.realpath(await fs.mkdtemp(path.join(REAL_TMP, 'sfr-symtarget-')));
+    const realBinary = path.join(targetDir, 'trivy');
+    const symlinkBin = path.join(REAL_TMP, 'sfr-symlinked-trivy-bin');
+    process.env.TRIVY_BIN = symlinkBin;
+    vi.spyOn(fs, 'realpath').mockImplementation((async (p: string) =>
+      path.resolve(p) === path.resolve(symlinkBin) ? realBinary : p) as typeof fs.realpath);
+    try {
+      // Bind the real target directory, NOT the symlink's directory: only the
+      // canonicalized managed root catches this overlap.
+      stub({ rendered: renderModel({ web: [{ type: 'bind', source: targetDir, target: '/opt/trivy', read_only: false }] }) });
+      const roots = await StackFileRootsService.getInstance(1).listRoots(STACK, { fresh: true });
+      const bind = roots.find((r) => r.kind === 'bind');
+      expect(bind?.managedSourceOverlap).toBe(true);
+      expect(bind?.browsable).toBe(false);
+      expect(bind?.writable).toBe(false);
+    } finally {
+      await fs.rm(targetDir, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
+  it('keeps a legitimate external bind browsable when a configured managed path is absent (ENOENT realpath tolerated)', async () => {
+    // A relocated TRIVY_BIN (or upload spool) routinely points at a path that does
+    // not exist yet on a fresh install, so realpath on a configured managed path
+    // throws ENOENT every discovery. That must be tolerated: the configured path
+    // still anchors containment and an unrelated external bind stays browsable,
+    // rather than the realpath failure collapsing discovery to stack-source only.
+    process.env.TRIVY_BIN = path.join(REAL_TMP, 'sfr-absent-trivy-bin-xyz-12345');
+    const outside = await fs.realpath(await fs.mkdtemp(path.join(REAL_TMP, 'sfr-legit-')));
+    try {
+      stub({ rendered: renderModel({ web: [{ type: 'bind', source: outside, target: '/config', read_only: false }] }) });
+      const roots = await StackFileRootsService.getInstance(1).listRoots(STACK, { fresh: true });
+      const bind = roots.find((r) => r.kind === 'bind');
+      expect(bind?.managedSourceOverlap).toBe(false);
+      expect(bind?.browsable).toBe(true);
+      expect(bind?.writable).toBe(true);
+    } finally {
+      await fs.rm(outside, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
   it('resolves a named volume by its Docker name (not the compose key) and inspects that name', async () => {
     const inspected: string[] = [];
     stub({

--- a/backend/src/services/StackFileRootsService.ts
+++ b/backend/src/services/StackFileRootsService.ts
@@ -167,13 +167,39 @@ function resolveAppRoot(): string {
  * The managed Trivy install and cache default under the data dir, so they are
  * already covered unless an env override moves them elsewhere.
  */
-function resolveManagedRoots(baseDir: string): string[] {
-  const roots = [path.resolve(baseDir), resolveDataDir(), resolveAppRoot(), path.resolve(os.tmpdir())];
-  const add = (value: string | undefined): void => { if (value) roots.push(path.resolve(value)); };
+async function resolveManagedRoots(baseDir: string): Promise<string[]> {
+  const configured = [path.resolve(baseDir), resolveDataDir(), resolveAppRoot(), path.resolve(os.tmpdir())];
+  const add = (value: string | undefined): void => { if (value) configured.push(path.resolve(value)); };
   add(process.env.SENCHO_UPLOAD_DIR);
   add(process.env.TRIVY_BIN);
   add(process.env.TRIVY_CACHE_DIR);
-  return roots;
+
+  // Bind sources are canonicalized before the overlap check (probeBindRootAccess
+  // realpaths the declared source), so a managed path that is itself a symlink
+  // must be canonicalized too. Otherwise TRIVY_BIN=/opt/trivy -> /srv/tool/trivy
+  // is only compared as /opt/trivy: a bind to /srv/tool slips past the overlap
+  // check, letting a stack editor overwrite the real Trivy binary a later scan
+  // executes (the same gap re-exposes a symlinked upload spool, Trivy cache, or
+  // OS temp root holding transient registry credentials). Keep both the configured
+  // path (catches a bind to its literal parent) and the realpath target (catches
+  // a bind to the symlink target's parent).
+  const roots = new Set<string>(configured);
+  for (const p of configured) {
+    try {
+      roots.add(await fsPromises.realpath(p));
+    } catch (err) {
+      // ENOENT is expected: a configured-but-absent path (e.g. SENCHO_UPLOAD_DIR,
+      // or a relocated TRIVY_BIN/TRIVY_CACHE_DIR that env points at but that does
+      // not exist yet) has no canonical target, and the configured path already
+      // anchors containment. Anything else (e.g. EACCES) is logged so an operator
+      // chasing a containment surprise has a trail.
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT') {
+        console.warn('[StackFileRoots] managed-root realpath failed (%s):', code ?? 'unknown', sanitizeForLog(p));
+      }
+    }
+  }
+  return [...roots];
 }
 
 /** A bind source equal to or under one of the dangerous roots (POSIX semantics). */
@@ -398,9 +424,10 @@ export class StackFileRootsService {
       }
     }
 
+    const managedRoots = await resolveManagedRoots(baseDir);
     const roots: StackFileRoot[] = [];
     for (const group of bindByCanonical.values()) {
-      const root = this.buildBindRoot(group, baseDir, stackDir);
+      const root = this.buildBindRoot(group, managedRoots, stackDir);
       if (root) roots.push(root);
     }
     for (const group of volByName.values()) {
@@ -411,7 +438,7 @@ export class StackFileRootsService {
 
   private buildBindRoot(
     group: BindGroup,
-    baseDir: string,
+    managedRoots: string[],
     stackDir: string,
   ): StackFileRoot | null {
     const { canonical } = group;
@@ -429,7 +456,7 @@ export class StackFileRootsService {
     // must never become a browsable/editable root. Compare in both directions so
     // a mount equal to, inside, or an ancestor of a managed dir is caught.
     const overlapsManaged = (dir: string): boolean => isPathWithinBase(canonical, dir) || isPathWithinBase(dir, canonical);
-    const overlap = !inStack && resolveManagedRoots(baseDir).some(overlapsManaged);
+    const overlap = !inStack && managedRoots.some(overlapsManaged);
     const dangerous = isDangerousHostPath(canonical) || group.dangerousSource || group.dockerSock;
     const readonly = group.mounts.every((m) => m.readOnly);
     const isFile = group.accessible && !group.isDir;


### PR DESCRIPTION
## Summary

The Files & Volumes explorer derives the set of host paths a stack file operation may touch by classifying each declared bind mount. A bind that overlaps a Sencho-managed area (compose base, data dir, application root, OS temp root, upload spool, Trivy binary, Trivy cache) is suppressed so it cannot be browsed or written.

That overlap check canonicalized the declared bind source (it realpaths the source) but compared it against the managed paths using `path.resolve` only. When a managed path is itself a symlink (for example a relocated Trivy binary whose configured path links to the real binary elsewhere), it was compared by its symlink path. A bind to the symlink target's real directory did not register as a managed overlap, so it became browsable and writable. A stack editor could then overwrite the real Trivy binary that a later pre or post deploy scan executes, or reach the transient registry credentials Sencho writes under a symlinked temporary root.

The fix resolves each managed path to its canonical target and keeps both the configured path and the realpath target in the overlap set, mirroring the bind-side canonicalization. The managed roots are now resolved once per discovery pass and threaded into the bind classifier.

The set of suppressed paths only ever expands, so existing deployments and fresh installs are unaffected. A missing managed path (the common fresh-install case, before Trivy is installed or an upload dir is created) is tolerated: the configured path still anchors containment, and any non-ENOENT realpath failure is logged rather than collapsing discovery.

## Test plan

- `backend`: `vitest run src/__tests__/stack-file-roots-service.test.ts` (29 passed). Added two tests:
  - a regression test that fails before the fix and passes after, asserting a bind to the real target directory of a symlinked managed Trivy path is suppressed (`managedSourceOverlap`, not browsable, not writable).
  - a fresh-install test that an absent configured managed path leaves a legitimate external bind browsable and writable (the realpath ENOENT is tolerated, discovery is not collapsed).
- `backend`: file-roots route and gateway suites green (`stack-files-routes`, `file-root-gateway`: 132 passed, 4 skipped).
- `backend`: `tsc --noEmit` clean, `eslint src` clean on the changed files.

## Notes

- Scope is limited to the overlap check in the file-roots discovery service, the single server-side source of truth for which paths a file operation may touch. The Trivy and registry-auth consumers that execute or write to these paths are unchanged; suppressing the bind at discovery is what removes the write primitive.
- The bidirectional overlap check (a bind equal to, inside, or an ancestor of a managed path) is unchanged; only the managed side is now canonicalized to match the already-canonicalized bind side.