### PR TITLE
fix: clear stale node-update changelog notes when a refetch fails

### DIFF
--- a/frontend/src/components/FleetView/NodeUpdatesSheet.tsx
+++ b/frontend/src/components/FleetView/NodeUpdatesSheet.tsx
@@ -72,34 +72,42 @@ export function NodeUpdatesSheet({
     useEffect(() => {
         if (!open || loadingRelease) return;
         if (loadedForVersion === advertisedLatest) return;
+        // Drop any previously loaded notes before fetching for a (possibly) newer
+        // advertised version. If this fetch mismatches, returns null, errors, or
+        // rejects, the panel must fall to the empty state rather than keep showing
+        // the prior version's notes; a confirmed match repopulates below. The
+        // skeleton (loadingRelease) covers the in-flight gap, so this does not flash.
+        setReleaseNotes(null);
+        setReleaseHtmlUrl(null);
+        setReleaseVersion(null);
         setLoadingRelease(true);
         const recheck = recheckingUpdates ? '?recheck=true' : '';
         apiFetch(`/fleet/update-status/release-notes${recheck}`, { localOnly: true })
             .then(res => res.ok ? res.json() as Promise<{ version: string | null; releaseNotes: string | null; htmlUrl: string | null }> : null)
             .then(data => {
-                if (data) {
-                    // Bind strictly to the advertised update: only render notes the
-                    // endpoint confirms belong to the advertised version. The version
-                    // lookup and the release-notes lookup use independent caches (and
-                    // version can fall back to Docker Hub while notes are GitHub-only),
-                    // so a drifted response must fall through to the empty state with
-                    // the online changelog link rather than show another version's notes.
-                    const matches = data.version !== null && data.version === advertisedLatest;
-                    setReleaseNotes(matches ? data.releaseNotes : null);
-                    setReleaseHtmlUrl(matches ? data.htmlUrl : null);
-                    setReleaseVersion(matches ? data.version : null);
+                // Bind strictly to the advertised update: render only notes the
+                // endpoint confirms belong to the advertised version. The version
+                // lookup and the release-notes lookup use independent caches (and
+                // version can fall back to Docker Hub while notes are GitHub-only),
+                // so a drifted, null, or failed response keeps the cleared state set
+                // above and falls through to the empty state with the online link.
+                if (data && data.version !== null && data.version === advertisedLatest) {
+                    setReleaseNotes(data.releaseNotes);
+                    setReleaseHtmlUrl(data.htmlUrl);
+                    setReleaseVersion(data.version);
                 }
             })
             .catch((err) => {
-                // Informational panel: a failure falls through to the empty
-                // state (with an online changelog link) rather than a toast,
-                // but leave a breadcrumb so the failure is diagnosable.
+                // Informational panel: a failure falls through to the empty state
+                // (notes already cleared above) rather than a toast, but leave a
+                // breadcrumb so the failure is diagnosable.
                 console.warn('[Fleet] Release-notes fetch failed:', err);
             })
             .finally(() => {
                 setLoadingRelease(false);
                 // Record the advertised version this fetch settled for, so a null
-                // result does not loop and a later version change forces a refetch.
+                // or failed result does not loop and a later version change forces
+                // a refetch.
                 setLoadedForVersion(advertisedLatest);
             });
     }, [open, advertisedLatest, loadedForVersion, loadingRelease, recheckingUpdates]);

--- a/frontend/src/components/FleetView/__tests__/NodeUpdatesSheet.test.tsx
+++ b/frontend/src/components/FleetView/__tests__/NodeUpdatesSheet.test.tsx
@@ -133,6 +133,49 @@ describe('NodeUpdatesSheet', () => {
     await waitFor(() => expect(releaseCalls()).toBe(2));
   });
 
+  it('clears stale notes when the refetch after a version change returns a non-OK response', async () => {
+    apiFetchMock.mockResolvedValue({ ok: true, json: async () => ({ version: '1.1.0', releaseNotes: '## v1.1.0 notes', htmlUrl: 'https://example.com/v1.1.0' }) });
+    const releaseCalls = () => apiFetchMock.mock.calls.filter(c => String(c[0]).includes('release-notes')).length;
+    const { rerender } = render(<NodeUpdatesSheet {...baseProps({ initialTab: 'changelog' })} />);
+    await screen.findByRole('heading', { name: 'v1.1.0 notes' });
+    expect(releaseCalls()).toBe(1);
+
+    // Advertised version moves to 1.2.0 but the refetch fails (HTTP 500). The
+    // previously loaded 1.1.0 notes must not linger as the 1.2.0 changelog.
+    apiFetchMock.mockResolvedValue({ ok: false, status: 500, json: async () => ({}) });
+    const bumped = STATUSES.map(s => ({ ...s, latestVersion: '1.2.0' }));
+    rerender(<NodeUpdatesSheet {...baseProps({ initialTab: 'changelog', updateStatuses: bumped })} />);
+
+    expect(await screen.findByText('No release notes to show')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'v1.1.0 notes' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Release v1.1.0')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /View on GitHub/ })).not.toBeInTheDocument();
+    // The failed refetch settles without looping.
+    await waitFor(() => expect(releaseCalls()).toBe(2));
+  });
+
+  it('clears stale notes when the refetch after a version change rejects', async () => {
+    let calls = 0;
+    apiFetchMock.mockImplementation(() => {
+      calls += 1;
+      return calls === 1
+        ? Promise.resolve({ ok: true, json: async () => ({ version: '1.1.0', releaseNotes: '## v1.1.0 notes', htmlUrl: null }) })
+        : Promise.reject(new Error('network down'));
+    });
+    const releaseCalls = () => apiFetchMock.mock.calls.filter(c => String(c[0]).includes('release-notes')).length;
+    const { rerender } = render(<NodeUpdatesSheet {...baseProps({ initialTab: 'changelog' })} />);
+    await screen.findByRole('heading', { name: 'v1.1.0 notes' });
+
+    // A rejected (network/JSON) refetch after the version change must also clear
+    // the stale notes rather than leave them mislabelled as the new version.
+    const bumped = STATUSES.map(s => ({ ...s, latestVersion: '1.2.0' }));
+    rerender(<NodeUpdatesSheet {...baseProps({ initialTab: 'changelog', updateStatuses: bumped })} />);
+
+    expect(await screen.findByText('No release notes to show')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'v1.1.0 notes' })).not.toBeInTheDocument();
+    await waitFor(() => expect(releaseCalls()).toBe(2));
+  });
+
   it('does not refetch loaded notes on re-render when the version is unchanged', async () => {
     apiFetchMock.mockResolvedValue({
       ok: true,


### PR DESCRIPTION
## Summary

Follow-up to the changelog version-binding work. The prior fixes cleared mismatched notes on a successful response, but a re-audit found one path still leaves stale notes: when version N notes are loaded, the advertised version changes to N+1, and the N+1 release-notes request fails (non-OK response, network rejection, or unparseable JSON), neither the null path nor the catch cleared the loaded N notes, and `finally` latched `loadedForVersion = N+1`. The sheet then kept showing N notes as the N+1 changelog and would not retry automatically.

The changelog now drops the loaded notes, version, and link the moment it commits to fetching for a different advertised version (right after the effect guards, before the request). Any outcome other than a confirmed version match (mismatch, null, HTTP error, network rejection, bad JSON) leaves the panel cleared and falls through to the existing empty state with the online changelog link. A confirmed match repopulates as before. The skeleton (driven by `loadingRelease`) covers the in-flight gap, so there is no flash of empty content, and the settled-version latch is preserved so a failure does not loop.

## Test plan

`frontend/src/components/FleetView/__tests__/NodeUpdatesSheet.test.tsx`:
- N loaded, advertised moves to N+1, refetch returns HTTP 500: the N notes, version label, and GitHub link are gone; the empty state with the online link shows; the fetch settles without looping.
- Same sequence with a rejected refetch (network/JSON failure): the N notes are cleared and the empty state shows.
- Both new tests were confirmed red against the pre-fix component and green with the fix.
- Existing cases (version-match render, version-change refetch with new notes, no-refetch-when-unchanged, mismatch-on-success, recovery via recheck, unknown advertised version) remain green: 22 passed.
- `npx tsc -b --noEmit` clean; ESLint no errors.

## Notes

Frontend-only; no schema, settings, or migration impact, so fresh installs and upgrades behave identically. When the version and release lookups agree (the common case), notes render exactly as before.