### PR TITLE
fix: stack the volume browser panels on phones so the file preview is readable

### DIFF
--- a/frontend/src/components/resources/VolumeBrowserSheet.tsx
+++ b/frontend/src/components/resources/VolumeBrowserSheet.tsx
@@ -90,7 +90,7 @@ export function VolumeBrowserSheet({ volumeName, onClose }: VolumeBrowserSheetPr
       {volumeName && (
         <>
           {isAnonymousVolumeName(volumeName) && <AnonymousNameBand name={volumeName} />}
-          <div className="grid grid-cols-[260px_1fr] gap-3 px-6 py-5 flex-1 min-h-0">
+          <div className="grid grid-cols-[260px_1fr] gap-3 px-6 py-5 flex-1 min-h-0 max-md:grid-cols-1 max-md:grid-rows-[40%_1fr] max-md:px-4">
             <div className="rounded-md border border-card-border bg-card overflow-hidden">
               <FileTree
                 key={`${volumeName}:${refreshKey}`}


### PR DESCRIPTION
## Summary

A release-stabilization QA pass found the Resources volume browser unusable on phones. The sheet kept its fixed `260px` file-tree column beside the preview, leaving the preview pane roughly 54px wide at 375px, so file content wrapped to one or two characters per line.

Below the `md` breakpoint the two panels now stack into a single column (tree above, preview below), with the tree capped at 40% of the available height so the preview spans the full width. The change is expressed entirely as additive `max-md:` overrides; the desktop and tablet layouts are byte-identical.

## Changes

- `frontend/src/components/resources/VolumeBrowserSheet.tsx`: append `max-md:grid-cols-1 max-md:grid-rows-[40%_1fr] max-md:px-4` to the panel grid.

## Test plan

- Verified live in a browser at 1440px: the volume browser renders the unchanged two-column grid (tree + preview).
- Verified live at 375px (phone): the tree and preview stack full-width and a selected file's content renders readably across the full width instead of being squeezed into ~54px.
- `tsc -b --noEmit` clean; ESLint clean on the changed file.

## Notes

- Both grid children fill their cell and scroll internally (`FileTree` is `h-full` with an internal scroll area; the preview panel is a flex column with a flex-1 scroll area), so the stacked `40%`/`1fr` row tracks do not overflow.
- No desktop class was modified, per the mobile-responsive contract (mobile expressed only as `max-md:` overrides).