### PR TITLE
fix: replace Janitor wording with reclaim/prune actions in user-facing copy

### DIFF
--- a/backend/src/services/MonitorService.ts
+++ b/backend/src/services/MonitorService.ts
@@ -450,7 +450,7 @@ export class MonitorService {
                     JANITOR_COOLDOWN_MS,
                     'info',
                     'system',
-                    `Node "${nodeLabel}" has accumulated ${reclaimGb.toFixed(1)} GB of unused Docker data. Consider using the Janitor tool.`,
+                    `Node "${nodeLabel}" has accumulated ${reclaimGb.toFixed(1)} GB of unused Docker data. Open Resources to reclaim space, or set up a Prune Node Resources schedule.`,
                 );
             }
         } finally {

--- a/docs/features/alerts-notifications.mdx
+++ b/docs/features/alerts-notifications.mdx
@@ -290,9 +290,9 @@ The suppression window defaults to 60 minutes and is configured per node in **Se
 
 The entire host threshold evaluation can be silenced per node from **Settings · Monitoring · Host Alerts · Host threshold alerts** while keeping the configured limit values. This toggle affects only the CPU, RAM, and disk threshold checks; crash capture, stack alert rules, and health gate checks all continue to run independently.
 
-### Docker janitor
+### Reclaimable Docker data
 
-`info`/`system`: `Node "<name>" has accumulated <N> GB of unused Docker data. Consider using the Janitor tool.` 24-hour cooldown.
+`info`/`system`: `Node "<name>" has accumulated <N> GB of unused Docker data. Open Resources to reclaim space, or set up a Prune Node Resources schedule.` 24-hour cooldown.
 
 ### Sencho version availability
 
@@ -375,7 +375,7 @@ The global crash-capture switch lives under **Settings · Monitoring · Containe
 
 The **Container crash & health alerts** toggle controls whether `DockerEventService` raises crash, OOM, and healthcheck alerts on the active node. Helper text: `Send alerts for unexpected container exits, OOM kills, and Docker healthcheck failures. Auto-Heal can still observe crash signals independently.` Defaults to on; if the database read fails, Sencho falls back to default-deny so the system never leaks alerts you cannot turn off.
 
-The **Host Alerts** panel carries the **Host thresholds** rows (CPU limit, RAM limit, Disk limit, all expressed as percent) that drive the host-level monitor warnings. Container crash and health alerts live in the **Container Alerts** panel. The **Janitor threshold** (in GiB) that drives the unused-Docker-data alert lives in the **Docker & Storage** panel.
+The **Host Alerts** panel carries the **Host thresholds** rows (CPU limit, RAM limit, Disk limit, all expressed as percent) that drive the host-level monitor warnings. Container crash and health alerts live in the **Container Alerts** panel. The **Reclaimable Docker data threshold** (in GiB) that drives the unused-Docker-data alert lives in the **Docker & Storage** panel.
 
 ## Refresh cadence
 

--- a/docs/reference/settings.mdx
+++ b/docs/reference/settings.mdx
@@ -271,7 +271,7 @@ Configure the reclaimable-space alert, the reclaimable-space banner, and automat
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| **Janitor threshold** | 5 GiB | Alert when reclaimable Docker data (images, volumes, build cache that `docker prune` could free) exceeds this size. Set to `0` to disable the alert. |
+| **Reclaimable Docker data threshold** | 5 GiB | Alert when reclaimable Docker data (images, volumes, build cache that `docker prune` could free) exceeds this size. Set to `0` to disable the alert. |
 | **Show reclaimable-space banner** | On | Show the reclaimable-space banner at the top of the Resource Hub when this node has unused images, stopped containers, or dangling volumes to clear. |
 
 ### Image cleanup

--- a/frontend/src/components/settings/DockerStorageSection.tsx
+++ b/frontend/src/components/settings/DockerStorageSection.tsx
@@ -115,7 +115,7 @@ export function DockerStorageSection({ onDirtyChange }: DockerStorageSectionProp
         <fieldset disabled={readOnly} className="m-0 flex min-w-0 flex-col gap-10 border-0 p-0">
             <SettingsSection title="Storage alerts">
                 <SettingsField
-                    label="Janitor threshold"
+                    label="Reclaimable Docker data threshold"
                     helper="Alert when reclaimable Docker data exceeds this size."
                 >
                     <NumberChip

--- a/frontend/src/components/settings/registry.ts
+++ b/frontend/src/components/settings/registry.ts
@@ -195,7 +195,7 @@ export const SETTINGS_ITEMS: readonly SettingsItemMeta[] = [
         group: 'monitoring',
         label: 'Docker & Storage',
         description: 'Reclaimable-space alerts and Docker image cleanup after updates.',
-        keywords: ['docker', 'janitor', 'prune', 'reclaim', 'storage', 'images', 'cleanup', 'dangling'],
+        keywords: ['docker', 'prune', 'reclaim', 'storage', 'images', 'cleanup', 'dangling'],
         tier: null,
         scope: 'node',
     },


### PR DESCRIPTION
## Summary

The backend alert and Settings UI used the term "Janitor" ("Janitor tool", "Janitor threshold") to refer to Docker cleanup, but no "Janitor" feature exists as a visible UI element. Users were told to use a tool that does not exist.

This renames all user-facing "Janitor" references to point at the real cleanup surfaces: the **Resources** view (top-level nav, visible to all authenticated users) and the **Prune Node Resources** scheduled operation.

## Changes

- **Alert notification** (MonitorService): `"Consider using the Janitor tool"` changed to `"Open Resources to reclaim space, or set up a Prune Node Resources schedule"`
- **Settings label** (Docker & Storage): `"Janitor threshold"` changed to `"Reclaimable Docker data threshold"`
- **Settings search keywords**: removed `"janitor"` from the Docker & Storage keyword list
- **Docs**: updated settings reference table and alerts/notifications page to match the new terminology

The internal `docker_janitor_gb` database key and all `JANITOR_*` constants, fields, and method names are unchanged.

## Test plan

- Backend typecheck and 86 monitor-service tests pass
- Frontend typecheck and lint pass with zero errors
- Grep confirms zero remaining user-facing "Janitor tool" or "Janitor threshold" strings outside CHANGELOG and internal code