### PR TITLE
fix: scroll auth canvas when preflight content overflows

### DIFF
--- a/frontend/src/components/auth/AuthCanvas.test.tsx
+++ b/frontend/src/components/auth/AuthCanvas.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AuthCanvas } from './AuthCanvas';
+
+describe('AuthCanvas', () => {
+  it('caps card height and scrolls overflowing body content', () => {
+    render(
+      <AuthCanvas footer={<span>Footer copy</span>}>
+        <p>Tall content</p>
+      </AuthCanvas>,
+    );
+
+    const card = screen.getByRole('group');
+    expect(card.className).toContain('max-h-[calc(100svh-5rem)]');
+    expect(card.className).toContain('flex-col');
+
+    const body = screen.getByText('Tall content').parentElement;
+    expect(body?.className).toContain('overflow-y-auto');
+    expect(body?.className).toContain('min-h-0');
+    expect(body?.className).toContain('flex-1');
+  });
+
+  it('keeps header and footer outside the scroll region', () => {
+    render(
+      <AuthCanvas footer={<span>Footer copy</span>}>
+        <p>Body</p>
+      </AuthCanvas>,
+    );
+
+    const header = screen.getByText('SENCHO').parentElement;
+    const footer = screen.getByText('Footer copy').parentElement;
+
+    expect(header?.className).toContain('shrink-0');
+    expect(footer?.className).toContain('shrink-0');
+  });
+});

--- a/frontend/src/components/auth/AuthCanvas.tsx
+++ b/frontend/src/components/auth/AuthCanvas.tsx
@@ -21,14 +21,14 @@ export function AuthCanvas({ children, className, footer, ...props }: AuthCanvas
 
       <div
         role="group"
-        className="relative w-full max-w-[440px] animate-scale-in overflow-hidden rounded-lg border border-card-border border-t-card-border-top bg-card text-card-foreground shadow-card-bevel"
+        className="relative flex max-h-[calc(100svh-5rem)] w-full max-w-[440px] flex-col animate-scale-in overflow-hidden rounded-lg border border-card-border border-t-card-border-top bg-card text-card-foreground shadow-card-bevel"
         style={{ animationDuration: 'var(--duration-base)', animationTimingFunction: 'var(--ease-out-expo)' }}
       >
         <div aria-hidden className="absolute inset-y-0 left-0 w-[3px] overflow-hidden bg-brand/70">
           <div className="animate-shimmer absolute inset-x-0 h-1/3 bg-gradient-to-b from-transparent via-white/60 to-transparent" />
         </div>
 
-        <div className="flex items-center justify-between border-b border-card-border/60 px-7 pt-6 pb-4">
+        <div className="flex shrink-0 items-center justify-between border-b border-card-border/60 px-7 pt-6 pb-4">
           <span className="font-mono text-[10px] uppercase tracking-[0.22em] text-stat-subtitle">
             SENCHO
           </span>
@@ -38,10 +38,10 @@ export function AuthCanvas({ children, className, footer, ...props }: AuthCanvas
           </span>
         </div>
 
-        <div className="px-7 pb-7 pt-6">{children}</div>
+        <div className="min-h-0 flex-1 overflow-y-auto px-7 pb-7 pt-6">{children}</div>
 
         {footer && (
-          <div className="border-t border-card-border/60 px-7 py-3 font-mono text-[10px] uppercase tracking-[0.18em] text-stat-subtitle">
+          <div className="shrink-0 border-t border-card-border/60 px-7 py-3 font-mono text-[10px] uppercase tracking-[0.18em] text-stat-subtitle">
             {footer}
           </div>
         )}


### PR DESCRIPTION
## Summary
- Cap the auth card height to the viewport and scroll its body when content exceeds available space.
- Keeps the SENCHO header and card footer pinned while setup preflight checks and the Enter Sencho action stay reachable on short viewports.

## Test plan
- [x] `cd frontend && npx tsc -b --noEmit`
- [x] `cd frontend && npm run lint`
- [x] `npx vitest run src/components/auth/AuthCanvas.test.tsx`
- [x] Manual check on login at 440x500: card body uses `overflow-y-auto`
- [x] `npx playwright test --project=visual` (11/12 passed; home-1280 had 0.01% live-data drift unrelated to auth)

## Notes
- Fix lives in `AuthCanvas`, so login and MFA screens inherit the same overflow behavior.
- Recovery settings already scroll via `SettingsPage`; no change there.