### PR TITLE
fix: make auth canvas scroll actually constrain on short viewports

### DIFF
--- a/frontend/src/components/Setup.tsx
+++ b/frontend/src/components/Setup.tsx
@@ -93,9 +93,18 @@ export function Setup({ onComplete, className, ...props }: SetupProps & React.Co
       <div className={cn('relative', className)} {...props}>
         <AuthCanvas
           footer={
-            <div className="flex items-center justify-between">
-              <span>Console · First boot</span>
-              <span className="text-stat-subtitle/70">Account ready</span>
+            <div className="flex flex-col gap-4">
+              <Button
+                type="button"
+                onClick={onComplete}
+                className="h-11 w-full bg-brand text-brand-foreground shadow-btn-glow hover:bg-brand/90"
+              >
+                Enter Sencho<ArrowRight strokeWidth={1.5} />
+              </Button>
+              <div className="flex items-center justify-between border-t border-card-border/60 pt-3">
+                <span>Console · First boot</span>
+                <span className="text-stat-subtitle/70">Account ready</span>
+              </div>
             </div>
           }
         >
@@ -106,13 +115,6 @@ export function Setup({ onComplete, className, ...props }: SetupProps & React.Co
               caption="A quick check that this host can run Docker deploys. Warnings won't stop you; each one carries a fix."
             />
             <EnvironmentChecks />
-            <Button
-              type="button"
-              onClick={onComplete}
-              className="h-11 w-full bg-brand text-brand-foreground shadow-btn-glow hover:bg-brand/90"
-            >
-              Enter Sencho<ArrowRight strokeWidth={1.5} />
-            </Button>
           </div>
         </AuthCanvas>
       </div>

--- a/frontend/src/components/auth/AuthCanvas.test.tsx
+++ b/frontend/src/components/auth/AuthCanvas.test.tsx
@@ -11,8 +11,13 @@ describe('AuthCanvas', () => {
     );
 
     const card = screen.getByRole('group');
-    expect(card.className).toContain('max-h-[calc(100svh-5rem)]');
+    expect(card.className).toContain('max-h-[calc(100dvh-5rem)]');
+    expect(card.className).toContain('min-h-0');
+    expect(card.className).toContain('my-auto');
     expect(card.className).toContain('flex-col');
+
+    const shell = card.parentElement;
+    expect(shell?.className).toContain('overflow-y-auto');
 
     const body = screen.getByText('Tall content').parentElement;
     expect(body?.className).toContain('overflow-y-auto');

--- a/frontend/src/components/auth/AuthCanvas.tsx
+++ b/frontend/src/components/auth/AuthCanvas.tsx
@@ -9,7 +9,10 @@ export function AuthCanvas({ children, className, footer, ...props }: AuthCanvas
   return (
     <div
       className={cn(
-        'relative flex min-h-svh flex-col items-center justify-center px-4 py-10 sm:px-6',
+        // overflow-y-auto: html/body are overflow:hidden, so this shell must scroll
+        // when the card still exceeds the viewport. my-auto on the card centers it
+        // when content is short (replaces justify-center, which clips tall cards).
+        'relative flex min-h-svh flex-col items-center overflow-y-auto px-4 py-10 sm:px-6',
         className,
       )}
       {...props}
@@ -21,7 +24,7 @@ export function AuthCanvas({ children, className, footer, ...props }: AuthCanvas
 
       <div
         role="group"
-        className="relative flex max-h-[calc(100svh-5rem)] w-full max-w-[440px] flex-col animate-scale-in overflow-hidden rounded-lg border border-card-border border-t-card-border-top bg-card text-card-foreground shadow-card-bevel"
+        className="relative my-auto flex min-h-0 w-full max-w-[440px] max-h-[calc(100dvh-5rem)] flex-col animate-scale-in overflow-hidden rounded-lg border border-card-border border-t-card-border-top bg-card text-card-foreground shadow-card-bevel"
         style={{ animationDuration: 'var(--duration-base)', animationTimingFunction: 'var(--ease-out-expo)' }}
       >
         <div aria-hidden className="absolute inset-y-0 left-0 w-[3px] overflow-hidden bg-brand/70">


### PR DESCRIPTION
## Summary
- Follow-up to #1521: the prior scroll classes were present in `:dev` but did not constrain the card in practice.
- Root cause: the auth card is a flex child with default `min-height: auto`, so it kept growing with content; `justify-center` plus `html/body { overflow: hidden }` clipped the bottom with no scroll affordance.
- Fix: add `min-h-0` and `my-auto` on the card, switch to `100dvh`, make the auth shell `overflow-y-auto`, and move **Enter Sencho** into the pinned footer on the setup preflight step so checks scroll while the CTA stays visible.

## Test plan
- [ ] Fresh install through setup step 2 on a short viewport (phone or resized browser)
- [ ] Preflight checks scroll inside the card; **Enter Sencho** and the footer meta row stay visible
- [ ] Login screen still centers correctly when content is short

## Notes
- Pull a new `ghcr.io/studio-saelix/sencho-dev:dev` image after merge; the previous image did include #1521 but that change was insufficient on its own.