### PR TITLE
fix(ci): correct github-script pin in preview workflow

### DIFF
--- a/.github/workflows/docker-preview.yml
+++ b/.github/workflows/docker-preview.yml
@@ -195,7 +195,7 @@ jobs:
 
       - name: Comment on pull request with pull instructions
         continue-on-error: true
-        uses: actions/github-script@ed597411d8f9240738b6aec6e6bc2f24db7bbd28 # v8.0.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           PR_NUMBER: ${{ inputs.pr_number }}
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}


### PR DESCRIPTION
## Summary
Fixes the \ctions/github-script\ commit SHA in \docker-preview.yml\. The user-facing preview workflow (truncated SHA caused workflow resolution failure).

## Test plan
- [ ] Re-run **Publish PR Preview Image** after merge
