### PR TITLE
fix: reflect toggle state in scheduled task Enabled/Disabled label

### DIFF
--- a/frontend/src/components/ScheduledOperationsView.tsx
+++ b/frontend/src/components/ScheduledOperationsView.tsx
@@ -937,7 +937,12 @@ export default function ScheduledOperationsView({ filterNodeId, onClearFilter, p
 
             <div className="flex items-center gap-2">
               <TogglePill checked={formEnabled} onChange={setFormEnabled} id="task-enabled" />
-              <Label htmlFor="task-enabled">Enabled</Label>
+              <label
+                htmlFor="task-enabled"
+                className="text-sm text-stat-value cursor-pointer select-none"
+              >
+                {formEnabled ? 'Enabled' : 'Disabled'}
+              </label>
             </div>
 
             <label className="flex items-start gap-2 cursor-pointer">


### PR DESCRIPTION
## Summary
- The New/Edit Scheduled Task modal's toggle was paired with a label that always read "Enabled", even when the toggle was switched off.
- The label now reads "Enabled" or "Disabled" based on the toggle's actual state, matching the existing convention used for the Deploy progress / Diff preview toggles in Settings > Stacks.

## Test plan
- [x] `npx tsc -b --noEmit` in frontend: clean.
- [x] `npm run lint` in frontend: 0 errors (pre-existing unrelated warnings only).
- [x] Manually verified in the browser: opened New scheduled task, toggled off (label switched to "Disabled"), toggled back on (label switched back to "Enabled").
