### PR TITLE
fix(deploy-modal): hide frozen countdown label in inline feedback style

### DIFF
--- a/frontend/src/components/DeployFeedbackModal.tsx
+++ b/frontend/src/components/DeployFeedbackModal.tsx
@@ -229,7 +229,7 @@ export function DeployFeedbackModal({ isMinimized, onMinimize }: DeployFeedbackM
               rowCount={logRows.length}
               errorMessage={errorMessage}
               countdown={countdown}
-              showCountdown={!gateHoldsOpen}
+              showCountdown={canAutoClose}
               gateStatus={healthGate?.status ?? null}
             />
             <Button
@@ -413,7 +413,7 @@ interface StatusIndicatorProps {
   rowCount: number;
   errorMessage?: string;
   countdown: number;
-  /** False while a health gate is observing or terminal-unhealthy (no auto-close). */
+  /** False when auto-close is not eligible: inline style, or while a gate is observing or terminal-unhealthy. */
   showCountdown: boolean;
   /** Active health gate status, or null when no gate was started. */
   gateStatus: 'observing' | 'passed' | 'failed' | 'unknown' | null;

--- a/frontend/src/components/__tests__/DeployFeedbackModal.inline.test.tsx
+++ b/frontend/src/components/__tests__/DeployFeedbackModal.inline.test.tsx
@@ -78,6 +78,20 @@ describe('DeployFeedbackModal Inline vs Modal style', () => {
         expect(onMinimize).not.toHaveBeenCalled();
     });
 
+    it('inline style: succeeded state shows no auto-close countdown label', () => {
+        mockStyle = 'inline';
+        mockPanelState = panel({ status: 'succeeded' });
+        render(<DeployFeedbackModal isMinimized={false} onMinimize={onMinimize} />);
+        expect(screen.queryByText(/closes in/i)).toBeNull();
+    });
+
+    it('modal style: succeeded state shows auto-close countdown label', () => {
+        mockStyle = 'modal';
+        mockPanelState = panel({ status: 'succeeded' });
+        render(<DeployFeedbackModal isMinimized={false} onMinimize={onMinimize} />);
+        expect(screen.getByText(/closes in/i)).toBeInTheDocument();
+    });
+
     it('modal style owns the live terminal; inline style renders no terminal (single socket)', () => {
         mockStyle = 'modal';
         const view = render(<DeployFeedbackModal isMinimized={false} onMinimize={onMinimize} />);


### PR DESCRIPTION
## Summary

- In **inline deploy feedback style**, the modal header showed a frozen **"closes in 4s"** countdown label after a successful update. The label never ticked and the modal never closed.
- Root cause: \`showCountdown\` was driven by \`!gateHoldsOpen\` (no gate or gate passed), ignoring the style condition. \`canAutoClose\` already excluded inline style correctly, but the label render did not use it.
- Fix: change \`showCountdown={!gateHoldsOpen}\` to \`showCountdown={canAutoClose}\` (one line). The label now only appears when the modal is actually eligible to auto-close.
- No gate contracts change. Modal-style auto-close behavior is unchanged.

## Test plan

- [x] \`DeployFeedbackModal.inline.test.tsx\` -- 6 tests pass (2 new: inline succeeded hides label, modal succeeded shows label)
- [x] \`DeployFeedbackModal.test.tsx\` -- 12 tests pass (no regression in modal-style behavior)
- [x] \`tsc -b --noEmit\` -- zero type errors
- [x] Manual (inline style): update a stack, click "View output" on the banner after success. Modal shows "Succeeded" with no countdown label and stays open until manually closed.
- [x] Manual (modal style): update a stack. Modal shows "Succeeded closes in 4s", counts down, and closes automatically.