### PR TITLE
feat: add GitHub Sponsors alongside Buy Me a Coffee

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,3 @@
+github: Studio-Saelix
 custom:
   - https://buymeacoffee.com/sencho

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
     <a href="https://docs.sencho.io">Docs</a> ·
     <a href="https://sencho.io">Website</a> ·
     <a href="https://github.com/studio-saelix/sencho/discussions">Discussions</a> ·
-    <a href="https://buymeacoffee.com/sencho">Sponsor</a>
+    <a href="https://github.com/sponsors/Studio-Saelix">Sponsor</a> ·
+    <a href="https://buymeacoffee.com/sencho">Buy Me a Coffee</a>
   </p>
 
   [![Latest release](https://img.shields.io/github/v/release/studio-saelix/sencho?label=release)](https://github.com/studio-saelix/sencho/releases)

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -10,7 +10,7 @@ Sencho is a solo-maintained project. Here is what to expect.
 - **Feature requests** → [Feature request](https://github.com/studio-saelix/sencho/issues/new?template=feature_request.yml)
 - **Security vulnerabilities** → [SECURITY.md](SECURITY.md). Do not open a public issue.
 - **Licensing, billing, refunds** → licensing@sencho.io
-- **Support the project** → [Buy Me a Coffee](https://buymeacoffee.com/sencho). Sponsorship is not required and does not change support response times; it helps fund the work.
+- **Support the project** → [GitHub Sponsors](https://github.com/sponsors/Studio-Saelix) or [Buy Me a Coffee](https://buymeacoffee.com/sencho). Sponsorship is not required and does not change support response times; it helps fund the work.
 
 ## Response times
 


### PR DESCRIPTION
## Summary
- Adds `github: Studio-Saelix` to `.github/FUNDING.yml` so GitHub can show a Sponsors button alongside the existing custom link.
- README and SUPPORT.md now link both GitHub Sponsors and Buy Me a Coffee instead of Buy Me a Coffee alone.

## Test plan
- [x] Confirm the Sponsors button appears on the repo sidebar once the Studio-Saelix org completes GitHub Sponsors onboarding (identity/bank verification is a manual step outside this PR).
- [x] Spot-check the README and SUPPORT.md links resolve correctly after merge.