### PR TITLE
fix: update NodeCard cordon tests for paid-tier gate parity

### DIFF
--- a/frontend/src/components/FleetView/__tests__/NodeCard.test.tsx
+++ b/frontend/src/components/FleetView/__tests__/NodeCard.test.tsx
@@ -55,23 +55,24 @@ describe('NodeCard', () => {
     expect(screen.queryByText('Running')).not.toBeInTheDocument();
   });
 
-  it('hides the actions menu when the user lacks node:manage and no edit/delete affordances', () => {
-    useAuthMock.mockReturnValue({ isAdmin: false, can: vi.fn(() => false) });
+  it('hides the actions menu for a free-tier user', () => {
     useLicenseMock.mockReturnValue({ isPaid: false });
     render(<NodeCard {...baseProps(onlineNode())} />);
     expect(screen.queryByRole('button', { name: 'Node actions' })).not.toBeInTheDocument();
   });
 
-  it('exposes the actions menu (cordon entry point) for a Community admin with node:manage', () => {
-    useLicenseMock.mockReturnValue({ isPaid: false });
+  it('exposes the actions menu (cordon entry point) for a paid admin', () => {
+    useLicenseMock.mockReturnValue({ isPaid: true });
     render(<NodeCard {...baseProps(onlineNode())} />);
+    // With no edit/delete affordances wired, the menu renders iff cordon is
+    // allowed: isPaid && can('node:manage'). The admin's can() returns true.
     expect(screen.getByRole('button', { name: 'Node actions' })).toBeInTheDocument();
   });
 
   it('exposes the cordon control for a node-admin via the node:manage permission', async () => {
     const can = vi.fn((action: string) => action === 'node:manage');
     useAuthMock.mockReturnValue({ isAdmin: false, can });
-    useLicenseMock.mockReturnValue({ isPaid: false });
+    useLicenseMock.mockReturnValue({ isPaid: true });
     render(<NodeCard {...baseProps(onlineNode())} />);
 
     await userEvent.click(screen.getByRole('button', { name: 'Node actions' }));
@@ -79,18 +80,18 @@ describe('NodeCard', () => {
     expect(can).toHaveBeenCalledWith('node:manage', 'node', '2');
   });
 
-  it('hides the cordon control from a user lacking node:manage', () => {
+  it('hides the cordon control from a paid user lacking node:manage', () => {
     useAuthMock.mockReturnValue({ isAdmin: false, can: vi.fn(() => false) });
-    useLicenseMock.mockReturnValue({ isPaid: false });
+    useLicenseMock.mockReturnValue({ isPaid: true });
     render(<NodeCard {...baseProps(onlineNode())} />);
-    // node:manage alone must not surface cordon when false to a deployer/viewer/auditor.
+    // The paid tier alone must not surface cordon to a deployer/viewer/auditor.
     expect(screen.queryByRole('button', { name: 'Node actions' })).not.toBeInTheDocument();
   });
 
   it('shows Uncordon when the node is already cordoned', async () => {
     const can = vi.fn((action: string) => action === 'node:manage');
     useAuthMock.mockReturnValue({ isAdmin: false, can });
-    useLicenseMock.mockReturnValue({ isPaid: false });
+    useLicenseMock.mockReturnValue({ isPaid: true });
     render(<NodeCard {...baseProps({ ...onlineNode(), cordoned: true, cordoned_reason: 'patching' })} />);
 
     await userEvent.click(screen.getByRole('button', { name: 'Node actions' }));
@@ -103,13 +104,13 @@ describe('NodeCard', () => {
   };
 
   it('renders the update button for an admin when an update is available', () => {
-    useAuthMock.mockReturnValue({ isAdmin: true, can: vi.fn(() => true) });
+    useAuthMock.mockReturnValue({ isAdmin: true });
     render(<NodeCard {...baseProps(onlineNode())} updateStatus={updateAvailableStatus} onUpdate={vi.fn()} />);
     expect(screen.getByRole('button', { name: /Update/ })).toBeInTheDocument();
   });
 
   it('hides the update button for a non-admin but still shows the read-only badge', () => {
-    useAuthMock.mockReturnValue({ isAdmin: false, can: vi.fn(() => false) });
+    useAuthMock.mockReturnValue({ isAdmin: false });
     render(<NodeCard {...baseProps(onlineNode())} updateStatus={updateAvailableStatus} onUpdate={vi.fn()} />);
     expect(screen.queryByRole('button', { name: /Update/ })).not.toBeInTheDocument();
     expect(screen.getByText('Update available')).toBeInTheDocument();


### PR DESCRIPTION
## Summary

PR #1567 added the `isPaid` gate to `canCordon` in NodeCard, bringing the frontend into parity with the backend's existing `requirePaid` guard on cordon/uncordon routes. Three NodeCard tests were not updated to set `isPaid: true`, causing CI to fail because the actions menu was hidden when `canCordon` evaluated to `false`.

## Changes

- Three cordon tests: `isPaid: false` → `isPaid: true`
- Free-tier test: simplified to rely on `beforeEach` default (`isPaid: false`)
- Paid-user-lacking-permission test: `isPaid: true` to isolate the permission gate
- Renamed tests to accurately reflect the paid-tier gating
- Removed unnecessary `can` overrides from update-button tests

## Test plan

- NodeCard test file: 9/9 passing
- No other test file touched