### PR TITLE
fix: default to compact density only for multi-container stacks

### DIFF
--- a/frontend/src/components/EditorLayout/__tests__/ContainersHealth.test.tsx
+++ b/frontend/src/components/EditorLayout/__tests__/ContainersHealth.test.tsx
@@ -185,7 +185,7 @@ describe('density toggle and summary strip', () => {
     expect(screen.queryByRole('button', { name: 'Detailed view' })).toBeNull();
   });
 
-  it('resets density to compact on remount (key change)', () => {
+  it('resets density to detailed on remount (key change)', () => {
     const { unmount } = render(
       <ContainersHealth
         safeContainers={[makeContainer({ Id: 'a' }), makeContainer({ Id: 'b' })]}
@@ -216,9 +216,8 @@ describe('density toggle and summary strip', () => {
         serviceAction={vi.fn()}
       />,
     );
-    // Density reset to compact; single container hides sparklines,
-    // no density toggle for a single container
-    expect(screen.queryByText('cpu')).toBeNull();
+    // Density reset; single container shows sparklines
+    expect(screen.getByText('cpu')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Compact view' })).toBeNull();
   });
 });

--- a/frontend/src/components/EditorLayout/editor-view-blocks.tsx
+++ b/frontend/src/components/EditorLayout/editor-view-blocks.tsx
@@ -361,7 +361,9 @@ export function ContainersHealth({
     const copiedUrlTimerRef = useRef<number | null>(null);
     // Compact mode hides sparkline grids across all containers for a denser
     // list. Detailed mode (default) shows CPU / Mem / Net per container.
-    const [density, setDensity] = useState<'compact' | 'detailed'>('compact');
+    const [density, setDensity] = useState<'compact' | 'detailed'>(
+    safeContainers.length > 1 ? 'compact' : 'detailed',
+);
     useEffect(() => () => {
         if (copiedUrlTimerRef.current !== null) window.clearTimeout(copiedUrlTimerRef.current);
     }, []);


### PR DESCRIPTION
## Summary

The compact density default was applied unconditionally, which hid sparklines for single-container stacks where the density toggle does not render. Now the default is compact only when the stack has more than one container.

## Test plan

- Updated `ContainersHealth.test.tsx`: the density-reset-on-remount test now expects detailed mode for single-container stacks.
- All 16 ContainersHealth tests pass locally.
- TypeScript compiles cleanly.