### PR TITLE
docs: reorganize documentation navigation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -79,29 +79,39 @@
   "navigation": {
     "tabs": [
       {
-        "tab": "Documentation",
+        "tab": "Guides",
         "groups": [
           {
-            "group": "Getting Started",
+            "group": "Start here",
+            "root": "getting-started/introduction",
+            "directory": "card",
             "pages": [
-              "getting-started/introduction",
               "getting-started/quickstart",
-              "getting-started/configuration",
-              "getting-started/sso-quickstart"
+              "getting-started/configuration"
             ]
           },
           {
-            "group": "Features",
+            "group": "Product guide",
+            "root": "features/overview",
             "pages": [
-              "features/overview",
-              "features/appearance",
               {
-                "group": "Stacks",
+                "group": "Core workflow",
                 "expanded": true,
                 "pages": [
                   "features/stack-management",
                   "features/editor",
                   "features/stack-file-explorer",
+                  "features/resources",
+                  "features/dashboard",
+                  "features/app-store",
+                  "features/global-search",
+                  "features/deep-links",
+                  "features/appearance"
+                ]
+              },
+              {
+                "group": "Stack intelligence",
+                "pages": [
                   "features/stack-activity",
                   "features/stack-dossier",
                   "features/stack-drift",
@@ -115,34 +125,30 @@
                 ]
               },
               {
-                "group": "Deployment",
-                "expanded": true,
+                "group": "Deploy and automate",
                 "pages": [
                   "features/deploy-progress",
                   "features/atomic-deployments",
                   "features/health-gated-updates",
                   "features/deploy-enforcement",
                   "features/git-sources",
-                  "features/app-store",
-                  "features/blueprint-model"
+                  "features/blueprint-model",
+                  "features/scheduled-operations",
+                  "features/auto-update-policies",
+                  "features/auto-heal-policies",
+                  "features/webhooks"
                 ]
               },
-              "features/resources",
               {
-                "group": "Observability",
-                "expanded": true,
+                "group": "Observe and audit",
                 "pages": [
-              "features/dashboard",
-              "features/deep-links",
-              "features/global-search",
                   "features/global-observability",
                   "features/alerts-notifications",
                   "features/audit-log"
                 ]
               },
               {
-                "group": "Fleet",
-                "expanded": true,
+                "group": "Fleet management",
                 "pages": [
                   "features/multi-node",
                   "features/pilot-agent",
@@ -160,35 +166,26 @@
                 ]
               },
               {
-                "group": "Automation",
-                "expanded": true,
+                "group": "Security and access",
                 "pages": [
-                  "features/scheduled-operations",
-                  "features/auto-update-policies",
-                  "features/auto-heal-policies",
-                  "features/webhooks"
-                ]
-              },
-              {
-                "group": "Security & Identity",
-                "expanded": true,
-                "pages": [
-                  "features/two-factor-authentication",
-                  "features/rbac",
-                  "features/sso",
-                  "features/api-tokens",
                   "features/security",
                   "features/vulnerability-scanning",
                   "features/cve-suppressions",
-                  "features/private-registries"
+                  "features/private-registries",
+                  "features/two-factor-authentication",
+                  "features/rbac",
+                  "features/sso",
+                  "getting-started/sso-quickstart",
+                  "features/api-tokens"
                 ]
               }
             ]
           },
           {
             "group": "Operations",
+            "root": "operations/self-hosting",
+            "directory": "accordion",
             "pages": [
-              "operations/self-hosting",
               "operations/upgrade",
               "operations/backup",
               "operations/recovery",
@@ -201,8 +198,9 @@
           },
           {
             "group": "Reference",
+            "root": "reference/settings",
+            "directory": "accordion",
             "pages": [
-              "reference/settings",
               "features/licensing",
               "reference/security",
               "reference/contact"

--- a/docs/features/alerts-notifications.mdx
+++ b/docs/features/alerts-notifications.mdx
@@ -1,5 +1,6 @@
 ---
 title: Alerts & Notifications
+sidebarTitle: Alerts and notifications
 description: Threshold and event alerts for your fleet, dispatched to Discord, Slack, or any webhook, with per-stack rules and channel routing.
 ---
 

--- a/docs/features/atomic-deployments.mdx
+++ b/docs/features/atomic-deployments.mdx
@@ -1,5 +1,6 @@
 ---
 title: Atomic Deployments
+sidebarTitle: Atomic deploys
 description: Wrap every deploy and update in a backup, a 3-second health probe, and an automatic rollback when a container crashes.
 ---
 

--- a/docs/features/auto-heal-policies.mdx
+++ b/docs/features/auto-heal-policies.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Auto-Heal Policies"
+sidebarTitle: Auto-heal
 description: "Restart containers that fail their Docker healthcheck or crash, with per-policy thresholds and a built-in safety rail set."
 ---
 

--- a/docs/features/auto-update-policies.mdx
+++ b/docs/features/auto-update-policies.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Auto-Update Policies"
+sidebarTitle: Auto-update
 description: "Review pending container updates across your fleet, with risk badges, changelogs, and scheduled run times, before applying."
 ---
 

--- a/docs/features/compose-storage.mdx
+++ b/docs/features/compose-storage.mdx
@@ -1,5 +1,6 @@
 ---
 title: Storage Portability
+sidebarTitle: Storage portability
 description: See every mount a stack depends on, understand whether it can move cleanly between nodes, and find out what you need to back up before you move or restore it.
 ---
 

--- a/docs/features/deploy-enforcement.mdx
+++ b/docs/features/deploy-enforcement.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Deploy Enforcement"
+sidebarTitle: Deploy policies
 description: "Block deploys that violate a scan policy before docker compose up runs, with an admin bypass path and a full audit trail."
 ---
 

--- a/docs/features/docker-label-audit.mdx
+++ b/docs/features/docker-label-audit.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Docker Label Audit"
+sidebarTitle: Label audit
 description: "Audit Docker and Compose labels that drive external automation across the fleet and inside each stack."
 ---
 

--- a/docs/features/environment-guardrails.mdx
+++ b/docs/features/environment-guardrails.mdx
@@ -1,5 +1,6 @@
 ---
 title: Environment and Secrets Guardrails
+sidebarTitle: Env guardrails
 description: See every environment variable a stack uses, where it comes from, and whether it is likely a secret, without ever exposing a value. Sencho builds a per-stack inventory, shows env file status, flags missing and duplicate variables, and can block a deploy when a required variable has no value.
 ---
 

--- a/docs/features/fleet-backups.mdx
+++ b/docs/features/fleet-backups.mdx
@@ -1,5 +1,6 @@
 ---
 title: Fleet-Wide Backups
+sidebarTitle: Fleet backups
 description: Snapshot compose files across all nodes for disaster recovery and auditing.
 ---
 

--- a/docs/features/global-observability.mdx
+++ b/docs/features/global-observability.mdx
@@ -1,5 +1,6 @@
 ---
 title: Global Observability
+sidebarTitle: Global logs
 description: A unified, searchable log stream from the containers Sencho manages on the hub.
 ---
 

--- a/docs/features/health-gated-updates.mdx
+++ b/docs/features/health-gated-updates.mdx
@@ -1,5 +1,6 @@
 ---
 title: Health-Gated Updates
+sidebarTitle: Health gates
 description: Check update readiness before applying, watch container health after the update lands, and know exactly what a rollback can restore.
 ---
 

--- a/docs/features/licensing.mdx
+++ b/docs/features/licensing.mdx
@@ -1,5 +1,6 @@
 ---
 title: Licensing & Billing
+sidebarTitle: Licensing
 description: How Sencho licensing works, including trials, activation, and subscription management.
 ---
 

--- a/docs/features/multi-node.mdx
+++ b/docs/features/multi-node.mdx
@@ -1,5 +1,6 @@
 ---
 title: Multi-Node Management
+sidebarTitle: Multi-node
 description: Connect multiple Sencho instances and manage every server from one console with no central server, no SSH, and no shared Docker sockets.
 ---
 

--- a/docs/features/overview.mdx
+++ b/docs/features/overview.mdx
@@ -1,15 +1,15 @@
 ---
-title: Features Overview
-description: A high-level tour of everything Sencho can do, organized by area.
+title: Product Guide
+description: A high-level tour of Sencho, organized by the same areas as the product guide sidebar.
 ---
 
-Sencho is a self-hosted cockpit for Docker Compose. The catalog below groups Sencho's features by area, mirroring the Features navigation, so you can scan the surface at a glance and jump into the deep-dive page for the parts you care about. Tier callouts are inline with each entry; if no tier is mentioned, the feature is available on every Sencho installation.
+Sencho is a self-hosted cockpit for Docker Compose. The catalog below groups Sencho's product areas the same way the sidebar does, so you can scan the surface at a glance and jump into the deep-dive page for the parts you care about. Tier callouts are inline with each entry; if no tier is mentioned, the feature is available on every Sencho installation.
 
 <Frame>
   <img src="/images/overview/dashboard-hero.png" alt="Sencho Home dashboard: the Healthy masthead with running container count, fleet-wide CPU, and memory, the CPU sparkline and memory, disk, and network gauge tiles, and the Stack health table sorted by load." />
 </Frame>
 
-## Stacks
+## Core workflow
 
 <Frame>
   <img src="/images/overview/stack-anatomy.png" alt="A stack open in the editor: the action toolbar, the container card with CPU and memory sparklines, the live log stream, and the right-hand panel on the Networking tab showing exposure intent, network memberships, published ports, and a runtime drift check. The full tab strip (Anatomy, Activity, Dossier, Drift, Environment, Networking, Doctor, Storage) is visible across the top of the panel." />
@@ -27,101 +27,129 @@ Full in-browser Monaco editor for `compose.yaml` and `.env` files with syntax hi
 
 Browse, preview, and download files inside a stack's directory from the dashboard with any signed-in role. Write actions (upload, edit, rename, move, create folders, change permissions, and delete) require stack edit permission. [Learn more →](/features/stack-file-explorer)
 
-### Stack activity
-
-Every stack has its own event log showing deploys, restarts, starts, stops, image updates, and drift, each event attributed to the user or system that triggered it. The most recent 50 events load immediately and new events stream in live without a page refresh; pagination fetches older events on demand. [Learn more →](/features/stack-activity)
-
-### Stack Dossier
-
-The **Dossier** tab in the right-hand Anatomy panel turns each stack into living documentation. Sencho fills in the operational facts it derives from your Compose file, and you add what it cannot infer (purpose, owner, access URLs, network, recovery steps), then export the whole thing as Markdown. [Learn more →](/features/stack-dossier)
-
-### Drift Detection
-
-The **Drift** tab compares the Compose file on disk against the live Docker runtime and reports exactly where they diverge: a missing service, an undeclared container, a changed image, or different published ports. The check is read-only and keeps a short history of what it has seen. [Learn more →](/features/stack-drift)
-
-### Compose Doctor
-
-The **Doctor** tab runs a preflight check before you deploy. It renders the effective Compose model and reports common failure modes (unset variables, port conflicts, missing bind paths, a mounted Docker socket, a moving `latest` tag) grouped by severity, with a clear fix for each. It is advisory and never blocks a deploy. [Learn more →](/features/compose-doctor)
-
-### Compose Networking
-
-The **Networking** tab shows how a stack is networked and exposed: its networks, each service's published ports and bindings, and a per-stack or per-service exposure intent (internal, LAN, reverse proxy, public, and more) that Sencho uses to flag when the Compose file disagrees. [Learn more →](/features/compose-networking)
-
-### Environment & secrets guardrails
-
-The **Environment** tab inventories every variable a stack uses, where each one comes from (Compose interpolation versus container injection), and whether it looks like a secret, all from variable names so no value is ever exposed. It flags missing and duplicate variables and can block a deploy when a required variable has no value. [Learn more →](/features/environment-guardrails)
-
-### Storage portability
-
-The **Storage** tab lists every mount a stack depends on, classifies each one (bind, named, anonymous, tmpfs, or Docker socket) with its read-only flag, and gives the stack a single portability verdict so you know what will break if you move or restore it. [Learn more →](/features/compose-storage)
-
-### Stack labels
-
-Tag stacks with custom colored labels like `production`, `staging`, or `media-server`. Filter the sidebar by label, identify stacks at a glance, and bulk-action a label to deploy, stop, or restart every stack that carries it. [Learn more →](/features/stack-labels)
-
-### Stack sidebar
-
-Manage, group, and pin your stacks from the primary sidebar, organized by label. Pinned stacks sit in a dedicated `PINNED` group at the top, the context menu groups actions by purpose (Inspect, Organize, Lifecycle, Destructive), and bulk mode (press `B`) acts on a hand-picked subset at once. [Learn more →](/features/sidebar)
-
-## Deployment
-
-### Deploy progress
-
-Stream live output from stack actions in a structured log view with stage badges (PULL, BUILD, CREATE, START, STOP). Choose a modal or an inline band; it auto-dismisses on success and minimizes to a status pill that persists across navigation. [Learn more →](/features/deploy-progress)
-
-### Atomic deployments
-
-Sencho snapshots your compose and environment files before applying changes. If containers crash within a few seconds of deploy, the previous configuration is restored automatically. [Learn more →](/features/atomic-deployments)
-
-### Health-Gated Updates
-
-Before an update, a readiness dialog gives a single verdict (Ready, Ready with warnings, Review required, Blocked, or Unknown) drawn from Compose Doctor, drift, container health, the pending image change, rollback backup, and node disk. After the update lands, a health gate watches the containers for an observation window and records whether it held. [Learn more →](/features/health-gated-updates)
-
-### Deploy enforcement
-
-Block deploys that violate a scan policy before `docker compose up` runs, with an admin bypass path and a full audit trail. The pre-flight gate enumerates images and rejects a deploy when any image meets or exceeds the policy's severity threshold. [Learn more →](/features/deploy-enforcement)
-
-### Git sources
-
-Link a stack to a Git repository and keep one or more compose files in sync via manual pulls or webhook triggers. Merge a base file with environment overrides in order, review a diff before applying, create stacks directly from a repo, and optionally sync sibling `.env` files. [Learn more →](/features/git-sources)
-
-### App Store
-
-Browse pre-configured application templates. Filter by category (Media, Automation, Development, and more), configure environment variables, volumes, and ports, and deploy with a single click. Point the template source at your own registry when you want. [Learn more →](/features/app-store)
-
-### Blueprints
-
-Fleet-wide compose templates that Sencho keeps in sync across the nodes you choose. One declaration covers many nodes via label selectors, drift detection always runs, and stateful blueprints get a confirmation prompt before first deploy and before eviction. [Learn more →](/features/blueprint-model)
-
-## Resources
-
 ### Resources hub
 
-View and manage all Docker images, volumes, and networks. Resources are classified as Managed (owned by a Sencho stack), External (part of another Compose project), or Unused / Reclaimable (safe to prune). Run scoped prune operations against Sencho-managed resources only, or target all Docker resources when needed. [Learn more →](/features/resources)
-
-## Observability
+View and manage Docker images, volumes, networks, and unmanaged containers. Resources are classified as Managed, External, or Unused / Reclaimable, so cleanup decisions are visible before you prune. [Learn more →](/features/resources)
 
 ### Dashboard
 
-The Home view shows real-time system stats at a glance: active and exited containers, Docker network activity, and host resource usage (CPU, RAM, disk), with historical CPU and RAM charts over the last 24 hours. A Docker Run converter turns any `docker run` command into a Compose stack. [Learn more →](/features/dashboard)
+The Home view shows system status, active and exited containers, Docker network activity, host resource usage, stack health, configuration status, fleet heartbeat, and recent alerts. [Learn more →](/features/dashboard)
+
+### App Store
+
+Browse pre-configured application templates. Filter by category, configure environment variables, volumes, and ports, and deploy with live progress feedback. Point the template source at your own registry when you want. [Learn more →](/features/app-store)
 
 ### Global search
 
 Jump to any page, node, or stack from anywhere with `Ctrl+K` (`Cmd+K` on macOS). The palette groups results into Pages, Nodes, and Stacks, fans out across every online node, and keeps your hands on the keyboard. [Learn more →](/features/global-search)
 
+### Deep links
+
+Open stable URLs for Home, Fleet, Resources, Security, stack detail, stack files, stack edit, and other routable views. URLs preserve node and stack context so operators can share exact places in the app. [Learn more →](/features/deep-links)
+
+### Appearance
+
+Personalize Sencho's look: choose a theme, accent color, contrast, border brightness, typography, density, and chart treatment. Every choice is saved to the current browser. [Learn more →](/features/appearance)
+
+## Stack intelligence
+
+### Stack activity
+
+Every stack has its own event log showing deploys, restarts, starts, stops, image updates, and drift, each event attributed to the user or system that triggered it. The most recent 50 events load immediately and new events stream in live without a page refresh. [Learn more →](/features/stack-activity)
+
+### Stack Dossier
+
+The **Dossier** tab in the right-hand Anatomy panel turns each stack into living documentation. Sencho fills in the operational facts it derives from your Compose file, and you add what it cannot infer, then export the whole thing as Markdown. [Learn more →](/features/stack-dossier)
+
+### Drift Detection
+
+The **Drift** tab compares the Compose file on disk against the live Docker runtime and reports where they diverge: a missing service, an undeclared container, a changed image, or different published ports. [Learn more →](/features/stack-drift)
+
+### Compose Doctor
+
+The **Doctor** tab runs a preflight check before you deploy. It renders the effective Compose model and reports common failure modes grouped by severity, with a clear fix for each. It is advisory and never blocks a deploy. [Learn more →](/features/compose-doctor)
+
+### Compose Networking
+
+The **Networking** tab shows how a stack is networked and exposed: its networks, each service's published ports and bindings, and a per-stack or per-service exposure intent that Sencho uses to flag when the Compose file disagrees. [Learn more →](/features/compose-networking)
+
+### Environment and secrets guardrails
+
+The **Environment** tab inventories every variable a stack uses, where each one comes from, and whether it looks like a secret, all from variable names so no value is ever exposed. [Learn more →](/features/environment-guardrails)
+
+### Docker Label Audit
+
+Inspect Docker and Compose labels that drive external automation across the fleet and inside each stack. The audit view helps you understand which labels exist and where they are attached. [Learn more →](/features/docker-label-audit)
+
+### Storage portability
+
+The **Storage** tab lists every mount a stack depends on, classifies each one, and gives the stack a single portability verdict so you know what will break if you move or restore it. [Learn more →](/features/compose-storage)
+
+### Stack labels
+
+Tag stacks with custom colored labels like `production`, `staging`, or `media-server`. Filter the sidebar by label, identify stacks at a glance, and bulk-action a label across every stack that carries it. [Learn more →](/features/stack-labels)
+
+### Stack sidebar
+
+Manage, group, and pin your stacks from the primary sidebar, organized by label. Pinned stacks sit in a dedicated `PINNED` group at the top, and bulk mode acts on a hand-picked subset at once. [Learn more →](/features/sidebar)
+
+## Deploy and automate
+
+### Deploy progress
+
+Stream live output from stack actions in a structured log view with stage badges. Choose a modal or an inline band; it auto-dismisses on success and minimizes to a status pill that persists across navigation. [Learn more →](/features/deploy-progress)
+
+### Atomic deployments
+
+Sencho snapshots your compose and environment files before applying changes. If containers crash within a few seconds of deploy, the previous configuration is restored automatically. [Learn more →](/features/atomic-deployments)
+
+### Health-gated updates
+
+Before an update, a readiness dialog gives a single verdict drawn from Compose Doctor, drift, container health, the pending image change, rollback backup, and node disk. After the update lands, a health gate watches the containers for an observation window and records whether it held. [Learn more →](/features/health-gated-updates)
+
+### Deploy enforcement
+
+Block deploys that violate a scan policy before `docker compose up` runs, with an admin bypass path and a full audit trail. The pre-flight gate enumerates images and blocks a deploy when an image meets or exceeds the policy's severity threshold. [Learn more →](/features/deploy-enforcement)
+
+### Git sources
+
+Link a stack to a Git repository and keep one or more compose files in sync via manual pulls or webhook triggers. Merge a base file with environment overrides in order, review a diff before applying, and create stacks directly from a repo. [Learn more →](/features/git-sources)
+
+### Blueprints
+
+Fleet-wide compose templates that Sencho keeps in sync across the nodes you choose. One declaration covers many nodes via label selectors, drift detection always runs, and stateful blueprints get a confirmation prompt before first deploy and before eviction. [Learn more →](/features/blueprint-model)
+
+### Scheduled operations
+
+Automate recurring maintenance like stack restarts, fleet snapshots, system prunes, scans, and image updates. Use the simple point-and-click mode or switch to a full cron expression for precise control. [Learn more →](/features/scheduled-operations)
+
+### Auto-update policies
+
+Review pending container updates across your fleet with risk badges and one-line changelog previews on a single board. The hero counts how many updates are ready to apply without review and surfaces major version bumps separately. [Learn more →](/features/auto-update-policies)
+
+### Auto-heal policies
+
+Automatically restart containers that fail Docker healthchecks for longer than a threshold. Each policy ships with safety rails: a cooldown period, an hourly restart cap, recent-user-action suppression, and auto-disable on repeated restart failures. [Learn more →](/features/auto-heal-policies)
+
+### Webhooks
+
+Trigger stack actions from external CI/CD pipelines over HTTP. Create a webhook targeting a specific stack and action, then call it from GitHub Actions, GitLab CI, or anything that can send a POST. [Learn more →](/features/webhooks)
+
+## Observe and audit
+
 ### Global observability
 
-The **Logs** view aggregates output from every container across every stack into a single scrollable stream. Filter by stack, log level (stdout/stderr), or keyword, and switch to developer mode for real-time SSE streaming instead of polling. [Learn more →](/features/global-observability)
+The **Logs** view aggregates output from every container across every stack into a single scrollable stream. Filter by stack, log level, or keyword, and switch to developer mode for real-time streaming instead of polling. [Learn more →](/features/global-observability)
 
-### Alerts & notifications
+### Alerts and notifications
 
-Configure threshold-based alerts (CPU, memory, network, restart count) per stack and route notifications to Discord, Slack, or any generic webhook. Alerts are evaluated every 30 seconds with configurable duration and cooldown, and per-stack [routing rules](/features/alerts-notifications#notification-routing) send each stack's alerts to the right channel. [Learn more →](/features/alerts-notifications)
+Configure threshold-based alerts per stack and route notifications to Discord, Slack, or any generic webhook. Per-stack [routing rules](/features/alerts-notifications#notification-routing) send each stack's alerts to the right channel. [Learn more →](/features/alerts-notifications)
 
 ### Audit log
 
-Track every mutating action across your Sencho instance with a searchable trail: who deployed, stopped, deleted, or changed settings, with timestamps, user attribution, and node context. The recent 14-day window is available on every installation. Admiral adds CSV and JSON export, anomaly detection, and configurable retention. [Learn more →](/features/audit-log)
+Track mutating actions across your Sencho instance with a searchable trail: who deployed, stopped, deleted, or changed settings, with timestamps, user attribution, and node context. The recent 14-day window is available on every installation. Admiral adds CSV and JSON export, anomaly detection, and configurable retention. [Learn more →](/features/audit-log)
 
-## Fleet
+## Fleet management
 
 <Frame>
   <img src="/images/overview/fleet-topology.png" alt="Fleet view in grid layout: the fleet masthead showing aggregate CPU, memory, and container counts across all nodes, the tab strip (Overview, Snapshots, Status, Map, Deployments, Routing, Federation, Actions, Secrets), and the node grid with per-node container counts and CPU, RAM, and disk usage bars." />
@@ -129,15 +157,15 @@ Track every mutating action across your Sencho instance with a searchable trail:
 
 ### Multi-node support
 
-Add remote Sencho instances as nodes. Every dashboard operation (stack management, logs, stats) works identically whether you target your local machine or a server across the world, using a transparent HTTP proxy model with no SSH or shared Docker sockets. [Learn more →](/features/multi-node)
+Add remote Sencho instances as nodes. Every dashboard operation works identically whether you target your local machine or a server across the world, using a transparent HTTP proxy model with no SSH or shared Docker sockets. [Learn more →](/features/multi-node)
 
 ### Pilot Agent
 
-Add remote nodes behind NAT, residential networks, or corporate firewalls without exposing any inbound port. The agent runs in a container on the remote host and holds an outbound WebSocket tunnel to your primary instance; every request rides through it. [Learn more →](/features/pilot-agent)
+Add remote nodes behind NAT, residential networks, or corporate firewalls without exposing any inbound port. The agent runs in a container on the remote host and holds an outbound WebSocket tunnel to your primary instance. [Learn more →](/features/pilot-agent)
 
 ### Sencho Mesh
 
-Connect containers across nodes by hostname over the Pilot tunnel so a multi-node fleet feels like one machine. Opt a stack into the mesh and its services become reachable from any other meshed stack at a stable hostname, with no VPN or firewall changes. Admiral. [Learn more →](/features/sencho-mesh)
+Connect containers across nodes by hostname over the Pilot tunnel so a multi-node fleet feels like one machine. Opt a stack into the mesh and its services become reachable from any other meshed stack at a stable hostname. Admiral. [Learn more →](/features/sencho-mesh)
 
 ### Fleet View
 
@@ -145,102 +173,78 @@ Monitor your whole infrastructure from one screen. The Fleet view shows every no
 
 ### Fleet Dossier
 
-Export your entire homelab as a single Markdown archive. The **Export Dossier** action in the Fleet view walks every node and stack, pairs the facts Sencho derives with the notes you wrote in each [Stack Dossier](/features/stack-dossier), and produces a browsable `homelab-dossier.zip` to commit to Git or store with your backups. Admin-only. [Learn more →](/features/fleet-dossier)
+Export your entire homelab as a single Markdown archive. The **Export Dossier** action walks every node and stack, pairs the facts Sencho derives with the notes you wrote in each [Stack Dossier](/features/stack-dossier), and produces a browsable archive. Admin-only. [Learn more →](/features/fleet-dossier)
 
 ### Fleet Federation
 
-Operator-driven placement controls for fleets running Blueprints. Cordon a node to mark it unschedulable for new work, or pin a blueprint to a specific node to override selector matches. Cordon affects new placements only; existing deployments keep running. [Learn more →](/features/fleet-federation)
+Operator-driven placement controls for fleets running Blueprints. Cordon a node to mark it unschedulable for new work, or pin a blueprint to a specific node to override selector matches. [Learn more →](/features/fleet-federation)
 
 ### Fleet Actions
 
-Run fleet-wide bulk operations from one tab: stop every stack carrying a label across all nodes, assign a label to selected stacks across nodes (creating it where missing), or prune Docker resources fleet-wide. Admin-only. [Learn more →](/features/fleet-actions)
+Run fleet-wide bulk operations from one tab: stop every stack carrying a label across all nodes, assign a label to selected stacks across nodes, or prune Docker resources fleet-wide. Admin-only. [Learn more →](/features/fleet-actions)
 
 ### Fleet Sync
 
-When several Sencho instances run as a fleet, the control instance is the source of truth for security configuration and replicates scan policies and CVE suppressions to every remote automatically. Replicas show the rules read-only and reject direct writes with `403 Forbidden`. [Learn more →](/features/fleet-sync)
+When several Sencho instances run as a fleet, the control instance is the source of truth for security configuration and replicates scan policies and CVE suppressions to every remote automatically. Replicas show the rules read-only. [Learn more →](/features/fleet-sync)
 
 ### Fleet Secrets
 
-Centralized, encrypted, versioned env-var bundles you push to labeled nodes' stacks. Bundles are encrypted at rest with AES-256-GCM, every save bumps a version, and every push records a per-node diff in the audit log using overlay merge semantics. Admiral. [Learn more →](/features/fleet-secrets)
+Centralized, encrypted, versioned env-var bundles you push to labeled nodes' stacks. Every save bumps a version, and every push records a per-node diff in the audit log using overlay merge semantics. Admiral. [Learn more →](/features/fleet-secrets)
 
 ### Fleet-wide backups
 
-Create point-in-time snapshots of every compose and environment file across all nodes, stored centrally and browsable by node and stack. Restore an individual stack from any snapshot with optional one-click redeploy, even to a remote node. Manual and scheduled snapshots are both included. [Learn more →](/features/fleet-backups)
+Create point-in-time snapshots of every compose and environment file across all nodes, stored centrally and browsable by node and stack. Restore an individual stack from any snapshot with optional one-click redeploy. [Learn more →](/features/fleet-backups)
 
 ### Remote updates
 
-Check for outdated nodes and trigger over-the-air updates from the Fleet view. When the control instance runs a newer version than a remote, a one-click update pulls the latest image and recreates the container; an **Update all** action covers the whole fleet at once. [Learn more →](/features/remote-updates)
+Check for outdated nodes and trigger over-the-air updates from the Fleet view. A one-click update pulls the latest image and recreates the container; an **Update all** action covers the whole fleet at once. [Learn more →](/features/remote-updates)
 
 ### Node compatibility
 
-When you manage nodes running different Sencho versions, the dashboard detects each node's capabilities and disables features an older instance does not support, so unsupported actions stay hidden instead of failing. [Learn more →](/features/node-compatibility)
+When you manage nodes running different Sencho versions, the dashboard detects each node's capabilities and disables unsupported actions so they stay hidden instead of failing. [Learn more →](/features/node-compatibility)
 
 ### Host console
 
 Open an interactive terminal on the host OS directly in the browser with full xterm.js emulation and color support. No SSH client required; admin-only. [Learn more →](/features/host-console)
 
-## Automation
-
-### Scheduled operations
-
-Automate recurring maintenance like stack restarts, fleet snapshots, system prunes, scans, and image updates. Use the simple point-and-click mode for one-time or common recurring schedules, or switch to a full cron expression for precise control. Every run is logged with full history so you always know what ran and when. [Learn more →](/features/scheduled-operations)
-
-### Auto-Update Policies
-
-Review pending container updates across your fleet with risk badges (`Safe · patch`, `Review · minor`, `Blocked · major`, `Digest rebuild`) and one-line changelog previews on a single board. The hero counts how many updates are ready to apply without review and surfaces major version bumps as a separate count. [Learn more →](/features/auto-update-policies)
-
-### Auto-Heal Policies
-
-Automatically restart containers that fail Docker healthchecks for longer than a threshold. Each policy ships with safety rails: a cooldown period, an hourly restart cap, recent-user-action suppression, and auto-disable on repeated restart failures. [Learn more →](/features/auto-heal-policies)
-
-### Webhooks
-
-Trigger stack actions from external CI/CD pipelines over HTTP. Create a webhook targeting a specific stack and action, then call it from GitHub Actions, GitLab CI, or anything that can send a POST. Requests are authenticated with HMAC-SHA256 signatures. [Learn more →](/features/webhooks)
-
-## Security & Identity
+## Security and access
 
 <Frame>
   <img src="/images/overview/security-overview.png" alt="The Security page: the 'Action needed' masthead with critical and high CVE counts and last scan time, the tab strip (Overview, Images, Compose risks, Secrets, Policies, Suppressions, History, Scanner setup), the actionable findings summary listing fixable CVEs, detected secrets, and exposed images, and the 30-day risk trend chart." />
 </Frame>
 
-### Two-factor authentication
-
-Protect your account with a time-based one-time password (TOTP) from an authenticator app and ten single-use backup codes for sign-in recovery. Enroll by scanning a QR code or typing the secret; on every sign-in, Sencho asks for the current six-digit code after your password passes. [Learn more →](/features/two-factor-authentication)
-
-### RBAC & user management
-
-Create unlimited accounts with read-only Viewer access to dashboards, logs, and file contents, while keeping deploy and edit locked to admins. Community includes the Admin and Viewer roles; Admiral adds three more (Deployer, Node Admin, Auditor) plus scoped permissions per stack or node. [Learn more →](/features/rbac)
-
-### SSO & LDAP authentication
-
-Authenticate with your existing identity provider. Custom OIDC (Authelia, Keycloak, Authentik, any spec-compliant provider) and preset providers for Google, GitHub, and Okta are built in. Admiral adds LDAP / Active Directory. SSO runs alongside password login and auto-provisions accounts on first sign-in with configurable role mapping. [Learn more →](/features/sso)
-
-### API tokens
-
-Generate scoped API tokens for CI/CD pipelines, scripts, and automation workflows. Each token carries a permission level (Read Only, Deploy Only, or Full Admin) so you can follow the principle of least privilege. [Learn more →](/features/api-tokens)
-
 ### Security
 
-A primary surface in the top navigation that brings your security posture into one command center, scoped to the active node. An overview masthead reports your current posture (Action needed, Monitoring, or Secure), and tabs cover image findings, Compose risks, secrets, scan policies, suppressions, scan history, and scanner setup. [Learn more →](/features/security)
+A primary surface in the top navigation that brings your security posture into one command center, scoped to the active node. An overview masthead reports your current posture, and tabs cover image findings, Compose risks, secrets, scan policies, suppressions, scan history, and scanner setup. [Learn more →](/features/security)
 
 ### Vulnerability scanning
 
-Scan container images for known CVEs with [Trivy](https://trivy.dev). Install Trivy with one click from the Security page Scanner setup tab on first use; the [setup guide](/operations/trivy-setup) covers bind-mounted and air-gapped alternatives. Manual scanning, secret and misconfiguration detection, scan comparison, scheduled scans, CVE suppressions, scan policies that gate deploys, SARIF export, single-scan SBOM export, and auto-update of the managed Trivy binary are all available on every tier. [Learn more →](/features/vulnerability-scanning)
+Scan container images for known CVEs with [Trivy](https://trivy.dev). Install Trivy with one click from the Security page Scanner setup tab on first use; the [setup guide](/operations/trivy-setup) covers bind-mounted and air-gapped alternatives. [Learn more →](/features/vulnerability-scanning)
 
 ### CVE suppressions
 
-Accept known-benign vulnerabilities so scan results stay focused on findings that actually need action. Suppressed findings remain in the database and raw counts but are visually dimmed in scan drawers and comparison sheets with your reason shown, optionally expiring after a specified number of days. [Learn more →](/features/cve-suppressions)
+Accept known-benign vulnerabilities so scan results stay focused on findings that actually need action. Suppressed findings remain in the database and raw counts but are visually dimmed in scan drawers and comparison sheets with your reason shown. [Learn more →](/features/cve-suppressions)
 
 ### Private registries
 
-Store credentials for private Docker registries: Docker Hub organizations, GHCR, and self-hosted registries. Admiral adds AWS ECR. Sencho injects them automatically during deploy and pull, refreshing ECR's short-lived tokens on every operation. [Learn more →](/features/private-registries)
+Store credentials for private Docker registries: Docker Hub organizations, GHCR, and self-hosted registries. Admiral adds AWS ECR. Sencho injects them automatically during deploy and pull. [Learn more →](/features/private-registries)
 
-## Platform & licensing
+### Two-factor authentication
 
-### Appearance
+Protect your account with a time-based one-time password from an authenticator app and ten single-use backup codes for sign-in recovery. On every sign-in, Sencho asks for the current six-digit code after your password passes. [Learn more →](/features/two-factor-authentication)
 
-Personalize Sencho's look: choose a theme (Dim, OLED, Light, or Auto) and one of eight accent colors, fine-tune contrast, border brightness, and the ambient glow, swap the interface and data fonts, and set the text size. Every choice is saved to the current browser. [Learn more →](/features/appearance)
+### RBAC and user management
 
-### Licensing & billing
+Create unlimited accounts with read-only Viewer access to dashboards, logs, and file contents, while keeping deploy and edit locked to admins. Community includes the Admin and Viewer roles; Admiral adds more granular team roles and scoped permissions. [Learn more →](/features/rbac)
 
-Community is the complete self-hosted control plane, free forever, including the full vulnerability-scanning and deploy-enforcement suite. Admiral adds governance and fleet control for teams: advanced RBAC, audit log export and retention, Fleet Secrets, Sencho Mesh, and more. Manage your license, view subscription details, and access the billing portal from Settings. [Learn more →](/features/licensing)
+### SSO and LDAP authentication
+
+Authenticate with your existing identity provider. Custom OIDC and preset providers for Google, GitHub, and Okta are built in. Admiral adds LDAP / Active Directory. SSO runs alongside password login and auto-provisions accounts on first sign-in with configurable role mapping. [Learn more →](/features/sso)
+
+### SSO setup guide
+
+Follow provider-specific setup steps for Google, GitHub, Okta, custom OIDC providers, and LDAP / Active Directory. [Learn more →](/getting-started/sso-quickstart)
+
+### API tokens
+
+Generate scoped API tokens for CI/CD pipelines, scripts, and automation workflows. Each token carries a permission level so you can follow the principle of least privilege. [Learn more →](/features/api-tokens)

--- a/docs/features/private-registries.mdx
+++ b/docs/features/private-registries.mdx
@@ -1,5 +1,6 @@
 ---
 title: Private Registries
+sidebarTitle: Registries
 description: Store credentials for private Docker registries so Sencho can authenticate automatically during deploy, pull, and image-update checks.
 ---
 

--- a/docs/features/rbac.mdx
+++ b/docs/features/rbac.mdx
@@ -1,5 +1,6 @@
 ---
 title: RBAC & User Management
+sidebarTitle: RBAC
 description: Role-based access control for Sencho. Manage admin, viewer, deployer, node admin, and auditor accounts with scoped permissions, MFA, and SSO.
 ---
 

--- a/docs/features/sso.mdx
+++ b/docs/features/sso.mdx
@@ -1,5 +1,6 @@
 ---
 title: SSO & LDAP Authentication
+sidebarTitle: SSO and LDAP
 description: Authenticate with your existing identity provider, including LDAP, Google, GitHub, Okta, and any spec-compliant OIDC provider.
 ---
 

--- a/docs/features/two-factor-authentication.mdx
+++ b/docs/features/two-factor-authentication.mdx
@@ -1,5 +1,6 @@
 ---
 title: Two-Factor Authentication
+sidebarTitle: Two-factor auth
 description: Protect your Sencho account with a time-based one-time password (TOTP), single-use recovery codes, and optional SSO enforcement.
 ---
 

--- a/docs/features/vulnerability-scanning.mdx
+++ b/docs/features/vulnerability-scanning.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Vulnerability Scanning"
+sidebarTitle: Vulnerability scans
 description: "Scan container images and stack compose files for CVEs, secrets, and misconfigurations. Surface severity badges in the Resources Hub, compare scans over time, and gate deploys on policy violations."
 ---
 

--- a/docs/getting-started/sso-quickstart.mdx
+++ b/docs/getting-started/sso-quickstart.mdx
@@ -1,5 +1,6 @@
 ---
 title: SSO Setup Guide
+sidebarTitle: SSO setup
 description: Step-by-step instructions for connecting Sencho to your identity provider.
 ---
 

--- a/docs/operations/emergency-cli.mdx
+++ b/docs/operations/emergency-cli.mdx
@@ -1,5 +1,6 @@
 ---
 title: Emergency command-line recovery
+sidebarTitle: Emergency CLI
 description: Host-level commands that recover access when the Sencho UI is unreachable, plus the in-app Recovery surface for everyday health checks.
 ---
 

--- a/docs/operations/self-hosting.mdx
+++ b/docs/operations/self-hosting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Self-Hosting Best Practices
+sidebarTitle: Self-hosting
 description: Volume mounts, Docker socket security, networking, and resource recommendations for running Sencho in production.
 ---
 

--- a/docs/operations/two-factor-admin.mdx
+++ b/docs/operations/two-factor-admin.mdx
@@ -1,5 +1,6 @@
 ---
 title: Managing Two-Factor Authentication
+sidebarTitle: 2FA admin
 description: Reset a user's 2FA, recover from lockouts, and understand the per-user vs per-provider MFA toggles.
 ---
 

--- a/docs/operations/verifying-images.mdx
+++ b/docs/operations/verifying-images.mdx
@@ -1,5 +1,6 @@
 ---
 title: Verifying Published Images
+sidebarTitle: Verify images
 description: How to verify signatures, provenance, SBOMs, and CVE triage for Sencho Docker images.
 ---
 

--- a/docs/reference/contact.mdx
+++ b/docs/reference/contact.mdx
@@ -1,5 +1,6 @@
 ---
 title: Contact & Support
+sidebarTitle: Contact
 description: Official contact channels for support, licensing, security, privacy, and general inquiries.
 ---
 

--- a/docs/reference/security.mdx
+++ b/docs/reference/security.mdx
@@ -1,5 +1,6 @@
 ---
 title: Security Architecture
+sidebarTitle: Security architecture
 description: How Sencho protects your infrastructure with layered authentication, encryption, access control, and audit logging.
 ---
 

--- a/docs/reference/settings.mdx
+++ b/docs/reference/settings.mdx
@@ -1,5 +1,6 @@
 ---
 title: Settings Reference
+sidebarTitle: Settings
 description: Complete reference for every option in the Sencho Settings Hub.
 ---
 


### PR DESCRIPTION
## Summary
- Reorganizes the docs sidebar around reader tasks: Start here, Product guide, Operations, and Reference.
- Moves the product guide into focused groups for core workflow, stack intelligence, deploy and automate, observe and audit, fleet management, and security and access.
- Adds shorter sidebar labels for long page titles while keeping full page titles intact.
- Updates the Product Guide landing page so its catalog matches the new sidebar taxonomy.

## Validation
- Parsed `docs/docs.json` successfully.
- Verified navigation coverage: 73 MDX pages, 73 nav refs, 0 hidden pages, 0 missing refs, 0 duplicate refs.
- Ran docs policy greps for tier fence wording, tier workaround wording, greenfield wording, and added em dashes.
- Ran `git diff --cached --check`.
- Ran `cd backend && npx tsc --noEmit`.
- Ran `mint validate`; build validation passed.
- Ran local Mintlify preview at `http://localhost:3000` and stopped the preview server.

## Notes
- `mint broken-links` is currently blocked by an existing parser error in a non-navigation Markdown file before it reaches link checking.