### PR TITLE
docs: remove duplicate license url key in openapi.yaml

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -33,7 +33,6 @@ info:
   license:
     name: AGPL-3.0-only
     url: https://github.com/studio-saelix/sencho/blob/main/LICENSE
-    url: https://github.com/studio-saelix/sencho/blob/main/LICENSE
 
 servers:
   - url: "{protocol}://{host}:{port}"


### PR DESCRIPTION
## Summary
- The AGPLv3 relicensing change (#1623) left a duplicated `url` mapping key under `info.license` in `docs/openapi.yaml`.
- This breaks YAML parsing (`error duplicated mapping key`), which blocks `mintlify dev` from starting on any branch.

## Test plan
- [x] Confirmed `mintlify dev` fails on `main` with this duplicate key present.
- [x] Confirmed `mintlify dev` starts and serves pages cleanly with the duplicate removed.