### PR TITLE
fix(notifications): stop embedding Local in janitor alerts

### DIFF
--- a/backend/src/__tests__/monitor-service.test.ts
+++ b/backend/src/__tests__/monitor-service.test.ts
@@ -1453,7 +1453,7 @@ describe('MonitorService - janitor cycle and circuit breaker', () => {
     expect(mockGetDiskUsage).not.toHaveBeenCalled();
   });
 
-  it('dispatches an alert when reclaimable exceeds the threshold', async () => {
+  it('dispatches a node-neutral janitor alert', async () => {
     mockGetGlobalSettings.mockReturnValue({ docker_janitor_gb: '0.5' });
     mockGetDiskUsage.mockResolvedValue(RECLAIMABLE_3GB);
     mockGetSystemState.mockReturnValue('0'); // No prior alert; cooldown elapsed.
@@ -1462,7 +1462,10 @@ describe('MonitorService - janitor cycle and circuit breaker', () => {
     await (svc as any).evaluateJanitor();
 
     expect(mockDispatchAlert).toHaveBeenCalledWith(
-      'info', 'system', expect.stringContaining('3.0 GB'), { stackName: undefined, actor: 'system:monitor' },
+      'info',
+      'system',
+      'This node has accumulated 3.0 GB of unused Docker data. Open Resources to reclaim space, or set up a Prune Node Resources schedule.',
+      { stackName: undefined, actor: 'system:monitor' },
     );
   });
 

--- a/backend/src/services/MonitorService.ts
+++ b/backend/src/services/MonitorService.ts
@@ -439,15 +439,14 @@ export class MonitorService {
             const MIN_RECLAIMABLE_GB = 0.1;
 
             if (reclaimGb >= janitorLimitGb && reclaimGb >= MIN_RECLAIMABLE_GB) {
-                const registry = NodeRegistry.getInstance();
-                const localNode = registry.getNode(registry.getDefaultNodeId());
-                const nodeLabel = localNode?.name ?? 'this node';
+                // Node-neutral body: the hub bell badge attributes remotes.
+                // Embedding the local seed name ("Local") made fleet alerts look wrong.
                 await this.dispatchWithCooldown(
                     HOST_ALERT_KEYS.janitor,
                     JANITOR_COOLDOWN_MS,
                     'info',
                     'system',
-                    `Node "${nodeLabel}" has accumulated ${reclaimGb.toFixed(1)} GB of unused Docker data. Open Resources to reclaim space, or set up a Prune Node Resources schedule.`,
+                    `This node has accumulated ${reclaimGb.toFixed(1)} GB of unused Docker data. Open Resources to reclaim space, or set up a Prune Node Resources schedule.`,
                 );
             }
         } finally {

--- a/docs/features/alerts-notifications.mdx
+++ b/docs/features/alerts-notifications.mdx
@@ -324,7 +324,7 @@ The entire host threshold evaluation can be silenced per node from **Settings ·
 
 ### Reclaimable Docker data
 
-`info`/`system`: `Node "<name>" has accumulated <N> GB of unused Docker data. Open Resources to reclaim space, or set up a Prune Node Resources schedule.` 24-hour cooldown.
+`info`/`system`: `This node has accumulated <N> GB of unused Docker data. Open Resources to reclaim space, or set up a Prune Node Resources schedule.` 24-hour cooldown. On a multi-node fleet the bell attributes remotes with a node-name badge rather than embedding the name in the message.
 
 ### Sencho version availability
 


### PR DESCRIPTION
## Summary
- Reclaimable Docker janitor alerts no longer embed the satellite-local node name (often the default `Local`) in the message body.
- Hub fleet identity for remotes continues to come from the existing bell / Recent Alerts node badge.
- Docs example and unit assertion updated to the node-neutral wording. Existing stored notification rows are not rewritten (they remain until dismissed or retention removes them).

## Test plan
- [x] `cd backend && npm test -- monitor-service` (janitor cases; exact node-neutral dispatch assertion)
- [x] `cd backend && npx tsc --noEmit`
- [x] eslint on `MonitorService.ts` and `monitor-service.test.ts` (0 errors)
- [x] Rebased onto `main` after merging the Sencho update-notification cooldown PR; no conflicts
- [ ] Optional: trigger a new janitor alert on a remote whose local node is still named Local; confirm hub body starts with `This node has accumulated` and the remote badge still shows the hub roster name
