### PR TITLE
docs: align Community and Admiral assurance positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Sencho does not emit telemetry, analytics, or crash reports, and makes no outbou
 
 ## Admiral
 
-**Admiral** is Studio Saelix's paid business assurance plan on top of everything in Community: priority support, managed continuity (Sencho Cloud Backup), governance depth (advanced RBAC roles, LDAP / Active Directory, full audit log export and anomaly detection), and cross-node Fleet Sync policy replication. AWS ECR registry credentials currently require Admiral as well. See [sencho.io/pricing](https://sencho.io/pricing) for current plan details.
+**Admiral** is Studio Saelix's paid business assurance plan on top of everything in Community: Hardened Build, Recovery Vault (managed off-site snapshots), priority support, and governance depth (advanced RBAC roles, LDAP / Active Directory, full audit log export and anomaly detection). Fleet Sync policy replication and AWS ECR registry credentials currently require Admiral as well; those access rules are temporary availability, not the reason Admiral exists. See [sencho.io/pricing](https://sencho.io/pricing) for current plan details.
 
 ---
 

--- a/docs/features/alerts-notifications.mdx
+++ b/docs/features/alerts-notifications.mdx
@@ -373,7 +373,9 @@ See [Vulnerability scanning](/features/vulnerability-scanning).
 
 See [Blueprints](/features/blueprint-model).
 
-### Fleet sync (Admiral)
+### Fleet sync
+
+Fleet Sync requires Admiral on the control instance.
 
 - `warning`/`system` identity drift: `Fleet self-identity changed from "X" to "Y". Identity-scoped policies are reapplied on the next sync.`
 - `warning`/`system` truncation: `Fleet sync truncated <resource> to <N> rows (<dropped> not replicated). Reduce the local set or contact support.`

--- a/docs/features/audit-log.mdx
+++ b/docs/features/audit-log.mdx
@@ -4,11 +4,11 @@ description: Track every mutating action on your Sencho instance with a searchab
 ---
 
 <Note>
-  The recent-activity audit log, scoped to the last 14 days, is available on every tier. CSV and JSON export, anomaly detection, and configurable retention beyond the recent window require a Sencho **Admiral** license.
+  Community keeps a rolling 14-day recent-activity audit API window. The Audit navigation view, CSV and JSON export, anomaly detection, and configurable retention beyond the recent window require a Sencho **Admiral** license.
 </Note>
 
 <Note>
-  Audit is hub-only and is hidden from the nav strip when a remote node is the active selection. See [Multi-Node Management](/features/multi-node#what-top-level-views-show-when-a-remote-node-is-active).
+  Audit is hub-only and is not shown in the nav strip when a remote node is the active selection. See [Multi-Node Management](/features/multi-node#what-top-level-views-show-when-a-remote-node-is-active).
 </Note>
 
 Sencho records every mutating action (deploy, stop, delete, settings changes, user management) with full attribution. The audit log answers the question every team eventually asks: **"Who changed what, and when?"**
@@ -64,7 +64,9 @@ Expanding a row in the Table view reveals additional detail:
 
 ## Viewing the audit log
 
-Navigate to the **Audit** tab in the sidebar. The tab is available to users whose role grants the `system:audit` permission, which by default means **Admin** or **Auditor**. On every tier the feed is scoped to the last 14 days; the full retention window, along with export and anomaly detection, comes with Admiral.
+The **Audit** view in navigation is an Admiral governance surface: it appears for users whose role grants the `system:audit` permission (by default **Admin** or **Auditor**). Community still has a rolling **14-day recent-activity** audit API window; Admiral adds the full Audit view, statistics, export, anomaly annotations, and configurable retention beyond that window.
+
+Navigate to the **Audit** tab in the sidebar when it is available for your role and plan. On Admiral the feed in that view is scoped to the last 14 days by default unless you configure longer retention; export and anomaly detection come with Admiral.
 
 The page has two views, toggled from the segmented control in the card header: **Stream** (default) and **Table**. The card subtitle reports the total number of entries that match the current filters.
 
@@ -182,7 +184,7 @@ Sensitive database values (such as remote node API tokens) are encrypted at rest
 
 <AccordionGroup>
   <Accordion title="The Audit tab is missing from the sidebar">
-    The Audit tab is shown to users whose role grants the `system:audit` permission. By default that means **Admin** or **Auditor**. If you are signed in as a Deployer or Viewer, ask an admin to assign you the Auditor role from **Settings · Users**. The recent-activity feed is available on every tier; export, anomaly detection, and retention beyond the recent window come with Admiral.
+    The Audit tab is an Admiral governance view shown to users whose role grants the `system:audit` permission. By default that means **Admin** or **Auditor**. If you are signed in as a Deployer or Viewer, ask an admin to assign you the Auditor role from **Settings · Users**. Community still has a rolling 14-day recent-activity audit API window; export, anomaly detection, and retention beyond the recent window come with Admiral.
   </Accordion>
   <Accordion title="Stream view shows everything but I want to filter to a specific user, action, or date">
     Filters live in **Table view only**. Toggle the segmented control in the card header from **Stream** to **Table** and the search box, method dropdown, and From / To date pickers will appear above the grid. Switching back to Stream clears the filter strip but does not remember the last filter.

--- a/docs/features/deploy-enforcement.mdx
+++ b/docs/features/deploy-enforcement.mdx
@@ -7,7 +7,7 @@ description: "Block deploys that violate a scan policy before docker compose up 
 Deploy enforcement is the pre-flight half of Sencho's vulnerability workflow. When a [scan policy](/features/vulnerability-scanning#scan-policies) with **Block on deploy** enabled matches a stack, Sencho scans every image referenced by the stack's compose file before starting any container. A policy gates on exploitation risk: a known-exploited CVE (CISA KEV), a fixable Critical/High finding, or a raw severity threshold. If any image matches an enabled condition, the deploy is rejected and the stack never starts. Detection always continues post-deploy and on a schedule, so images that develop new vulnerabilities after the initial deploy still surface through alerts.
 
 <Note>
-  Deploy enforcement and scan policies require an **Admiral** license.
+  Deploy enforcement and scan policies are available on every tier.
 </Note>
 
 ## Configuring a block policy

--- a/docs/features/fleet-backups.mdx
+++ b/docs/features/fleet-backups.mdx
@@ -42,10 +42,10 @@ This is off by default. Turn it on in **Settings → Infrastructure → Fleet** 
 The snapshot list shows each snapshot in a table with the following columns:
 
 - **Date** - when the snapshot was taken
-- **Description** - your optional label, or a prefix like "Scheduled snapshot" for automated ones. If Cloud Backup is configured, an upload icon in this column marks snapshots that have been mirrored off-site.
+- **Description** - your optional label, or a prefix like "Scheduled snapshot" for automated ones. If Recovery Vault (or a custom off-site target) is configured, an upload icon in this column marks snapshots that have been mirrored off-site.
 - **Scope** - how many nodes and stacks were captured (e.g. "3 nodes, 21 stacks")
 - **Warnings** - a warning icon with a count if any nodes or stacks were skipped, or "None"
-- **Actions** - **View** to open the detail view, a cloud-upload icon for snapshots not yet mirrored to a configured Cloud Backup target, and a delete button for admins
+- **Actions** - **View** to open the detail view, a cloud-upload icon for snapshots not yet mirrored to a configured Recovery Vault or custom off-site target, and a delete button for admins
 
 <Frame>
   <img src="/images/fleet-backups/browse-snapshots.png" alt="Snapshot list showing paginated rows with date, description with cloud upload indicator, scope, warnings, and action buttons" />

--- a/docs/features/fleet-secrets.mdx
+++ b/docs/features/fleet-secrets.mdx
@@ -12,7 +12,7 @@ The unit of work is the **bundle**. One bundle has one current `kv` payload; pus
 </Frame>
 
 <Note>
-Fleet Secrets is a limited-availability surface. When it is enabled on an instance, it requires an Admiral license and an admin user role.
+Fleet Secrets is a limited-availability surface. When it is present on an instance, managing it requires an admin user role.
 </Note>
 
 ## What Fleet Secrets covers (and what it doesn't)
@@ -38,8 +38,7 @@ A **push** is a separate action. It reads the bundle's current version, walks ev
 
 | Requirement | Why it matters |
 |---|---|
-| Admiral license on the control instance | Fleet Secrets requires Admiral when the surface is enabled |
-| Admin user role | Bundle CRUD and push run as the signed-in operator and write authored-by rows into the audit log |
+| Admin role on the control instance | Bundle CRUD and push require an administrator when the surface is present; authored-by rows are written into the audit log |
 | At least one stack on at least one node | Pushes target an existing stack directory; the wizard does not create stacks |
 | The target stack's compose declares the env file via `env_file:` | The env-file dropdown in the push wizard reads `env_file:` entries from a representative node's compose; a stack with only an inline `environment:` block will not show up |
 | The control instance can reach the remote node's API URL | Each remote write is an HTTP call from the control instance to the remote's `/api/stacks/.../env`; an unreachable remote is reported as a per-node failure, not a transport error for the whole push |

--- a/docs/features/fleet-sync.mdx
+++ b/docs/features/fleet-sync.mdx
@@ -115,7 +115,7 @@ Demote requires `{"confirm": true}` in the request body to prevent a misclick fr
 
 | Requirement | Why it matters |
 |---|---|
-| **A paid Sencho tier on the control instance** | Authoring scan policies, CVE suppressions, and misconfig acknowledgements works on every tier, but replicating them across a fleet is the paid part: Fleet Sync's cross-node replication and anchor controls require a paid tier on the control. Replicas accept pushes regardless of their own tier. |
+| **A Sencho Admiral plan on the control instance** | Authoring scan policies, CVE suppressions, and misconfig acknowledgements works on every tier. Fleet Sync (cross-node replication and anchor controls) requires Admiral on the control instance. Replicas accept pushes regardless of their own tier. |
 | **Admin user role on the control** | Authoring the rules that replicate, and operating the re-anchor and demote endpoints on a replica, are all admin-only actions. Operator and viewer roles can read rules but cannot create or remove them. |
 | **Proxy-mode remotes with `api_url` and `api_token` configured in Settings → Nodes** | Fleet Sync pushes over HTTPS to each remote's Sencho API using its long-lived bearer token. Remotes without an `api_url` or `api_token`, or remotes that connect over the pilot tunnel, are skipped. |
 | **Network reachability from the control to each remote** | Pushes are HTTP requests originating on the control. A remote that is firewalled off, behind NAT without a forwarded port, or otherwise unreachable will queue retries until it returns. |

--- a/docs/features/global-search.mdx
+++ b/docs/features/global-search.mdx
@@ -25,7 +25,7 @@ The palette groups results into three sections.
 
 | Group | What it contains | What happens when you pick one |
 |-------|------------------|--------------------------------|
-| **Pages** | The same set of destinations the top bar shows you. Home, Fleet, Resources, App Store, and Logs always appear; Update and Schedules appear for admins; Console appears for admins on Admiral; Audit appears for any role on Admiral with the audit permission. | Navigates to that page |
+| **Pages** | The same set of destinations the top bar shows you. Home, Fleet, Resources, App Store, and Logs always appear; Update and Schedules appear for admins; Console appears for admins when that limited-availability surface is present; Audit appears on Admiral for roles with the audit permission (the full Audit view, statistics, export, anomalies, and extended retention). Community keeps a rolling 14-day recent-activity audit API window without the Audit view in navigation. | Navigates to that page |
 | **Nodes** | Every node in your fleet, with a green dot for online and a grey dot for offline. The currently active node carries a small **ACTIVE** chip on the right. | Switches the active node without leaving the current page |
 | **Stacks** | Every compose stack on every online node, matched on the compose filename (extension included). | Switches to the stack's node and opens it in the editor |
 

--- a/docs/features/host-console.mdx
+++ b/docs/features/host-console.mdx
@@ -6,7 +6,7 @@ description: An interactive terminal on your host OS, directly in the browser - 
 The **Console** tab opens a full interactive terminal session on the machine running Sencho. It behaves exactly like an SSH session, but without needing an SSH server, client, or key management.
 
 <Note>
-  The Host Console is a limited-availability operator surface. When it is enabled on an instance, it requires an **Admiral** license and the **admin** role. [Learn more about licensing](/features/licensing).
+  The Host Console is a limited-availability operator surface. When it is present on an instance, it requires the **admin** role. [Learn more about licensing](/features/licensing).
 </Note>
 
 <Frame>
@@ -74,8 +74,7 @@ Environment variables whose names suggest secrets (passwords, tokens, keys, cred
 
 The Host Console is one of the most powerful features in Sencho and is treated as such:
 
-- **Admin role required.** Only users with the **admin** role can open a console session.
-- **Admiral license required when enabled.** The Host Console is a limited-availability surface that uses an Admiral license.
+- **Admin role required when present.** The Host Console is a limited-availability surface; only users with the **admin** role can open a console session.
 - **Browser sessions only.** Console sessions are only available from a signed-in browser session, not from API tokens.
 - **Audited.** Every console session is recorded in the audit log. Opening and closing a session each write an entry capturing the user, node, client IP, and timestamp, so shell access is fully accountable.
 
@@ -98,7 +97,7 @@ The Host Console is one of the most powerful features in Sencho and is treated a
   </Accordion>
 
   <Accordion title="Session ends immediately after connecting">
-    This typically means the shell could not be found on the host. In a Docker deployment, ensure `bash` or `sh` is available inside the container. You can check by running `docker exec <container> which bash` from the host. Also verify that your user has the **admin** role and your instance has an active Admiral license.
+    This typically means the shell could not be found on the host. In a Docker deployment, ensure `bash` or `sh` is available inside the container. You can check by running `docker exec <container> which bash` from the host. Also verify that your user has the **admin** role and that Console is available on this instance.
   </Accordion>
 
   <Accordion title="Connection drops after a short time">
@@ -106,6 +105,6 @@ The Host Console is one of the most powerful features in Sencho and is treated a
   </Accordion>
 
   <Accordion title="Console tab is not visible">
-    Console appears only when the surface is enabled on the instance, and only for users with the **admin** role on an Admiral-licensed instance. Verify those conditions are met. If you recently activated an Admiral license, refresh the page.
+    Console appears only when the surface is present on the instance, and only for users with the **admin** role. Verify those conditions are met, then refresh the page.
   </Accordion>
 </AccordionGroup>

--- a/docs/features/licensing.mdx
+++ b/docs/features/licensing.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Licensing
 description: How Sencho licensing works, including trials, activation, and subscription management.
 ---
 
-Sencho is [AGPLv3](https://github.com/studio-saelix/sencho/blob/main/LICENSE) open source. **Community** is the complete self-hosted Compose-first control plane, free forever with unlimited nodes. **Admiral** is Studio Saelix business assurance (priority support, managed continuity, governance depth, and release assurance) delivered as a paid plan.
+Sencho is [AGPLv3](https://github.com/studio-saelix/sencho/blob/main/LICENSE) open source. **Community** is the complete self-hosted Compose-first control plane, free forever with unlimited nodes. **Admiral** is Studio Saelix business assurance (priority support, managed continuity, governance depth, and Hardened Build) delivered as a paid plan.
 
 <Tip>
   *Our tier names are inspired by the meaning of Sencho (船長), because you're the captain of your container fleet.*
@@ -49,12 +49,14 @@ See [the pricing page](https://sencho.io/pricing) for current pricing.
 
 **Admiral** is the official business assurance plan from Studio Saelix. It includes everything in Community, plus:
 
+- **Hardened Build:** an Admiral image channel with published supply-chain assurance artifacts
+- **Managed continuity:** Recovery Vault (a managed, off-site snapshot allowance)
 - **Assurance and support:** priority email support and Studio Saelix-backed continuity for production fleets
 - **Governance:** advanced RBAC roles (Deployer, Node Admin, Auditor), scoped permissions per stack or node, and audit log export (CSV, JSON), anomaly detection, and configurable retention beyond the recent window
-- **Managed continuity:** Recovery Vault (a managed, off-site snapshot allowance)
-- **Hardened Build:** an Admiral image channel with published supply-chain assurance artifacts
 - **Directory integration:** LDAP / Active Directory authentication
-- **Current plan availability:** some product surfaces (including AWS ECR credentials) still require an Admiral plan today. That access rule is temporary availability, not the reason Admiral exists. Other operator surfaces may be limited-availability on a given instance and are documented on their own feature pages when enabled.
+- **Current plan availability:** some product surfaces (including AWS ECR credentials and Fleet Sync policy replication) still require an Admiral plan today. That access rule is temporary availability, not the reason Admiral exists. Other operator surfaces may be limited-availability on a given instance and are documented on their own feature pages when enabled.
+
+**Planned assurance services** (not available today; no delivery date committed): Release Safety Channel, Production Assurance Reports, and Fleet Beacon.
 
 ## Free trial
 
@@ -136,7 +138,7 @@ The License page renders differently depending on the license status:
 | **Community** | `Sencho Community` with "Community plan. Full AGPLv3 self-hosted control plane." | Visible | Visible |
 | **Trial** | `Sencho Admiral (Trial)` with a countdown chip | Visible (so a paid key can replace the trial) | Hidden |
 | **Active subscription** | Tier name with Customer, Product, License key, plus `Manage subscription` and `Deactivate` | Hidden | Hidden |
-| **Expired** | `Sencho Community` with "Your Admiral license has expired. Renew to restore Admiral plan benefits." and a destructive **Status: Expired** field | Visible | Visible |
+| **Expired** | `Sencho Community` with "Your Admiral license has expired. Renew to restore Admiral assurance (priority support, Recovery Vault, Hardened Build, and governance)." and a destructive **Status: Expired** field | Visible | Visible |
 | **Disabled** | `Sencho Community` with "Your license has been disabled. Contact support for assistance." | Visible | Visible |
 
 The **Pricing** section, when visible, holds a single **See pricing** button that opens [the pricing page](https://sencho.io/pricing) in a new tab so you can pick a tier and billing cadence.

--- a/docs/features/overview.mdx
+++ b/docs/features/overview.mdx
@@ -147,7 +147,7 @@ Configure threshold-based alerts per stack and route notifications to Discord, S
 
 ### Audit log
 
-Track mutating actions across your Sencho instance with a searchable trail: who deployed, stopped, deleted, or changed settings, with timestamps, user attribution, and node context. The recent 14-day window is available on every installation. Admiral adds CSV and JSON export, anomaly detection, and configurable retention. [Learn more →](/features/audit-log)
+Track mutating actions across your Sencho instance with a searchable trail: who deployed, stopped, deleted, or changed settings, with timestamps, user attribution, and node context. Community keeps a rolling 14-day recent-activity audit API window. The Audit navigation view, plus CSV/JSON export, anomaly detection, and configurable retention, is Admiral governance. [Learn more →](/features/audit-log)
 
 ## Fleet management
 
@@ -165,7 +165,7 @@ Add remote nodes behind NAT, residential networks, or corporate firewalls withou
 
 ### Sencho Mesh
 
-Connect containers across nodes by hostname over the Pilot tunnel so a multi-node fleet feels like one machine. Opt a stack into the mesh and its services become reachable from any other meshed stack at a stable hostname. Limited availability; requires Admiral when enabled on an instance. [Learn more →](/features/sencho-mesh)
+Connect containers across nodes by hostname over the Pilot tunnel so a multi-node fleet feels like one machine. Opt a stack into the mesh and its services become reachable from any other meshed stack at a stable hostname. Limited-availability surface when present on an instance. [Learn more →](/features/sencho-mesh)
 
 ### Fleet View
 
@@ -189,7 +189,7 @@ When several Sencho instances run as a fleet, the control instance is the source
 
 ### Fleet Secrets
 
-Centralized, encrypted, versioned env-var bundles you push to labeled nodes' stacks. Every save bumps a version, and every push records a per-node diff in the audit log using overlay merge semantics. Limited availability; requires Admiral and the admin role when enabled on an instance. [Learn more →](/features/fleet-secrets)
+Centralized, encrypted, versioned env-var bundles you push to labeled nodes' stacks. Every save bumps a version, and every push records a per-node diff in the audit log using overlay merge semantics. Limited-availability surface when present; admin role required to manage. [Learn more →](/features/fleet-secrets)
 
 ### Fleet-wide backups
 
@@ -205,7 +205,7 @@ When you manage nodes running different Sencho versions, the dashboard detects e
 
 ### Host console
 
-Open an interactive terminal on the host OS directly in the browser with full xterm.js emulation and color support. No SSH client required. Limited availability; requires Admiral and the admin role when enabled on an instance. [Learn more →](/features/host-console)
+Open an interactive terminal on the host OS directly in the browser with full xterm.js emulation and color support. No SSH client required. Limited-availability surface when present; admin role required. [Learn more →](/features/host-console)
 
 ## Security and access
 

--- a/docs/features/pilot-agent.mdx
+++ b/docs/features/pilot-agent.mdx
@@ -3,13 +3,9 @@ title: Pilot Agent
 description: Connect a remote Sencho node to your control instance through a single outbound WebSocket tunnel. No inbound ports, no TLS certificates, no public URL on the remote host.
 ---
 
-Pilot Agent is one of Sencho's two remote-node modes. A small agent container runs on the remote host, dials your control instance over a single outbound WebSocket, and holds that connection open. Every request the control instance sends to that node rides through the same tunnel, whether it's HTTP, WebSocket, or Sencho Mesh TCP. The remote host never opens an inbound port and never needs a TLS certificate of its own.
+Pilot Agent is one of Sencho's two remote-node modes. A small agent container runs on the remote host, dials your control instance over a single outbound WebSocket, and holds that connection open. Every request the control instance sends to that node rides through the same tunnel (HTTP, WebSocket, and, when that limited-availability surface is present, mesh TCP). The remote host never opens an inbound port and never needs a TLS certificate of its own.
 
 This page is the architecture-and-operations reference for Pilot Agent. For the step-by-step UI walkthrough that adds a remote node, see [Multi-Node Management](/features/multi-node).
-
-<Card title="Sencho Mesh" icon="link" href="/features/sencho-mesh">
-  Once a node is enrolled, you can wire stacks across nodes by hostname using Sencho Mesh. Mesh traffic rides on the same pilot tunnel.
-</Card>
 
 ## How Pilot Agent fits Sencho
 
@@ -288,7 +284,7 @@ These are the boundaries operators should know about before designing a fleet ar
 
 ## Sencho Mesh on Pilot Agent
 
-Sencho Mesh works identically across both remote modes. On a Pilot Agent node, mesh traffic rides the existing long-lived tunnel instead of opening a separate connection. Stack opt-in to the mesh is per stack per node and is not affected by the transport choice. See [Sencho Mesh](/features/sencho-mesh) for the full mesh model.
+When the limited-availability Mesh surface is present, mesh TCP can ride the existing pilot tunnel instead of opening a separate connection. Stack opt-in is per stack per node and is not affected by the transport choice. See [Sencho Mesh](/features/sencho-mesh) for the full mesh model.
 
 ## Troubleshooting
 

--- a/docs/features/resources.mdx
+++ b/docs/features/resources.mdx
@@ -78,7 +78,7 @@ Lists all Docker images on the host with their ID, repository tag, size, and sta
 **Per-row actions** sit on the right:
 
 - **Inspect** (eye) opens the image detail sheet.
-- **Scan** (shield) opens a menu with `Scan (vulnerabilities)` and `Full scan (vulnerabilities + secrets)`. The full scan is a paid-tier option.
+- **Scan** (shield) opens a menu with `Scan (vulnerabilities)` and `Full scan (vulnerabilities + secrets)`. Full scan is available on every tier.
 - **Delete** (trash, admin-only) removes the image. Sencho warns before deleting an image that is still in use.
 
 #### Inspect image

--- a/docs/features/sencho-mesh.mdx
+++ b/docs/features/sencho-mesh.mdx
@@ -4,7 +4,7 @@ description: Cross-node container networking. Reach any meshed service on any no
 ---
 
 <Note>
-  Sencho Mesh is a limited-availability surface. When it is enabled on an instance, it requires an [Admiral license](/features/licensing).
+  Sencho Mesh is a limited-availability surface. When it is present on an instance, managing it requires an administrator.
 </Note>
 
 Sencho Mesh gives a multi-node fleet the network topology of a single machine. Once a stack opts in, every service it exposes becomes reachable from any other meshed stack on the fleet by a stable hostname. Cross-node traffic rides the same authenticated channel Sencho already uses to manage the fleet, so a node behind NAT or a residential firewall participates exactly like a public VPS.
@@ -33,7 +33,7 @@ The user-facing effect is `psql -h db.api.opsix.sencho` from a container on any 
 
 ## Prerequisites
 
-- Mesh enabled on the instance, with an Admiral license on the central Sencho.
+- Mesh present on the instance (limited availability).
 - At least one [enrolled remote node](/features/multi-node) (Pilot Agent or Distributed API Proxy).
 - Functioning `sencho_mesh` data plane on every node that should participate. The Routing tab shows a red banner if a node's data plane did not come up; the troubleshooting section below covers each cause.
 - Per-stack opt-in. Enabling mesh on a node does not automatically place every stack into the mesh; each stack is opted in individually.
@@ -328,6 +328,6 @@ These are the explicit boundaries of the v1 mesh.
     Steer blueprint placement across the same fleet Mesh networks together.
   </Card>
   <Card title="Licensing" icon="key" href="/features/licensing">
-    Mesh is limited-availability and, when enabled, requires an Admiral plan. See [Licensing](/features/licensing) for Community and Admiral plan details.
+    Mesh is a limited-availability surface when present. See [Licensing](/features/licensing) for Community and Admiral plan details.
   </Card>
 </CardGroup>

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -67,7 +67,7 @@ tags:
   - name: Scheduled Tasks
     description: Configure recurring automated operations (admin role required)
   - name: Registries
-    description: Manage private container registry credentials (Admiral license required). These endpoints are only accessible via browser sessions — API tokens receive `SCOPE_DENIED`.
+    description: Manage private container registry credentials. Docker Hub, GHCR, and custom registries are available on every tier; AWS ECR requires Admiral. These endpoints are only accessible via browser sessions. API tokens receive `SCOPE_DENIED`.
   - name: Image Updates
     description: Check for available container image updates across stacks
 

--- a/docs/operations/troubleshooting.mdx
+++ b/docs/operations/troubleshooting.mdx
@@ -181,11 +181,11 @@ To re-test connectivity after making changes, open **Profile > Settings > Nodes*
 
 ## License tier shows the wrong name
 
-**Symptom:** The license card in **Settings > License** shows a tier that does not match what you purchased.
+**Symptom:** The license card in **Settings → Admiral Account** shows a tier that does not match what you purchased.
 
 **Cause:** The tier is read from your license at validation time. A stale cached value can show after the key was activated but before the next validation cycle ran.
 
-**Fix:** Deactivate and re-activate the key in **Settings > License**, then restart the Sencho container. The tier is re-read on the next validation and the correct name appears automatically. If it still does not match, email `licensing@sencho.io` with your order ID.
+**Fix:** Deactivate and re-activate the key in **Settings → Admiral Account**, then restart the Sencho container. The tier is re-read on the next validation and the correct name appears automatically. If it still does not match, email `licensing@sencho.io` with your order ID.
 
 ---
 
@@ -202,15 +202,15 @@ To re-test connectivity after making changes, open **Profile > Settings > Nodes*
 
 ---
 
-## Admiral plan features are still locked after activation
+## Admiral assurance is still unavailable after activation
 
-**Symptom:** Features remain locked even though you activated a valid license key.
+**Symptom:** Admiral assurance surfaces remain unavailable even though you activated a valid license key.
 
 **Checks in order:**
 
-1. Open **Settings > License** and verify it shows your license as **active** with the correct tier name.
+1. Open **Settings → Admiral Account** and verify it shows your license as **active** with the correct tier name.
 2. If the tier name does not match what you purchased, see [License tier shows the wrong name](#license-tier-shows-the-wrong-name) above.
-3. If the tier shows correctly but features are still locked, restart the Sencho container.
+3. If the tier shows correctly but assurance surfaces are still unavailable, restart the Sencho container.
 
 ---
 
@@ -224,13 +224,13 @@ To re-test connectivity after making changes, open **Profile > Settings > Nodes*
 
 ---
 
-## Admiral plan features return 403 on remote nodes
+## Admiral assurance returns 403 on remote nodes
 
-**Symptom:** An Admiral feature works on the local node but returns a 403 error when you switch to a remote node.
+**Symptom:** An Admiral assurance surface works on the local node but returns a 403 error when you switch to a remote node.
 
 **Checks in order:**
 
-1. **Is your primary instance licensed?** Open **Profile > Settings > License** on the primary instance and verify it shows an active Admiral license. Remote nodes inherit the primary's tier; if the primary is on Community, all remote nodes will be Community too.
+1. **Is your primary instance licensed?** Open **Settings → Admiral Account** on the primary instance and verify it shows an active Admiral license. Remote nodes inherit the primary's tier; if the primary is on Community, all remote nodes will be Community too.
 2. **Is the remote node's token valid?** An expired or revoked token prevents the license tier from being transmitted. Regenerate the token on the remote instance and update the node config on the primary.
 3. **Is the remote node running an up-to-date version of Sencho?** Distributed license enforcement requires both the primary and remote instances to be on a compatible version. Update the remote node if it's outdated.
 4. **Are you accessing the remote node directly?** If you navigate directly to the remote Sencho instance's URL (bypassing the primary), it uses its own local license. License inheritance only works through the primary's proxy.

--- a/docs/reference/security.mdx
+++ b/docs/reference/security.mdx
@@ -61,7 +61,7 @@ Every self-hosted instance includes the full security stack. Some advanced gover
 </Card>
 
 <Card title="Fleet Secrets" icon="key-skeleton" href="/features/fleet-secrets">
-  Encrypted, versioned env-var bundles pushed to labeled nodes' stacks. Sealed with the same data key as MFA and registry credentials.
+  Limited-availability encrypted, versioned env-var bundles pushed to labeled nodes' stacks when the surface is present. Sealed with the same data key as MFA and registry credentials.
 </Card>
 
 <Card title="Webhook signatures" icon="signature" href="/features/webhooks">
@@ -91,9 +91,8 @@ Every Sencho instance includes the foundational security stack. Advanced access-
 | API tokens (scoped, expiring) | ✓ | ✓ |
 | SBOM generation (SPDX, CycloneDX) | ✓ | ✓ |
 | Recent-activity audit log (14-day window) | ✓ | ✓ |
-| Scan policies (`block_on_deploy`) | | ✓ |
-| SARIF export | | ✓ |
-| Fleet Secrets (encrypted env-var bundles, limited availability) | | ✓ |
+| Scan policies (`block_on_deploy`) | ✓ | ✓ |
+| SARIF export (admin) | ✓ | ✓ |
 | Advanced RBAC (Deployer, Node Admin, Auditor) | | ✓ |
 | Scoped permissions (per-stack, per-node) | | ✓ |
 | Audit log export, anomaly detection, and extended retention | | ✓ |

--- a/docs/reference/settings.mdx
+++ b/docs/reference/settings.mdx
@@ -26,7 +26,7 @@ Open the Settings Hub by clicking the **Profile** icon in the top bar and select
 
 Vulnerability scanning is no longer a Settings section: scanner setup, scan policies, suppressions, and acknowledgements now live on the dedicated [Security page](/features/security).
 
-Sections that require a higher license tier stay hidden until the operator has the matching license. Admin-only sections (Users, SSO, API Tokens, Fleet, Registries, Cloud Backup, Notification Routing) stay hidden for non-admin operators.
+Sections that require a higher license tier or the admin role are limited to operators who meet that requirement (Users, SSO, API Tokens, Fleet, Registries, Recovery Vault, Notification Routing are admin-only).
 
 ### Page chrome
 

--- a/frontend/src/components/settings/LicenseSection.tsx
+++ b/frontend/src/components/settings/LicenseSection.tsx
@@ -206,7 +206,7 @@ export function LicenseSection() {
                     label={getTierDisplayName(license?.tier, license?.status)}
                     helper={
                         license?.status === 'expired'
-                            ? 'Your Admiral license has expired. Renew to restore Admiral plan benefits.'
+                            ? 'Your Admiral license has expired. Renew to restore Admiral assurance (priority support, Recovery Vault, Hardened Build, and governance).'
                             : license?.status === 'disabled'
                                 ? 'Your license has been disabled. Contact support for assistance.'
                                 : license?.status === 'trial' && license.trialDaysRemaining !== null
@@ -299,7 +299,7 @@ export function LicenseSection() {
                 {license?.status === 'expired' ? (
                     <SettingsField
                         label="Status"
-                        helper="Renew to restore Admiral plan benefits."
+                        helper="Renew to restore Admiral assurance (priority support, Recovery Vault, Hardened Build, and governance)."
                         tone="error"
                     >
                         <div className="flex items-center gap-2 text-destructive">
@@ -312,7 +312,7 @@ export function LicenseSection() {
                 {license?.status === 'trial' && license.trialDaysRemaining !== null ? (
                     <SettingsField
                         label="Trial countdown"
-                        helper="Activate before the trial ends to keep Admiral plan benefits."
+                        helper="Activate before the trial ends to keep Admiral assurance (priority support, Recovery Vault, Hardened Build, and governance)."
                         tone="warn"
                     >
                         <div className="flex items-center gap-2">

--- a/frontend/src/components/settings/__tests__/LicenseSection.test.tsx
+++ b/frontend/src/components/settings/__tests__/LicenseSection.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { LicenseInfo } from '@/context/LicenseContext';
+
+const useLicenseMock = vi.fn();
+
+vi.mock('@/context/LicenseContext', () => ({
+    useLicense: () => useLicenseMock(),
+}));
+
+vi.mock('../MastheadStatsContext', () => ({
+    useMastheadStats: () => {},
+}));
+
+vi.mock('@/components/TierBadge', () => ({
+    TierBadge: () => <span data-testid="tier-badge">tier</span>,
+}));
+
+vi.mock('@/lib/api', () => ({
+    apiFetch: vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ channel: 'community' }),
+    })),
+}));
+
+import { LicenseSection } from '../LicenseSection';
+
+const ASSURANCE =
+    'Admiral assurance (priority support, Recovery Vault, Hardened Build, and governance)';
+
+function baseLicense(overrides: Partial<LicenseInfo> = {}): LicenseInfo {
+    return {
+        tier: 'community',
+        status: 'community',
+        customerName: null,
+        productName: null,
+        maskedKey: null,
+        validUntil: null,
+        trialDaysRemaining: null,
+        instanceId: 'abcdef0123456789',
+        portalUrl: null,
+        isLifetime: false,
+        ...overrides,
+    };
+}
+
+function mockLicense(license: LicenseInfo, isPaid = license.tier === 'paid') {
+    useLicenseMock.mockReturnValue({
+        license,
+        isPaid,
+        loading: false,
+        licenseStatus: 'ready',
+        licenseReady: true,
+        refresh: vi.fn(),
+        activate: vi.fn(),
+        deactivate: vi.fn(),
+    });
+}
+
+describe('LicenseSection assurance copy', () => {
+    beforeEach(() => {
+        useLicenseMock.mockReset();
+    });
+
+    it('describes Community as the full AGPLv3 self-hosted control plane', () => {
+        mockLicense(baseLicense());
+        render(<LicenseSection />);
+        expect(screen.getByText('Community plan. Full AGPLv3 self-hosted control plane.')).toBeTruthy();
+        expect(screen.queryByText(/plan benefits/i)).toBeNull();
+    });
+
+    it('describes trial countdown as evaluating current Admiral assurance', () => {
+        mockLicense(
+            baseLicense({
+                tier: 'paid',
+                status: 'trial',
+                trialDaysRemaining: 5,
+            }),
+            true,
+        );
+        render(<LicenseSection />);
+        expect(
+            screen.getByText(
+                `Activate before the trial ends to keep ${ASSURANCE}.`,
+            ),
+        ).toBeTruthy();
+        expect(screen.queryByText(/plan benefits/i)).toBeNull();
+        expect(screen.queryByText(/Release Safety|Fleet Beacon|Production Assurance/i)).toBeNull();
+    });
+
+    it('describes expired licenses with current assurance, not generic plan benefits', () => {
+        mockLicense(
+            baseLicense({
+                tier: 'community',
+                status: 'expired',
+            }),
+            false,
+        );
+        render(<LicenseSection />);
+        expect(
+            screen.getByText(
+                `Your Admiral license has expired. Renew to restore ${ASSURANCE}.`,
+            ),
+        ).toBeTruthy();
+        expect(
+            screen.getByText(
+                `Renew to restore ${ASSURANCE}.`,
+            ),
+        ).toBeTruthy();
+        expect(screen.queryByText(/plan benefits/i)).toBeNull();
+        expect(screen.queryByText(/Release Safety|Fleet Beacon|Production Assurance/i)).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary
- Align operator docs, README, and OpenAPI registries copy so Community is the full AGPLv3 product and Admiral leads with current assurance (Hardened Build, Recovery Vault, priority support, governance).
- Treat Mesh, Fleet Secrets, and Host Console as limited-availability surfaces without Admiral sales framing or experimental-flag documentation.
- Rewrite License trial/expiry helpers to name current assurance only; add focused LicenseSection unit tests.
- Document Console vs Audit accurately (Audit nav view remains Admiral; Community keeps the 14-day recent-activity API window).

## Test plan
- [x] `npm --prefix frontend run build`
- [x] `npm --prefix frontend run lint` (0 errors; existing warnings)
- [x] Backend/frontend `tsc --noEmit`
- [x] `vitest run LicenseSection` (3 passed)
- [x] Regression greps: no `SENCHO_EXPERIMENTAL`, no leftover `plan benefits`
- [x] Settings → Admiral Account desktop + phone spot-check
- [x] Playwright `e2e/admiral-account.spec.ts` when local stack is available

## Notes
- No SupportSection or tierGates API message changes.
- Known UI exception: Fleet node-card cordon still uses a stale frontend paid gate; separate follow-up filed.
- Companion website PR: https://github.com/Studio-Saelix/sencho-website/pull/77