### PR TITLE
fix: pin brace-expansion to a patched version in both packages

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -2487,9 +2487,9 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -28,6 +28,9 @@
   "engines": {
     "node": ">=26.0.0"
   },
+  "overrides": {
+    "brace-expansion": "^5.0.7"
+  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/bcrypt": "^6.0.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4000,9 +4000,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -64,7 +64,8 @@
   },
   "overrides": {
     "dompurify": "^3.4.11",
-    "@babel/core": "^7.29.6"
+    "@babel/core": "^7.29.6",
+    "brace-expansion": "^5.0.7"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## Summary
- `npm audit --audit-level=high` was failing CI on every branch (a high-severity DoS advisory for `brace-expansion`, pulled in transitively through `eslint -> minimatch` in both packages).
- Pins `brace-expansion` to a patched version via `overrides` in each `package.json`, since `minimatch` already declares a compatible range and no other packages need to move.

## Test plan
- [x] `npm audit --audit-level=high` passes with 0 vulnerabilities in both `backend/` and `frontend/`.
- [x] Lockfile diff is minimal: only `brace-expansion`'s resolved version/integrity changed in each `package-lock.json`, no unrelated dependency bumps.
- [x] `tsc --noEmit` clean in both packages.
- [x] `npm run lint` clean (0 errors) in both packages.
- [x] Frontend test suite: 1985/1985 passed.
- [x] Backend test suite: overwhelming majority passed across repeated runs; the small number of failures were non-overlapping across three separate runs (different tests failed each time), reproducing independently of this change even in isolation. These are pre-existing Windows-environment flakes (a known SQLite file-lock teardown race and DB-heavy tests hitting the default timeout under I/O contention), not a regression, the lockfile diff touches only one dev-only, lint-only dependency.