### PR TITLE
fix(sso): correct settings description to drop unsupported SAML claim

### DIFF
--- a/frontend/src/components/settings/registry.ts
+++ b/frontend/src/components/settings/registry.ts
@@ -92,7 +92,7 @@ export const SETTINGS_ITEMS: readonly SettingsItemMeta[] = [
         id: 'sso',
         group: 'access',
         label: 'SSO',
-        description: 'Single sign-on via SAML or OIDC identity providers.',
+        description: 'Single sign-on via OIDC or LDAP identity providers.',
         keywords: ['saml', 'oidc', 'okta', 'entra', 'azure', 'login'],
         tier: null,
         scope: 'global',


### PR DESCRIPTION
## Summary
- The SSO settings section description read "Single sign-on via SAML or OIDC identity providers," but Sencho does not implement SAML; only OIDC (custom + Google/GitHub/Okta presets) and LDAP/Active Directory are supported.
- Corrected the description to "Single sign-on via OIDC or LDAP identity providers." This string is the single source for both the Settings sidebar description and the SSO page's own subtitle.

## Test plan
- [x] `npx tsc -b --noEmit` passes clean.
- [x] Confirmed no other file makes the same false SAML claim; the `saml` entry in the section's search keywords was intentionally left as-is since it's a command-palette search synonym, not a support claim.
- [x] Confirmed no test or snapshot asserts this description string.