### PR TITLE
fix(security): bump grpc to 1.82.1 in docker CLI and compose builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,13 +102,14 @@ RUN if [ "$TARGETARCH" = "$BUILDARCH" ]; then \
 # The fetch pulls only the v29.4.1 commit, minimising transfer size.
 # docker/cli uses CalVer and ships vendor.mod instead of go.mod to avoid SemVer
 # compliance requirements. We copy vendor.mod -> go.mod, drop the committed vendor
-# tree, bump golang.org/x/net to v0.55.0, and build with -mod=mod so the patched
-# module is resolved from the module proxy instead of the pinned v0.53.0 that the
-# image scan flags for six HIGH advisories (CVE-2026-25680, -25681, -27136, -39821,
-# -42502, -42506; x/net/html parsing and x/net/idna). Removing vendor/ keeps -mod=mod
-# from reading the stale copy, and avoids `go mod tidy` (which does not run cleanly
-# against docker/cli's vendor.mod manifest). This stage now fetches modules at build
-# time rather than building fully offline.
+# tree, bump golang.org/x/net to v0.55.0 and google.golang.org/grpc to v1.82.1,
+# and build with -mod=mod so the patched modules are resolved from the module
+# proxy. x/net v0.53.0 is flagged for six HIGH advisories (CVE-2026-25680,
+# -25681, -27136, -39821, -42502, -42506; x/net/html parsing and x/net/idna).
+# grpc v1.80.0 is flagged for GHSA-hrxh-6v49-42gf (xDS RBAC / HTTP/2). Removing
+# vendor/ keeps -mod=mod from reading the stale copy, and avoids `go mod tidy`
+# (which does not run cleanly against docker/cli's vendor.mod manifest). This
+# stage now fetches modules at build time rather than building fully offline.
 # Base image pinned by digest so the Go toolchain that compiles the static
 # Docker CLI binary cannot change without an explicit Dependabot bump.
 FROM --platform=$BUILDPLATFORM golang:1.27rc2-alpine@sha256:dcbb18cc5fa1082364dc6aa95224b6b55429d09cbb9631a053d8064c1c367300 AS cli-builder
@@ -132,7 +133,8 @@ RUN mkdir -p /build
 
 RUN cp vendor.mod go.mod && cp vendor.sum go.sum && \
     rm -rf vendor && \
-    go get golang.org/x/net@v0.55.0 && \
+    go get golang.org/x/net@v0.55.0 \
+           google.golang.org/grpc@v1.82.1 && \
     CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
       -mod=mod \
       -ldflags "-extldflags=-static \
@@ -168,6 +170,9 @@ RUN cp vendor.mod go.mod && cp vendor.sum go.sum && \
 # patch-level fixes with no breaking API changes. Every vulnerable code path is
 # daemon-side (containerd's CRI service) and is not reached by compose at all,
 # so this is defense-in-depth rather than a live exposure.
+#
+# The same go get also bumps google.golang.org/grpc from v1.80.0 to v1.82.1 to
+# clear GHSA-hrxh-6v49-42gf (xDS RBAC fail-open and HTTP/2 transport issues).
 # Base image pinned by digest (same image as cli-builder above) so both
 # source builds share an identical, immutable Go toolchain.
 FROM --platform=$BUILDPLATFORM golang:1.27rc2-alpine@sha256:dcbb18cc5fa1082364dc6aa95224b6b55429d09cbb9631a053d8064c1c367300 AS compose-builder
@@ -190,8 +195,9 @@ WORKDIR /src/docker-compose
 RUN mkdir -p /build
 
 # Patch otel/sdk and exporters from v1.42.0 → v1.43.0 to clear CVE-2026-39883
-# and CVE-2026-39882, and bump containerd/v2 from v2.2.3 → v2.2.5 to clear
-# CVE-2026-46680 plus the CVE-2026-53488 / 53489 / 53492 cluster. All are
+# and CVE-2026-39882, bump containerd/v2 from v2.2.3 → v2.2.5 to clear
+# CVE-2026-46680 plus the CVE-2026-53488 / 53489 / 53492 cluster, and bump
+# google.golang.org/grpc to v1.82.1 to clear GHSA-hrxh-6v49-42gf. All are
 # targeted patch-level security bumps with no breaking API changes.
 RUN --mount=type=cache,id=go-mod,sharing=locked,target=/go/pkg/mod \
     go get go.opentelemetry.io/otel@v1.43.0 \
@@ -204,7 +210,8 @@ RUN --mount=type=cache,id=go-mod,sharing=locked,target=/go/pkg/mod \
            go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp@v1.43.0 \
            go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc@v1.43.0 \
            go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp@v1.43.0 \
-           github.com/containerd/containerd/v2@v2.2.5 && \
+           github.com/containerd/containerd/v2@v2.2.5 \
+           google.golang.org/grpc@v1.82.1 && \
     go mod tidy
 
 # Build target is ./cmd (the package main with plugin.Run), per docker/compose's

--- a/Dockerfile
+++ b/Dockerfile
@@ -197,8 +197,9 @@ RUN mkdir -p /build
 # Patch otel/sdk and exporters from v1.42.0 → v1.43.0 to clear CVE-2026-39883
 # and CVE-2026-39882, bump containerd/v2 from v2.2.3 → v2.2.5 to clear
 # CVE-2026-46680 plus the CVE-2026-53488 / 53489 / 53492 cluster, and bump
-# google.golang.org/grpc to v1.82.1 to clear GHSA-hrxh-6v49-42gf. All are
-# targeted patch-level security bumps with no breaking API changes.
+# google.golang.org/grpc to v1.82.1 to clear GHSA-hrxh-6v49-42gf. The otel and
+# containerd bumps are patch-level; the grpc bump is a minor security release.
+# None introduce breaking API changes.
 RUN --mount=type=cache,id=go-mod,sharing=locked,target=/go/pkg/mod \
     go get go.opentelemetry.io/otel@v1.43.0 \
            go.opentelemetry.io/otel/sdk@v1.43.0 \


### PR DESCRIPTION
## Summary
- Bump `google.golang.org/grpc` to `v1.82.1` in both Dockerfile source-build stages (`cli-builder` and `compose-builder`) to clear Trivy HIGH `GHSA-hrxh-6v49-42gf`.
- Unblocks Docker Build & Scan on open Dependabot and feature PRs that currently fail on the same finding in `/usr/local/bin/docker` and `/usr/local/lib/docker/cli-plugins/docker-compose`.

## Test plan
- [x] `docker build --target cli-builder` succeeds; `go version -m /build/docker` shows `google.golang.org/grpc v1.82.1`
- [x] `docker build --target compose-builder` succeeds; `go version -m /build/docker-compose` shows `google.golang.org/grpc v1.82.1`
- [x] CI Docker Build & Scan passes on this PR
- [x] After merge, re-run or rebase Dependabot PRs 1671 and 1673 so their Docker scan picks up the fix
