### PR TITLE
ci: refresh bug report subsystem checkboxes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -78,10 +78,10 @@ body:
       label: Subsystems involved
       description: Tick any that apply.
       options:
-        - label: Trivy / vulnerability scanning
-        - label: Pilot Agent (NAT tunnel)
-        - label: Sencho Mesh (cross-node networking)
-        - label: Fleet Actions / Secrets / Snapshots
-        - label: Cloud Backup
-        - label: SSO / LDAP
+        - label: Stacks, Compose & Deploy
+        - label: Multi-node, Pilot & Mesh
+        - label: Fleet (actions, sync, secrets, backups, blueprints)
+        - label: Alerts, Notifications & Observability
+        - label: Security, Scanning & Auth (Trivy, SSO, MFA, RBAC)
+        - label: Updates, Schedules & Automation
         - label: None of the above


### PR DESCRIPTION
## Summary
- Refresh the bug report "Subsystems involved" checkboxes to hybrid product-surface buckets that match current bug-prone areas
- Keep six options plus None of the above; fold Cloud Backup into Fleet and SSO/LDAP into Security/Auth
- Use `ci:` so release-please does not bump the version

## Test plan
- [x] Open "New issue" → Bug Report and confirm the six subsystem options render
- [x] Confirm multiple checkboxes can be selected
- [x] Confirm None of the above still appears last