### PR TITLE
fix: pin postcss override to clear backend audit vulnerability

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -5081,9 +5081,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -5428,9 +5428,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -5448,7 +5448,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/backend/package.json
+++ b/backend/package.json
@@ -30,7 +30,8 @@
     "node": ">=26.0.0"
   },
   "overrides": {
-    "brace-expansion": "^5.0.7"
+    "brace-expansion": "^5.0.7",
+    "postcss": "^8.5.23"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## Summary

- Backend CI's "Audit Dependencies" step (`npm audit --audit-level=high`) started failing on `main` and every open backend PR: `postcss@8.5.15`, pulled in transitively via `vitest -> vite -> postcss` (devDependency-only, not part of the runtime image), has a high-severity path-traversal advisory ([GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849)).
- A plain `npm audit fix` doesn't cleanly resolve it without touching ~40 unrelated packages (including some version downgrades), so instead this pins `postcss` to `^8.5.23` in the existing `overrides` block in `backend/package.json`, the same mechanism already used for `brace-expansion`. `vite@8.0.16` (the only backend package that depends on postcss) already accepts `^8.5.15`, so this raises the floor inside vite's own accepted range rather than forcing an untested version.
- `backend/package-lock.json` only changes the `postcss` entry and its own `nanoid` sub-dependency bump (which postcss's newer version requires); no other packages moved.
- Frontend's `postcss@8.5.22` (via its own `vite`) is already above the vulnerable range, so no matching change was needed there.

## Test plan

- [x] `npm audit --audit-level=high` (backend) now reports 0 vulnerabilities
- [x] `npx tsc --noEmit` (backend) passes
- [x] `npm run build` (backend) passes
- [x] `npm run lint` (backend) passes, 0 errors
- [x] `npm test` (backend): 5688/5735 pass; the one failure is the pre-existing Windows-only EBUSY teardown flake in `filesystem-backup.test.ts`, unrelated to this change
- [x] Confirmed `npm ci` resolves cleanly against the updated lockfile
- [x] Confirmed frontend's audit is unaffected (postcss already above the vulnerable range there)
