### PR TITLE
fix: bump brace-expansion override to 5.0.8 to clear high-severity audit

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -2490,16 +2490,16 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -30,7 +30,7 @@
     "node": ">=26.0.0"
   },
   "overrides": {
-    "brace-expansion": "^5.0.7",
+    "brace-expansion": "^5.0.8",
     "postcss": "^8.5.23"
   },
   "devDependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4004,16 +4004,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/brace-expansion/node_modules/balanced-match": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,7 +65,7 @@
   "overrides": {
     "dompurify": "^3.4.11",
     "@babel/core": "^7.29.6",
-    "brace-expansion": "^5.0.7"
+    "brace-expansion": "^5.0.8"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## Summary
- A new advisory (GHSA-mh99-v99m-4gvg) flags `brace-expansion <=5.0.7` as high severity. Both `backend` and `frontend` already override `brace-expansion` at `^5.0.7`, which resolved to exactly the flagged version in the committed lockfiles.
- Bumps the override to `^5.0.8` (already published, satisfies the existing range) and refreshes both lockfiles so `npm audit --audit-level=high` passes again.
- Blocking every open PR that rebases on `main`, not specific to any feature branch.

## Test plan
- [x] `cd backend && npm audit --audit-level=high` (0 vulnerabilities)
- [x] `cd frontend && npm audit --audit-level=high` (exit 0; only a pre-existing low-severity dompurify finding remains, requiring an unrelated breaking monaco-editor bump out of scope here)
- [x] `cd backend && npx tsc --noEmit`
- [x] `cd frontend && npx tsc -b --noEmit`
- [x] `cd backend && npm run lint` / `cd frontend && npm run lint` (0 errors, pre-existing warnings only)