### PR TITLE
fix(image-updates): normalize docker.io host aliases to the registry API host

### DIFF
--- a/backend/src/__tests__/registry-api.test.ts
+++ b/backend/src/__tests__/registry-api.test.ts
@@ -118,8 +118,8 @@ describe('repoDigestMatchesRef', () => {
 describe('parseImageRef', () => {
   // docker.io / index.docker.io / registry-1.docker.io are the same registry, but only
   // the literal 'registry-1.docker.io' is recognized elsewhere (getAuthToken, the
-  // library/ auto-prefix below). An unnormalized 'docker.io' or 'index.docker.io' leaks
-  // through into request URLs and hits the marketing domain instead of the registry API.
+  // library/ auto-prefix in parseImageRef). An unnormalized 'docker.io' or 'index.docker.io'
+  // leaks through into request URLs and hits the marketing domain instead of the registry API.
   it('normalizes an explicit docker.io host to the registry API host', () => {
     expect(parseImageRef('docker.io/library/traefik:latest')).toEqual({
       registry: 'registry-1.docker.io',
@@ -138,6 +138,14 @@ describe('parseImageRef', () => {
 
   it('normalizes an explicit index.docker.io host to the registry API host', () => {
     expect(parseImageRef('index.docker.io/library/traefik:latest')).toEqual({
+      registry: 'registry-1.docker.io',
+      repo: 'library/traefik',
+      tag: 'latest',
+    });
+  });
+
+  it('normalizes index.docker.io and still applies the library/ auto-prefix when the namespace is omitted', () => {
+    expect(parseImageRef('index.docker.io/traefik:latest')).toEqual({
       registry: 'registry-1.docker.io',
       repo: 'library/traefik',
       tag: 'latest',
@@ -1537,45 +1545,5 @@ describe('compareLocalToRemoteTag', () => {
 
     const result = await compareLocalToRemoteTag([CHILD_AMD64], REGISTRY, REPO, TAG, AMD64);
     expect(result.kind).toBe('error');
-  });
-
-  // Regression for issue #1705: traefik:latest (and any official multi-arch image) resolves
-  // to an OCI index with a per-platform child manifest plus an unrelated attestation-manifest
-  // sibling (os/architecture "unknown"), verified against the live Docker Hub API. A
-  // docker.io/-prefixed ref must resolve through the same registry-1.docker.io host as the
-  // bare form and still match on the platform-specific child, not the index digest.
-  it('matches the real traefik:latest index shape (attestation sibling + amd64 child) parsed from a docker.io/-prefixed ref', async () => {
-    const parsed = parseImageRef('docker.io/library/traefik:latest');
-    if (!parsed) throw new Error('unparseable ref');
-    expect(parsed.registry).toBe(REGISTRY);
-
-    const attestationDigest = `sha256:${'f'.repeat(64)}`;
-    const traefikIndexBody = JSON.stringify({
-      schemaVersion: 2,
-      mediaType: INDEX_CONTENT_TYPE,
-      manifests: [
-        { digest: CHILD_AMD64, mediaType: 'application/vnd.oci.image.manifest.v1+json', platform: { os: 'linux', architecture: 'amd64' } },
-        {
-          digest: attestationDigest,
-          mediaType: 'application/vnd.oci.image.manifest.v1+json',
-          platform: { os: 'unknown', architecture: 'unknown' },
-          annotations: { 'vnd.docker.reference.type': 'attestation-manifest' },
-        },
-        { digest: CHILD_ARM64, mediaType: 'application/vnd.oci.image.manifest.v1+json', platform: { os: 'linux', architecture: 'arm64' } },
-      ],
-    });
-    const indexDigest = contentDigest(traefikIndexBody);
-    const tagUrl = `https://${parsed.registry}/v2/${parsed.repo}/manifests/${parsed.tag}`;
-    const digestUrl = `https://${parsed.registry}/v2/${parsed.repo}/manifests/${indexDigest}`;
-    route = (url, method) => tokenOk(url) ?? (
-      url === tagUrl && method === 'HEAD'
-        ? { statusCode: 200, headers: { 'docker-content-digest': indexDigest, 'content-type': INDEX_CONTENT_TYPE } }
-        : url === digestUrl && method === 'GET'
-          ? { statusCode: 200, headers: { 'docker-content-digest': indexDigest }, body: traefikIndexBody }
-          : { statusCode: 500, headers: {} }
-    );
-
-    const result = await compareLocalToRemoteTag(CHILD_AMD64, parsed.registry, parsed.repo, parsed.tag, AMD64);
-    expect(result).toEqual({ kind: 'match' });
   });
 });

--- a/backend/src/__tests__/registry-api.test.ts
+++ b/backend/src/__tests__/registry-api.test.ts
@@ -120,32 +120,14 @@ describe('parseImageRef', () => {
   // the literal 'registry-1.docker.io' is recognized elsewhere (getAuthToken, the
   // library/ auto-prefix in parseImageRef). An unnormalized 'docker.io' or 'index.docker.io'
   // leaks through into request URLs and hits the marketing domain instead of the registry API.
-  it('normalizes an explicit docker.io host to the registry API host', () => {
-    expect(parseImageRef('docker.io/library/traefik:latest')).toEqual({
-      registry: 'registry-1.docker.io',
-      repo: 'library/traefik',
-      tag: 'latest',
-    });
-  });
-
-  it('normalizes docker.io and still applies the library/ auto-prefix when the namespace is omitted', () => {
-    expect(parseImageRef('docker.io/traefik:latest')).toEqual({
-      registry: 'registry-1.docker.io',
-      repo: 'library/traefik',
-      tag: 'latest',
-    });
-  });
-
-  it('normalizes an explicit index.docker.io host to the registry API host', () => {
-    expect(parseImageRef('index.docker.io/library/traefik:latest')).toEqual({
-      registry: 'registry-1.docker.io',
-      repo: 'library/traefik',
-      tag: 'latest',
-    });
-  });
-
-  it('normalizes index.docker.io and still applies the library/ auto-prefix when the namespace is omitted', () => {
-    expect(parseImageRef('index.docker.io/traefik:latest')).toEqual({
+  // Each alias is listed with and without an explicit library/ namespace to pin both paths.
+  it.each([
+    'docker.io/library/traefik:latest',
+    'docker.io/traefik:latest',
+    'index.docker.io/library/traefik:latest',
+    'index.docker.io/traefik:latest',
+  ])('normalizes %s to the registry API host and the library/ namespace', (ref) => {
+    expect(parseImageRef(ref)).toEqual({
       registry: 'registry-1.docker.io',
       repo: 'library/traefik',
       tag: 'latest',

--- a/backend/src/__tests__/registry-api.test.ts
+++ b/backend/src/__tests__/registry-api.test.ts
@@ -115,6 +115,44 @@ describe('repoDigestMatchesRef', () => {
   });
 });
 
+describe('parseImageRef', () => {
+  // docker.io / index.docker.io / registry-1.docker.io are the same registry, but only
+  // the literal 'registry-1.docker.io' is recognized elsewhere (getAuthToken, the
+  // library/ auto-prefix below). An unnormalized 'docker.io' or 'index.docker.io' leaks
+  // through into request URLs and hits the marketing domain instead of the registry API.
+  it('normalizes an explicit docker.io host to the registry API host', () => {
+    expect(parseImageRef('docker.io/library/traefik:latest')).toEqual({
+      registry: 'registry-1.docker.io',
+      repo: 'library/traefik',
+      tag: 'latest',
+    });
+  });
+
+  it('normalizes docker.io and still applies the library/ auto-prefix when the namespace is omitted', () => {
+    expect(parseImageRef('docker.io/traefik:latest')).toEqual({
+      registry: 'registry-1.docker.io',
+      repo: 'library/traefik',
+      tag: 'latest',
+    });
+  });
+
+  it('normalizes an explicit index.docker.io host to the registry API host', () => {
+    expect(parseImageRef('index.docker.io/library/traefik:latest')).toEqual({
+      registry: 'registry-1.docker.io',
+      repo: 'library/traefik',
+      tag: 'latest',
+    });
+  });
+
+  it('leaves a bare official image name unchanged (regression guard)', () => {
+    expect(parseImageRef('traefik:latest')).toEqual({
+      registry: 'registry-1.docker.io',
+      repo: 'library/traefik',
+      tag: 'latest',
+    });
+  });
+});
+
 describe('getRemoteDigest HEAD-first lookup', () => {
   beforeEach(() => {
     calls.length = 0;
@@ -1499,5 +1537,45 @@ describe('compareLocalToRemoteTag', () => {
 
     const result = await compareLocalToRemoteTag([CHILD_AMD64], REGISTRY, REPO, TAG, AMD64);
     expect(result.kind).toBe('error');
+  });
+
+  // Regression for issue #1705: traefik:latest (and any official multi-arch image) resolves
+  // to an OCI index with a per-platform child manifest plus an unrelated attestation-manifest
+  // sibling (os/architecture "unknown"), verified against the live Docker Hub API. A
+  // docker.io/-prefixed ref must resolve through the same registry-1.docker.io host as the
+  // bare form and still match on the platform-specific child, not the index digest.
+  it('matches the real traefik:latest index shape (attestation sibling + amd64 child) parsed from a docker.io/-prefixed ref', async () => {
+    const parsed = parseImageRef('docker.io/library/traefik:latest');
+    if (!parsed) throw new Error('unparseable ref');
+    expect(parsed.registry).toBe(REGISTRY);
+
+    const attestationDigest = `sha256:${'f'.repeat(64)}`;
+    const traefikIndexBody = JSON.stringify({
+      schemaVersion: 2,
+      mediaType: INDEX_CONTENT_TYPE,
+      manifests: [
+        { digest: CHILD_AMD64, mediaType: 'application/vnd.oci.image.manifest.v1+json', platform: { os: 'linux', architecture: 'amd64' } },
+        {
+          digest: attestationDigest,
+          mediaType: 'application/vnd.oci.image.manifest.v1+json',
+          platform: { os: 'unknown', architecture: 'unknown' },
+          annotations: { 'vnd.docker.reference.type': 'attestation-manifest' },
+        },
+        { digest: CHILD_ARM64, mediaType: 'application/vnd.oci.image.manifest.v1+json', platform: { os: 'linux', architecture: 'arm64' } },
+      ],
+    });
+    const indexDigest = contentDigest(traefikIndexBody);
+    const tagUrl = `https://${parsed.registry}/v2/${parsed.repo}/manifests/${parsed.tag}`;
+    const digestUrl = `https://${parsed.registry}/v2/${parsed.repo}/manifests/${indexDigest}`;
+    route = (url, method) => tokenOk(url) ?? (
+      url === tagUrl && method === 'HEAD'
+        ? { statusCode: 200, headers: { 'docker-content-digest': indexDigest, 'content-type': INDEX_CONTENT_TYPE } }
+        : url === digestUrl && method === 'GET'
+          ? { statusCode: 200, headers: { 'docker-content-digest': indexDigest }, body: traefikIndexBody }
+          : { statusCode: 500, headers: {} }
+    );
+
+    const result = await compareLocalToRemoteTag(CHILD_AMD64, parsed.registry, parsed.repo, parsed.tag, AMD64);
+    expect(result).toEqual({ kind: 'match' });
   });
 });

--- a/backend/src/__tests__/update-preview-service.test.ts
+++ b/backend/src/__tests__/update-preview-service.test.ts
@@ -432,6 +432,15 @@ describe('buildSummary', () => {
         expect(buildSummary('stacky', images).rollback_target).toBe('postgres:16');
     });
 
+    it('computes rollback target for an explicit docker.io/ ref the same as the bare form', () => {
+        // docker.io is a Docker Hub alias normalized by parseImageRef; the rollback target
+        // must render the same shortened form as the bare-name case above, not the literal host.
+        const images = [
+            baseImage({ service: 'db', image: 'docker.io/library/postgres:16', has_update: true, semver_bump: 'patch', next_tag: '16', current_tag: '16' }),
+        ];
+        expect(buildSummary('stacky', images).rollback_target).toBe('postgres:16');
+    });
+
     it('computes rollback target for registry with port', () => {
         const images = [
             baseImage({

--- a/backend/src/services/registry-api.ts
+++ b/backend/src/services/registry-api.ts
@@ -219,7 +219,11 @@ const MANIFEST_ACCEPT = [
     'application/vnd.oci.image.manifest.v1+json',
 ].join(', ');
 
-/** docker.io has three hostnames that all address the same registry. */
+/**
+ * docker.io has three hostnames that all address the same registry. Defensive
+ * normalizer for arbitrary host strings (e.g. from a raw RepoDigest entry); not the
+ * canonical form parseImageRef assigns (which normalizes to 'registry-1.docker.io').
+ */
 function canonicalRegistry(host: string): string {
     if (host === 'docker.io' || host === 'index.docker.io' || host === 'registry-1.docker.io') {
         return 'docker.io';

--- a/backend/src/services/registry-api.ts
+++ b/backend/src/services/registry-api.ts
@@ -35,7 +35,12 @@ export function parseImageRef(imageRef: string): ParsedRef | null {
     if (slashIdx !== -1) {
         const firstPart = imageRef.slice(0, slashIdx);
         if (firstPart.includes('.') || firstPart.includes(':') || firstPart === 'localhost') {
-            registry = firstPart;
+            // docker.io / index.docker.io are Docker Hub aliases; normalize them to the
+            // actual registry API host so requests never hit the marketing domain (which
+            // redirects instead of serving /v2/) and the library/ auto-prefix below still applies.
+            registry = (firstPart === 'docker.io' || firstPart === 'index.docker.io')
+                ? 'registry-1.docker.io'
+                : firstPart;
             rest = imageRef.slice(slashIdx + 1);
         }
     }

--- a/backend/src/services/registry-api.ts
+++ b/backend/src/services/registry-api.ts
@@ -220,9 +220,10 @@ const MANIFEST_ACCEPT = [
 ].join(', ');
 
 /**
- * docker.io has three hostnames that all address the same registry. Defensive
- * normalizer for arbitrary host strings (e.g. from a raw RepoDigest entry); not the
- * canonical form parseImageRef assigns (which normalizes to 'registry-1.docker.io').
+ * docker.io has three hostnames that all address the same registry. Folds two
+ * already-parsed ParsedRef.registry values down to a shared form for equality/cache-key
+ * comparisons; not the canonical form parseImageRef assigns (which normalizes to
+ * 'registry-1.docker.io').
  */
 function canonicalRegistry(host: string): string {
     if (host === 'docker.io' || host === 'index.docker.io' || host === 'registry-1.docker.io') {


### PR DESCRIPTION
## What does this PR do?

Fixes two Docker Hub host aliases (`docker.io`, `index.docker.io`) that `parseImageRef` kept as literal strings instead of normalizing to the registry API host (`registry-1.docker.io`, which is also the function's own default when no host is given). Every downstream request (auth token, manifest lookup) built its URL from that literal string, so an explicit `docker.io/library/traefik:latest` reference hit the marketing/redirect domain and failed with an unhandled 3xx, surfaced to the user as "Registry returned status 302 for docker.io/library/traefik:latest".

The fix normalizes both aliases before the existing `library/` auto-prefix check, so `docker.io/library/traefik:latest`, `docker.io/traefik:latest`, `index.docker.io/...`, and the bare `traefik:latest` form all resolve identically.

The second symptom in the issue (bare `traefik:latest` always reporting a new image, even when there is not one) traces to the same class of multi-arch-index false positive already fixed by a prior release (the reporter's version predates that fix by about a week, confirmed against the release tag and commit dates). Verified live against the real Docker Hub API that `traefik:latest` does resolve to an OCI index with per-platform child manifests, matching that already-fixed shape. No additional code change needed for that symptom.

## Changes (3 files, +49/-2)

- `backend/src/services/registry-api.ts` -- `parseImageRef` normalizes `docker.io` and `index.docker.io` to `registry-1.docker.io` before the `library/` auto-prefix
- `backend/src/__tests__/registry-api.test.ts` -- `it.each` covering 4 alias forms + bare-name regression guard
- `backend/src/__tests__/update-preview-service.test.ts` -- rollback-target assertion for explicit `docker.io/` ref

## Test plan
- [x] `npx vitest run src/__tests__/registry-api.test.ts src/__tests__/update-preview-service.test.ts` -- 159/159
- [x] `npx tsc --noEmit` clean
- [x] Rebased on current `main` (zero conflicts, includes #1695 multi-RepoDigest and #1698 sticky-indicator reconciliation)
- [x] QA audit on 3-node test fleet against real Docker Hub: all 6 alias forms produce `checkStatus=ok`, no `302`, no false updates, all UI surfaces agree
- [x] Network-level validation: token requests route to `auth.docker.io`, manifest requests to `registry-1.docker.io`, no requests hit the marketing domain
- [x] RepoDigest matching verified across all alias forms and both local digest formats (bare and registry-prefixed)
- [x] Security boundary: lookalike hosts (`docker.io.example.com`, `mydocker.io`) are not rewritten

Closes #1705
